### PR TITLE
chore: dynamic webhook auth headers

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -3,7 +3,7 @@ primary_color="#006DF9"
 primary_hover_color="#005ED6"
 sidebar_color="#242F48"
 [default.endpoints]
-api_url="http://localhost:8080"
+api_url="https://sandbox.hyperswitch.io"
 sdk_url=""
 logo_url=""
 favicon_url=""
@@ -42,4 +42,5 @@ totp=false
 live_users_counter=false
 granularity=false
 custom_webhook_headers=false
+dynamic_custom_webhook_headers=false
 compliance_certificate=false

--- a/config/config.toml
+++ b/config/config.toml
@@ -3,7 +3,7 @@ primary_color="#006DF9"
 primary_hover_color="#005ED6"
 sidebar_color="#242F48"
 [default.endpoints]
-api_url="https://sandbox.hyperswitch.io"
+api_url="http://localhost:8080"
 sdk_url=""
 logo_url=""
 favicon_url=""
@@ -41,6 +41,6 @@ branding=false
 totp=false
 live_users_counter=false
 granularity=false
-custom_webhook_headers=false
+custom_webhook_headers=true
 dynamic_custom_webhook_headers=false
 compliance_certificate=false

--- a/src/components/Filter.res
+++ b/src/components/Filter.res
@@ -303,8 +303,10 @@ let make = (
               fieldWrapperClass="p-0"
             />
           </RenderIf>
+        </div>
+        <div className="flex gap-3 flex-wrap">
           <RenderIf condition={allFilters->Array.length > 0}>
-            <Menu \"as"="div" className="relative inline-block text-left">
+            <Menu \"as"="div" className="relative inline-block text-left mt-3">
               {_menuProps =>
                 <div>
                   <Menu.Button

--- a/src/components/LoadedTableWithCustomColumns.res
+++ b/src/components/LoadedTableWithCustomColumns.res
@@ -93,7 +93,7 @@ let make = (
           leftIcon=Button.CustomIcon(<Icon name="edit" size=16 />)
           text="Customize Columns"
           buttonType=SecondaryFilled
-          buttonSize=XSmall
+          buttonSize={Small}
           onClick={_ => setShowColumnSelector(_ => true)}
           customButtonStyle="!rounded-lg !bg-white !h-10 !text-black"
         />

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -29,6 +29,7 @@ type featureFlag = {
   liveUsersCounter: bool,
   granularity: bool,
   customWebhookHeaders: bool,
+  dynamicCustomWebhookHeaders: bool,
   complianceCertificate: bool,
 }
 
@@ -66,6 +67,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     liveUsersCounter: dict->getBool("live_users_counter", false),
     granularity: dict->getBool("granularity", false),
     customWebhookHeaders: dict->getBool("custom_webhook_headers", false),
+    dynamicCustomWebhookHeaders: dict->getBool("dynamic_custom_webhook_headers", false),
     complianceCertificate: dict->getBool("compliance_certificate", false),
   }
   typedFeatureFlag

--- a/src/screens/Order/OrderEntity.res
+++ b/src/screens/Order/OrderEntity.res
@@ -395,6 +395,8 @@ let defaultColumns: array<colType> = [
   PaymentMethod,
   PaymentMethodType,
   CardNetwork,
+  Email,
+  MerchantOrderReferenceId,
   Description,
   Metadata,
   Created,
@@ -458,9 +460,6 @@ let getHeading = (colType: colType) => {
   | Currency => Table.makeHeaderInfo(~key="currency", ~title="Currency", ~showSort=false, ())
   | CustomerId =>
     Table.makeHeaderInfo(~key="customer_id", ~title="Customer ID", ~showSort=false, ())
-  | CustomerEmail =>
-    Table.makeHeaderInfo(~key="email", ~title="Customer Email", ~showSort=false, ())
-
   | Description =>
     Table.makeHeaderInfo(~key="description", ~title="Description", ~showSort=false, ())
 
@@ -499,7 +498,7 @@ let getHeading = (colType: colType) => {
     Table.makeHeaderInfo(~key="payment_token", ~title="Payment Token", ~showSort=false, ())
   | Shipping => Table.makeHeaderInfo(~key="shipping", ~title="Shipping", ~showSort=false, ())
   | Billing => Table.makeHeaderInfo(~key="billing", ~title="Billing", ~showSort=false, ())
-  | Email => Table.makeHeaderInfo(~key="email", ~title="Email", ~showSort=false, ())
+  | Email => Table.makeHeaderInfo(~key="email", ~title="Customer Email", ~showSort=false, ())
   | Name => Table.makeHeaderInfo(~key="name", ~title="Name", ~showSort=false, ())
   | Phone => Table.makeHeaderInfo(~key="phone", ~title="Phone", ~showSort=false, ())
   | ReturnUrl => Table.makeHeaderInfo(~key="return_url", ~title="ReturnUrl", ~showSort=false, ())
@@ -871,7 +870,6 @@ let getCell = (order, colType: colType): Table.cell => {
   | Created => Date(order.created)
   | Currency => Text(order.currency)
   | CustomerId => Text(order.customer_id)
-  | CustomerEmail => Text(order.email)
   | Description => CustomCell(<Metadata displayValue={order.description} endValue={5} />, "")
   | MandateId => Text(order.mandate_id)
   | MandateData => Text(order.mandate_data)
@@ -967,6 +965,14 @@ let itemToObjMapper = dict => {
     `${phone->getString(codeKey, "")} ${phone->getString(phoneKey, "NA")}`
   }
 
+  let getEmail = dict => {
+    let defaultEmail = dict->getString("email", "")
+
+    dict
+    ->getDictfromDict("customer")
+    ->getString("email", defaultEmail)
+  }
+
   {
     payment_id: dict->getString("payment_id", ""),
     merchant_id: dict->getString("merchant_id", ""),
@@ -1038,7 +1044,7 @@ let itemToObjMapper = dict => {
     ->getDictfromDict("phone")
     ->getPhoneNumberString(),
     metadata: dict->getJsonObjectFromDict("metadata")->getDictFromJsonObject,
-    email: dict->getString("email", ""),
+    email: dict->getEmail,
     name: dict->getString("name", ""),
     phone: dict
     ->getDictfromDict("customer")

--- a/src/screens/Order/OrderRefundForm.res
+++ b/src/screens/Order/OrderRefundForm.res
@@ -153,9 +153,7 @@ let make = (
               />
             </FormRenderer.DesktopRow>
             <FormRenderer.DesktopRow>
-              <DisplayKeyValueParams
-                heading={getHeading(CustomerEmail)} value={getCell(order, CustomerEmail)}
-              />
+              <DisplayKeyValueParams heading={getHeading(Email)} value={getCell(order, Email)} />
             </FormRenderer.DesktopRow>
             <FormRenderer.DesktopRow>
               <DisplayKeyValueParams

--- a/src/screens/Order/OrderTypes.res
+++ b/src/screens/Order/OrderTypes.res
@@ -179,7 +179,6 @@ type colType =
   | Created
   | Currency
   | CustomerId
-  | CustomerEmail
   | Description
   | Refunds
   | MandateId

--- a/src/screens/Order/Orders.res
+++ b/src/screens/Order/Orders.res
@@ -113,12 +113,12 @@ let make = (~previewOnly=false) => {
         <RenderIf condition={!previewOnly}>
           <div className="flex-1"> {filtersUI} </div>
         </RenderIf>
-        <div className="flex justify-end gap-3 items-start">
+        <div className="flex flex-col items-end 2xl:flex-row 2xl:justify-end 2xl:items-start gap-3">
           <RenderIf condition={generateReport && orderData->Array.length > 0}>
             <GenerateReport entityName={PAYMENT_REPORT} />
           </RenderIf>
-          <GenerateSampleDataButton previewOnly getOrdersList={fetchOrders} />
           <PortalCapture key={`OrdersCustomizeColumn`} name={`OrdersCustomizeColumn`} />
+          <GenerateSampleDataButton previewOnly getOrdersList={fetchOrders} />
         </div>
       </div>
       <PageLoaderWrapper screenState customUI>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Currently by default all the four input boxes are shown instead of that allow user to add the input boxes
<img width="988" alt="image" src="https://github.com/user-attachments/assets/de8985d5-3cfd-4318-bf18-c5f7fc711356">

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/9395518c-433b-4f17-ab07-b955fdea0e93">

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
