### PR TITLE
chore: make global search result table consistent

### DIFF
--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTableEntity.res
@@ -53,7 +53,7 @@ type cols =
   | SignFlag
   | Timestamp
 
-let visibleColumns = [RefundId, PaymentId, Connector, TotalAmount, Currency, Refundstatus]
+let visibleColumns = [RefundId, PaymentId, Refundstatus, TotalAmount, Currency, Connector]
 
 let colMapper = (col: cols) => {
   switch col {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
making the global search result page columns consistent 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the global search result page table cols should be in this order  ID -> ID -> Status -> Amount -> Currency -> Connector
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
