### PR TITLE
fix:  totp extra settings not visible in profile page

### DIFF
--- a/src/entryPoints/AuthModule/UserInfo/UserInfoUtils.res
+++ b/src/entryPoints/AuthModule/UserInfo/UserInfoUtils.res
@@ -13,7 +13,10 @@ let defaultValue = {
 open LogicUtils
 let itemMapper = dict => {
   email: dict->getString("email", defaultValue.email),
-  isTwoFactorAuthSetup: dict->getBool("is_two_factor_auth_setup", defaultValue.isTwoFactorAuthSetup),
+  isTwoFactorAuthSetup: dict->getBool(
+    "is_two_factor_auth_setup",
+    defaultValue.isTwoFactorAuthSetup,
+  ),
   merchantId: dict->getString("merchant_id", defaultValue.merchantId),
   name: dict->getString("name", defaultValue.name),
   orgId: dict->getString("org_id", defaultValue.orgId),

--- a/src/entryPoints/AuthModule/UserInfo/UserInfoUtils.res
+++ b/src/entryPoints/AuthModule/UserInfo/UserInfoUtils.res
@@ -13,7 +13,7 @@ let defaultValue = {
 open LogicUtils
 let itemMapper = dict => {
   email: dict->getString("email", defaultValue.email),
-  isTwoFactorAuthSetup: dict->getBool("email", defaultValue.isTwoFactorAuthSetup),
+  isTwoFactorAuthSetup: dict->getBool("is_two_factor_auth_setup", defaultValue.isTwoFactorAuthSetup),
   merchantId: dict->getString("merchant_id", defaultValue.merchantId),
   name: dict->getString("name", defaultValue.name),
   orgId: dict->getString("org_id", defaultValue.orgId),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Totp settings not showing up in profile section 
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/d9460dc3-a17d-4167-b80d-971a61737dd7">

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [X] INTEG
- [X] SANDBOX
- [X] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [X] I added unit tests for my changes where possible
