### PR TITLE
fix: remove name from address fields

### DIFF
--- a/src/screens/Order/OrderEntity.res
+++ b/src/screens/Order/OrderEntity.res
@@ -949,17 +949,7 @@ let concatValueOfGivenKeysOfDict = (dict, keys) => {
 }
 
 let itemToObjMapper = dict => {
-  let addressKeys = [
-    "first_name",
-    "last_name",
-    "line1",
-    "line2",
-    "line3",
-    "city",
-    "state",
-    "country",
-    "zip",
-  ]
+  let addressKeys = ["line1", "line2", "line3", "city", "state", "country", "zip"]
 
   let getPhoneNumberString = (phone, ~phoneKey="number", ~codeKey="country_code", ()) => {
     `${phone->getString(codeKey, "")} ${phone->getString(phoneKey, "NA")}`


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Currently the operation address fields are contracted based on multiple keys , this pr will remove first name and last name from the fields used in the address
![image](https://github.com/user-attachments/assets/3d1d4eae-1dfd-4756-a2b9-637a69128578)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
