### PR TITLE
fix: redirect to be send inside confirm params

### DIFF
--- a/src/screens/SDKPayment/WebSDK.res
+++ b/src/screens/SDKPayment/WebSDK.res
@@ -163,9 +163,13 @@ module CheckoutForm = {
         [
           (
             "confirmParams",
-            [("return_url", returnUrl->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object,
+            [
+              ("return_url", returnUrl->JSON.Encode.string),
+              ("redirect", "always"->JSON.Encode.string),
+            ]
+            ->Dict.fromArray
+            ->JSON.Encode.object,
           ),
-          ("redirect", "always"->JSON.Encode.string),
         ]->LogicUtils.getJsonFromArrayOfJson
       hyper.confirmPayment(confirmParams)
       ->then(val => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Redirect to be send inside confirm params that's why it was not able to redirect.


## How did you test it?

Via making a payment it redirected.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
