### PR TITLE
chore: removing recon_v2 feature flag

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -40,5 +40,4 @@ branding=false
 totp=false
 live_users_counter=false
 granularity=false
-recon_v2=false
 custom_webhook_headers=false

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -28,7 +28,6 @@ type featureFlag = {
   totp: bool,
   liveUsersCounter: bool,
   granularity: bool,
-  reconV2: bool,
   customWebhookHeaders: bool,
 }
 
@@ -65,7 +64,6 @@ let featureFlagType = (featureFlags: JSON.t) => {
     totp: dict->getBool("totp", false),
     liveUsersCounter: dict->getBool("live_users_counter", false),
     granularity: dict->getBool("granularity", false),
-    reconV2: dict->getBool("recon_v2", false),
     customWebhookHeaders: dict->getBool("custom_webhook_headers", false),
   }
   typedFeatureFlag

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -423,7 +423,7 @@ let make = () => {
                         | list{"reports"}
                         | list{"config-settings"}
                         | list{"file-processor"} =>
-                          <AccessControl isEnabled=featureFlagDetails.reconV2 permission=Access>
+                          <AccessControl isEnabled=featureFlagDetails.recon permission=Access>
                             <ReconModule urlList={url.path->urlPath} />
                           </AccessControl>
 

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -518,33 +518,32 @@ let reconFileProcessor = {
   })
 }
 
-let reconTag = (recon, isReconEnabled) => {
-  recon
-    ? Link({
-        name: "Reconcilation",
-        icon: isReconEnabled ? "recon" : "recon-lock",
-        link: `/recon`,
-        access: Access,
-      })
-    : emptyComponent
-}
+let reconAndSettlement = (recon, isReconEnabled) => {
+  switch (recon, isReconEnabled) {
+  | (true, true) =>
+    Section({
+      name: "Recon And Settlement",
+      icon: "recon",
+      showSection: true,
+      links: [
+        uploadReconFiles,
+        runRecon,
+        reconAnalytics,
+        reconReports,
+        reconConfigurator,
+        reconFileProcessor,
+      ],
+    })
+  | (true, false) =>
+    Link({
+      name: "Reconcilation",
+      icon: isReconEnabled ? "recon" : "recon-lock",
+      link: `/recon`,
+      access: Access,
+    })
 
-let reconAndSettlement = (recon_v2, isReconEnabled) => {
-  recon_v2 && isReconEnabled
-    ? Section({
-        name: "Recon And Settlement",
-        icon: "recon",
-        showSection: true,
-        links: [
-          uploadReconFiles,
-          runRecon,
-          reconAnalytics,
-          reconReports,
-          reconConfigurator,
-          reconFileProcessor,
-        ],
-      })
-    : emptyComponent
+  | (_, _) => emptyComponent
+  }
 }
 
 let useGetSidebarValues = (~isReconEnabled: bool) => {
@@ -568,7 +567,6 @@ let useGetSidebarValues = (~isReconEnabled: bool) => {
     quickStart,
     disputeAnalytics,
     configurePmts,
-    reconV2,
   } = featureFlagDetails
 
   let sidebar = [
@@ -589,8 +587,7 @@ let useGetSidebarValues = (~isReconEnabled: bool) => {
       ~permissionJson,
     ),
     default->workflow(isSurchargeEnabled, ~permissionJson, ~isPayoutEnabled=payOut),
-    recon->reconTag(isReconEnabled),
-    reconV2->reconAndSettlement(isReconEnabled),
+    recon->reconAndSettlement(isReconEnabled),
     default->developers(userRole, systemMetrics, ~permissionJson),
     settings(
       ~isSampleDataEnabled=sampleData,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Previously, the recon module was controlled by two feature flags: recon_v2 and recon. With this change, the reconciliation module with subitems will be shown to users who have the recon feature enabled and an active recon status. The recon_v2 feature flag will no longer be needed. 
**NOTE**: This will not affect users in live mode since recon will not be enabled in production.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
