### PR TITLE
feat: performance monitor exclude filter value

### DIFF
--- a/src/screens/Analytics/PerformanceMonitor/BarChartPerformance/BarChartPerformance.res
+++ b/src/screens/Analytics/PerformanceMonitor/BarChartPerformance/BarChartPerformance.res
@@ -18,6 +18,7 @@ let make = (
       let body = PerformanceUtils.requestBody(
         ~dimensions,
         ~startTime=startTimeVal,
+        ~excludeFilterValue=entity.requestBodyConfig.excludeFilterValue,
         ~endTime=endTimeVal,
         ~filters=entity.requestBodyConfig.filters,
         ~metrics=entity.requestBodyConfig.metrics,

--- a/src/screens/Analytics/PerformanceMonitor/GaugeChart/CustomGraphs/GaugeFailureRate.res
+++ b/src/screens/Analytics/PerformanceMonitor/GaugeChart/CustomGraphs/GaugeFailureRate.res
@@ -5,6 +5,7 @@ let make = (
   ~entity1: PerformanceMonitorTypes.entity<PerformanceMonitorTypes.gaugeData, 't1>,
   ~entity2: PerformanceMonitorTypes.entity<PerformanceMonitorTypes.gaugeData, float>,
   ~domain="payments",
+  ~dimensions,
 ) => {
   open APIUtils
   open LogicUtils
@@ -19,7 +20,7 @@ let make = (
       let url = getURL(~entityName=ANALYTICS_PAYMENTS, ~methodType=Post, ~id=Some(domain))
 
       let body = PerformanceUtils.requestBody(
-        ~dimensions=[],
+        ~dimensions,
         ~startTime=startTimeVal,
         ~endTime=endTimeVal,
         ~delta=entity2.requestBodyConfig.delta,
@@ -59,12 +60,15 @@ let make = (
       let url = getURL(~entityName=ANALYTICS_PAYMENTS, ~methodType=Post, ~id=Some(domain))
 
       let body = PerformanceUtils.requestBody(
-        ~dimensions=[],
+        ~dimensions,
         ~startTime=startTimeVal,
         ~endTime=endTimeVal,
         ~delta=entity1.requestBodyConfig.delta,
         ~metrics=entity1.requestBodyConfig.metrics,
+        ~filters=entity1.requestBodyConfig.filters,
         ~applyFilterFor=entity1.requestBodyConfig.applyFilterFor,
+        ~customFilter=entity1.requestBodyConfig.customFilter,
+        ~excludeFilterValue=entity1.requestBodyConfig.excludeFilterValue,
       )
 
       let res = await updateDetails(url, body, Post)

--- a/src/screens/Analytics/PerformanceMonitor/GaugeChart/GaugeChartPerformance.res
+++ b/src/screens/Analytics/PerformanceMonitor/GaugeChart/GaugeChartPerformance.res
@@ -21,6 +21,7 @@ let make = (
 
       let body = PerformanceUtils.requestBody(
         ~dimensions=[],
+        ~excludeFilterValue=entity.requestBodyConfig.excludeFilterValue,
         ~startTime=startTimeVal,
         ~endTime=endTimeVal,
         ~delta=entity.requestBodyConfig.delta,

--- a/src/screens/Analytics/PerformanceMonitor/PerformanceMonitor.res
+++ b/src/screens/Analytics/PerformanceMonitor/PerformanceMonitor.res
@@ -101,7 +101,11 @@ let make = (~domain="payments") => {
         <div className="flex flex-col gap-3">
           <GaugeChartPerformance startTimeVal endTimeVal entity={getSuccessRatePerformanceEntity} />
           <GaugeFailureRate
-            startTimeVal endTimeVal entity1={overallPaymentCount} entity2={getFailureRateEntity}
+            startTimeVal
+            endTimeVal
+            entity1={overallPaymentCount}
+            entity2={getFailureRateEntity}
+            dimensions
           />
         </div>
         <div className="col-span-3">

--- a/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorEntity.res
+++ b/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorEntity.res
@@ -73,6 +73,7 @@ let getStatusPerformanceEntity: entity<stackBarChartData, option<string>> = {
     metrics: [#payment_count],
     groupBy: [#status],
     filters: [#status],
+    excludeFilterValue: [#payment_method_awaited],
   },
   configRequiredForChartData: {
     groupByKeys: [#status],

--- a/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorEntity.res
+++ b/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorEntity.res
@@ -43,6 +43,8 @@ let overallPaymentCount: entity<gaugeData, option<string>> = {
   requestBodyConfig: {
     delta: true,
     metrics: [#payment_count],
+    filters: [#status],
+    excludeFilterValue: [#payment_method_awaited],
   },
   configRequiredForChartData: {
     groupByKeys: [],

--- a/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorTypes.res
+++ b/src/screens/Analytics/PerformanceMonitor/PerformanceMonitorTypes.res
@@ -1,7 +1,7 @@
 type performance = [#ConnectorPerformance | #PaymentMethodPerormance]
 type dimension = [#connector | #payment_method | #payment_method_type | #status | #no_value]
 
-type status = [#charged | #failure]
+type status = [#charged | #failure | #payment_method_awaited]
 type metrics = [#payment_count | #connector_success_rate]
 type distribution = [#payment_error_message | #TOP_5]
 
@@ -63,6 +63,7 @@ type requestBodyConfig = {
   filters?: array<dimension>,
   customFilter?: dimension,
   applyFilterFor?: array<status>,
+  excludeFilterValue?: array<status>,
   distribution?: distributionType,
 }
 type args<'t1> = {

--- a/src/screens/Analytics/PerformanceMonitor/PerformanceUtils.res
+++ b/src/screens/Analytics/PerformanceMonitor/PerformanceUtils.res
@@ -45,6 +45,7 @@ let getFilterForPerformance = (
   ~filters: option<array<dimension>>,
   ~custom: option<dimension>=None,
   ~customValue: option<array<status>>=None,
+  ~excludeFilterValue: option<array<status>>=None,
 ) => {
   let filtersDict = Dict.make()
   let customFilter = custom->Option.getOr(#no_value)
@@ -52,11 +53,20 @@ let getFilterForPerformance = (
   | Some(val) => {
       val->Array.forEach(filter => {
         let data = if filter == customFilter {
-          customValue->Option.getOr([])->Array.map(v => (v: status :> string)->JSON.Encode.string)
+          customValue->Option.getOr([])->Array.map(v => (v: status :> string))
         } else {
-          getSpecificDimension(dimensions, filter).values->Array.map(v => v->JSON.Encode.string)
+          getSpecificDimension(dimensions, filter).values
         }
-        filtersDict->Dict.set((filter: dimension :> string), data->JSON.Encode.array)
+
+        let updatedFilters = switch excludeFilterValue {
+        | Some(excludeValues) =>
+          data->Array.filter(item => {
+            !(excludeValues->Array.map(v => (v: status :> string))->Array.includes(item))
+          })
+        | None => data
+        }->Array.map(str => str->JSON.Encode.string)
+
+        filtersDict->Dict.set((filter: dimension :> string), updatedFilters->JSON.Encode.array)
       })
       filtersDict->JSON.Encode.object->Some
     }
@@ -79,6 +89,7 @@ let requestBody = (
   ~groupBy: option<array<dimension>>=None,
   ~filters: option<array<dimension>>=[]->Some,
   ~customFilter: option<dimension>=None,
+  ~excludeFilterValue: option<array<status>>=None,
   ~applyFilterFor: option<array<status>>=None,
   ~distribution: option<distributionType>=None,
   ~delta: option<bool>=None,
@@ -89,6 +100,7 @@ let requestBody = (
     ~filters,
     ~custom=customFilter,
     ~customValue=applyFilterFor,
+    ~excludeFilterValue,
   )
   let groupByNames = switch groupBy {
   | Some(vals) => getGroupByForPerformance(~dimensions=vals)->Some

--- a/src/screens/Analytics/PerformanceMonitor/PieChartPerformance/PieChartPerformance.res
+++ b/src/screens/Analytics/PerformanceMonitor/PieChartPerformance/PieChartPerformance.res
@@ -17,6 +17,7 @@ let make = (
       let metricsUrl = getURL(~entityName=ANALYTICS_PAYMENTS, ~methodType=Post, ~id=Some(domain))
       let body = PerformanceUtils.requestBody(
         ~dimensions,
+        ~excludeFilterValue=entity.requestBodyConfig.excludeFilterValue,
         ~startTime=startTimeVal,
         ~endTime=endTimeVal,
         ~filters=entity.requestBodyConfig.filters,

--- a/src/screens/Analytics/PerformanceMonitor/TablePerformance/TablePerformance.res
+++ b/src/screens/Analytics/PerformanceMonitor/TablePerformance/TablePerformance.res
@@ -29,6 +29,7 @@ let make = (
 
       let body = PerformanceUtils.requestBody(
         ~dimensions=[],
+        ~excludeFilterValue=entity.requestBodyConfig.excludeFilterValue,
         ~startTime=startTimeVal,
         ~endTime=endTimeVal,
         ~filters=entity.requestBodyConfig.filters,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Exclude user dropout status i.e payment_method_awaited from 
 1. payment distrubution by status graph in performance monitor analytics 
 2. payment failure rate graph
![image](https://github.com/user-attachments/assets/7d8c671c-1465-483a-a19b-4a4479470cf8)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
The payment distribution by status graphs should not contains payment_method_awaited status 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [x] INTEG
- [x] SANDBOX
- [x] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
