### PR TITLE
fix: accept invite flow breaking for non-auth users 

### DIFF
--- a/src/entryPoints/AuthModule/AuthUtils.res
+++ b/src/entryPoints/AuthModule/AuthUtils.res
@@ -64,7 +64,7 @@ let getUserInfoDetailsFromLocalStorage = () => {
 
 let defaultListOfAuth: array<SSOTypes.authMethodResponseType> = [
   {
-    id: "defaultpasswordId",
+    id: None,
     auth_id: "defaultpasswordAuthId",
     auth_method: {
       \"type": PASSWORD,
@@ -73,7 +73,7 @@ let defaultListOfAuth: array<SSOTypes.authMethodResponseType> = [
     allow_signup: true,
   },
   {
-    id: "defaultmagicLinkId",
+    id: None,
     auth_id: "defaultmagicLinkId",
     auth_method: {
       \"type": MAGIC_LINK,

--- a/src/entryPoints/AuthModule/AuthWrapper.res
+++ b/src/entryPoints/AuthModule/AuthWrapper.res
@@ -100,9 +100,10 @@ let make = (~children) => {
     setAuthStatus(PreLogin(info))
   }
 
-  let handleLoginWithSso = auth_id => {
-    switch auth_id {
-    | Some(id) => Window.Location.replace(`${Window.env.apiBaseUrl}/user/auth/url?id=${id}`)
+  let handleLoginWithSso = id => {
+    switch id {
+    | Some(method_id) =>
+      Window.Location.replace(`${Window.env.apiBaseUrl}/user/auth/url?id=${method_id}`)
     | _ => ()
     }
   }

--- a/src/entryPoints/AuthModule/AuthWrapper.res
+++ b/src/entryPoints/AuthModule/AuthWrapper.res
@@ -101,7 +101,10 @@ let make = (~children) => {
   }
 
   let handleLoginWithSso = auth_id => {
-    Window.Location.replace(`${Window.env.apiBaseUrl}/user/auth/url?id=${auth_id}`)
+    switch auth_id {
+    | Some(id) => Window.Location.replace(`${Window.env.apiBaseUrl}/user/auth/url?id=${id}`)
+    | _ => ()
+    }
   }
 
   React.useEffect0(() => {

--- a/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
+++ b/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
@@ -28,11 +28,13 @@ let make = (~setSelectedAuthId) => {
 
   let handleTerminateSSO = async method_id => {
     open AuthUtils
+    open LogicUtils
     try {
-      let body = [("id", method_id->JSON.Encode.string)]->Dict.fromArray->JSON.Encode.object
+      let body = Dict.make()
+      body->setOptionString("id", method_id)
       let terminateURL = getURL(~entityName=USERS, ~userType=#AUTH_SELECT, ~methodType=Post, ())
-      let response = await updateDetails(terminateURL, body, Post, ())
-      setSelectedAuthId(_ => Some(method_id))
+      let response = await updateDetails(terminateURL, body->JSON.Encode.object, Post, ())
+      setSelectedAuthId(_ => method_id)
       setAuthStatus(PreLogin(getPreLoginInfo(response)))
     } catch {
     | _ => setAuthStatus(LoggedOut)
@@ -65,6 +67,7 @@ let make = (~setSelectedAuthId) => {
     | (_, _) => React.null
     }
   }
+
   <PageLoaderWrapper screenState>
     <HSwitchUtils.BackgroundImageWrapper
       customPageCss="flex flex-col items-center  overflow-scroll ">
@@ -83,7 +86,7 @@ let make = (~setSelectedAuthId) => {
               ->Array.mapWithIndex((authMethod, index) =>
                 <React.Fragment key={index->Int.toString}>
                   {authMethod->renderComponentForAuthTypes}
-                  <UIUtils.RenderIf condition={index === 0 && authMethods->Array.length !== 1}>
+                  <UIUtils.RenderIf condition={index === 0 && authMethods->Array.length !== 2}>
                     {PreLoginUtils.divider}
                   </UIUtils.RenderIf>
                 </React.Fragment>

--- a/src/entryPoints/AuthModule/SSOAuth/SSOTypes.res
+++ b/src/entryPoints/AuthModule/SSOAuth/SSOTypes.res
@@ -16,7 +16,7 @@ type authMethodType = {
 }
 
 type authMethodResponseType = {
-  id: string,
+  id: option<string>,
   auth_id: string,
   auth_method: authMethodType,
   allow_signup: bool,

--- a/src/entryPoints/AuthModule/SSOAuth/SSOUtils.res
+++ b/src/entryPoints/AuthModule/SSOAuth/SSOUtils.res
@@ -23,7 +23,7 @@ let getTypedValueFromResponse: Dict.t<JSON.t> => SSOTypes.authMethodResponseType
   open LogicUtils
   let authMethodsDict = dict->getDictfromDict("auth_method")
   {
-    id: dict->getString("id", ""),
+    id: dict->getOptionString("id"),
     auth_id: dict->getString("auth_id", ""),
     auth_method: {
       \"type": authMethodsDict->getString("type", "")->authMethodsTypeToVariantMapper,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Previously, the `auth/select` API required auth_id as a mandatory request parameter. However, this caused the API to fail when users selected 'Continue with Hyperswitch' from an email. To address this, the backend team has made auth_id optional in the request body. Consequently, the frontend has also adjusted the request structure and made the auth_id parameter optional to support this change.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
