### PR TITLE
chore: extra param for row level customization with select box

### DIFF
--- a/src/components/FilterSelectBox.res
+++ b/src/components/FilterSelectBox.res
@@ -368,6 +368,7 @@ type dropdownOptionWithoutOptional = {
   iconStroke: string,
   textColor: string,
   optGroup: string,
+  customRowClass: string,
 }
 type dropdownOption = {
   label: string,
@@ -378,6 +379,7 @@ type dropdownOption = {
   description?: string,
   iconStroke?: string,
   textColor?: string,
+  customRowClass?: string,
 }
 
 let makeNonOptional = (dropdownOption: dropdownOption): dropdownOptionWithoutOptional => {
@@ -390,6 +392,7 @@ let makeNonOptional = (dropdownOption: dropdownOption): dropdownOptionWithoutOpt
     iconStroke: dropdownOption.iconStroke->Option.getOr(""),
     textColor: dropdownOption.textColor->Option.getOr(""),
     optGroup: dropdownOption.optGroup->Option.getOr("-"),
+    customRowClass: dropdownOption.customRowClass->Option.getOr(""),
   }
 }
 

--- a/src/components/SelectBox.res
+++ b/src/components/SelectBox.res
@@ -61,6 +61,7 @@ module ListItem = {
     ~showToolTipOptions=false,
     ~textEllipsisForDropDownOptions=false,
     ~textColorClass="",
+    ~customRowClass="",
   ) => {
     let {globalUIConfig: {font}} = React.useContext(ThemeProvider.themeContext)
     let labelText = switch labelValue->String.length {
@@ -196,7 +197,7 @@ module ListItem = {
         <div
           ref={parentRef->ReactDOM.Ref.domRef}
           onClick=onClickTemp
-          className={`flex  relative mx-2 md:mx-0 my-3 md:my-0 pr-2 md:pr-0 md:w-full items-center font-medium  ${overFlowTextCustomClass} ${itemRoundedClass} ${textColor} ${justifyClass} ${cursorClass} ${backgroundClass} ${selectedClass} ${customStyle}  ${customCss} `}>
+          className={`flex  relative mx-2 md:mx-0 my-3 md:my-0 pr-2 md:pr-0 md:w-full items-center font-medium  ${overFlowTextCustomClass} ${itemRoundedClass} ${textColor} ${justifyClass} ${cursorClass} ${backgroundClass} ${selectedClass} ${customStyle}  ${customCss} ${customRowClass}`}>
           {if !isDropDown {
             if showToggle {
               <div className={toggleClass ++ toggleProps} onClick>
@@ -367,6 +368,7 @@ type dropdownOptionWithoutOptional = {
   iconStroke: string,
   textColor: string,
   optGroup: string,
+  customRowClass: string,
 }
 type dropdownOption = {
   label: string,
@@ -377,6 +379,7 @@ type dropdownOption = {
   description?: string,
   iconStroke?: string,
   textColor?: string,
+  customRowClass?: string,
 }
 
 let makeNonOptional = (dropdownOption: dropdownOption): dropdownOptionWithoutOptional => {
@@ -389,6 +392,7 @@ let makeNonOptional = (dropdownOption: dropdownOption): dropdownOptionWithoutOpt
     iconStroke: dropdownOption.iconStroke->Option.getOr(""),
     textColor: dropdownOption.textColor->Option.getOr(""),
     optGroup: dropdownOption.optGroup->Option.getOr("-"),
+    customRowClass: dropdownOption.customRowClass->Option.getOr(""),
   }
 }
 
@@ -1047,6 +1051,7 @@ module BaseSelectButton = {
               isMobileView
               dataId=i
               iconStroke=option.iconStroke
+              customRowClass={option.customRowClass}
             />
           } else {
             React.null
@@ -1133,6 +1138,7 @@ module RenderListItemInBaseRadio = {
           textEllipsisForDropDownOptions
           textColorClass={option.textColor}
           customMarginStyle=customMarginStyleOfListItem
+          customRowClass={option.customRowClass}
         />
 
       if !descriptionOnHover {

--- a/src/components/SelectBox.resi
+++ b/src/components/SelectBox.resi
@@ -47,6 +47,7 @@ module ListItem: {
     ~showToolTipOptions: bool=?,
     ~textEllipsisForDropDownOptions: bool=?,
     ~textColorClass: string=?,
+    ~customRowClass: string=?,
   ) => React.element
 }
 type dropdownOptionWithoutOptional = {
@@ -58,6 +59,7 @@ type dropdownOptionWithoutOptional = {
   iconStroke: string,
   textColor: string,
   optGroup: string,
+  customRowClass: string,
 }
 type dropdownOption = {
   label: string,
@@ -68,6 +70,7 @@ type dropdownOption = {
   description?: string,
   iconStroke?: string,
   textColor?: string,
+  customRowClass?: string,
 }
 let makeNonOptional: dropdownOption => dropdownOptionWithoutOptional
 let useTransformed: array<dropdownOption> => array<dropdownOptionWithoutOptional>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Earlier row level customisation was not possible with select box for a specific row . With this change row level customisation will be possible by passing the custom css in `customRowClass` param. 

For eg : i have passed bg-color = blue just for 3ds 
<img width="490" alt="image" src="https://github.com/user-attachments/assets/d1528224-5c1a-483a-820f-4dd81b0dba84">
<img width="1232" alt="image" src="https://github.com/user-attachments/assets/c27eee34-bd08-4141-b03e-1007ab8e05a1">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Cannot be tested at the moment since it's a chore-level change.
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
