### PR TITLE
fix: Sign up button not working for sbx

### DIFF
--- a/src/entryPoints/AuthModule/BasicAuth/BasicAuth.res
+++ b/src/entryPoints/AuthModule/BasicAuth/BasicAuth.res
@@ -209,7 +209,7 @@ let make = (~authType, ~setAuthType) => {
   | ForgetPassword
   | ResendVerifyEmail
   | LoginWithEmail => ["email"]
-  | SignUP => ["email", "password"]
+  | SignUP => featureFlagValues.email ? ["email"] : ["email", "password"]
   | LoginWithPassword => ["email", "password"]
   | ResetPassword => ["create_password", "comfirm_password"]
   | _ => []

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaAuth.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaAuth.res
@@ -241,7 +241,7 @@ let make = (~setAuthStatus, ~authType, ~setAuthType) => {
   | ForgetPassword
   | ResendVerifyEmail
   | LoginWithEmail => ["email"]
-  | SignUP => ["email", "password"]
+  | SignUP => featureFlagValues.email ? ["email"] : ["email", "password"]
   | LoginWithPassword => ["email", "password"]
   | ResetPassword => ["create_password", "comfirm_password"]
   | _ => []


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Signup button not working in sbx as there is no password field when email feature flag is on 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
