### PR TITLE
chore: refund type removed from refunds api

### DIFF
--- a/src/screens/Order/OrderRefundForm.res
+++ b/src/screens/Order/OrderRefundForm.res
@@ -53,7 +53,10 @@ let make = (
     Dict.set(dict, "amount", Math.round(amount *. 100.0)->JSON.Encode.float)
     let body = dict
     Dict.set(body, "payment_id", order.payment_id->JSON.Encode.string)
-    Dict.set(body, "refund_type", "instant"->JSON.Encode.string)
+
+    // NOTE: Backend might change later , but for now removed as backend will have default value as scheduled
+    // Dict.set(body, "refund_type", "instant"->JSON.Encode.string)
+
     if !showRefundReason {
       Dict.set(body, "reason", "RETURN"->JSON.Encode.string)
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Earlier refund_type in the refunds API payload was going as "instant". But it needs to be "scheduled". So we have removed refund_type parameter in the refunds API payload which will by default take "scheduled".
<img width="726" alt="image" src="https://github.com/user-attachments/assets/377c4717-f7e8-4613-b221-429a3e794e38">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- For a successful payment , initiate a refund 
- The refunds API payload should not contain refunds_type 
- The refund_type should be by default "scheduled" 

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [X] INTEG
- [X] SANDBOX
- [X] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
