### PR TITLE
fix: commented apex charts and pinned mixpanel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "js-datepicker": "^5.18.2",
     "js-sha256": "^0.9.0",
     "lottie-react": "^2.3.1",
-    "mixpanel-browser": "^2.45.0",
+    "mixpanel-browser": "2.45.0",
     "monaco-editor": "^0.34.1",
     "nprogress": "^0.2.0",
     "react": "^18.2.0",

--- a/src/components/HSwitchSingleStatWidget.res
+++ b/src/components/HSwitchSingleStatWidget.res
@@ -63,7 +63,7 @@ let make = (
     })
   }, [data])
 
-  let options1 = {
+  let _options1 = {
     chart: {
       height: 10,
       toolbar: {
@@ -102,7 +102,7 @@ let make = (
     colors: ["#006DF9"],
   }
 
-  let series = [
+  let _series = [
     {
       \"type": "area",
       data: sortedData1,
@@ -128,15 +128,15 @@ let make = (
             <div className="font-bold text-3xl w-1/3">
               {statValue(statType)->String.toLowerCase->React.string}
             </div>
-            <div className="h-16 w-2/3 scale-[0.4]">
-              <ApexCharts.ReactApexChart
-                \"type"="area"
-                options={options1}
-                series={series->objToJson}
-                height={"170"}
-                width="380"
-              />
-            </div>
+            // <div className="h-16 w-2/3 scale-[0.4]">
+            // <ApexCharts.ReactApexChart
+            //   \"type"="area"
+            //   options={options1}
+            //   series={series->objToJson}
+            //   height={"170"}
+            //   width="380"
+            // />
+            // </div>
           </div>
           <div
             className={"flex gap-2 items-center pt-4 text-jp-gray-700 font-bold self-start h-1/2"}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
1. In newer versions Mixpanel.init is deprecated , hence pinned the version as of to `2.45.0`
2. Unresolved data is being sent to ApexCharts, preventing chart rendering and blocking the entire thread. Consequently, API responses are delayed despite a 200 status code.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [x] INTEG
- [x] SANDBOX
- [x] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
