### PR TITLE
fix: loading page height before login screen 

### DIFF
--- a/src/entryPoints/AuthModule/AuthWrapper.res
+++ b/src/entryPoints/AuthModule/AuthWrapper.res
@@ -154,7 +154,7 @@ let make = (~children) => {
   <div className="font-inter-style">
     {switch authStatus {
     | LoggedOut =>
-      <PageLoaderWrapper screenState>
+      <PageLoaderWrapper screenState sectionHeight="h-screen">
         <AuthHeaderWrapper childrenStyle="flex flex-col gap-4">
           <RenderIf condition={checkAuthMethodExists([PASSWORD, MAGIC_LINK])}>
             <TwoFaAuthScreen setAuthStatus />
@@ -175,7 +175,7 @@ let make = (~children) => {
       </PageLoaderWrapper>
     | PreLogin(_) => <DecisionScreen />
     | LoggedIn(_token) => children
-    | CheckingAuthStatus => <PageLoaderWrapper.ScreenLoader sectionHeight="h-screen"/>
+    | CheckingAuthStatus => <PageLoaderWrapper.ScreenLoader sectionHeight="h-screen" />
     }}
   </div>
 }

--- a/src/entryPoints/AuthModule/SSOAuth/SSODecisionScreen.res
+++ b/src/entryPoints/AuthModule/SSOAuth/SSODecisionScreen.res
@@ -64,6 +64,6 @@ let make = (~auth_id: option<string>) => {
 
   switch localSSOState {
   | SSO_FROM_REDIRECT(_) => <SSOFromRedirect localSSOState />
-  | LOADING => <PageLoaderWrapper.ScreenLoader />
+  | LOADING => <PageLoaderWrapper.ScreenLoader sectionHeight="h-screen" />
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
while rendering the home screen the height of the loading screen was not full screen
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/e1589259-9315-4408-8f14-eb100c77c451">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
- [X] INTEG
- [X] SANDBOX
- [X] PROD


## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
