### PR TITLE
feat: Netcetera to prod

### DIFF
--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -33,6 +33,8 @@ let threedsAuthenticatorList: array<connectorTypes> = [
   ThreeDsAuthenticator(NETCETERA),
 ]
 
+let threedsAuthenticatorListForLive: array<connectorTypes> = [ThreeDsAuthenticator(NETCETERA)]
+
 let pmAuthenticationConnectorList: array<connectorTypes> = [PMAuthenticationProcessor(PLAID)]
 
 let connectorList: array<connectorTypes> = [

--- a/src/screens/ThreeDsProcessors/ThreeDsConnectorList.res
+++ b/src/screens/ThreeDsProcessors/ThreeDsConnectorList.res
@@ -1,5 +1,6 @@
 @react.component
 let make = () => {
+  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let fetchConnectorListResponse = ConnectorListHook.useFetchConnectorList()
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ => [])
@@ -39,7 +40,9 @@ let make = () => {
           configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
             ~connectorType=ConnectorTypes.ThreeDsAuthenticator,
           )}
-          connectorsAvailableForIntegration=ConnectorUtils.threedsAuthenticatorList
+          connectorsAvailableForIntegration={featureFlagDetails.isLiveMode
+            ? ConnectorUtils.threedsAuthenticatorListForLive
+            : ConnectorUtils.threedsAuthenticatorList}
           urlPrefix="3ds-authenticators/new"
           connectorType=ConnectorTypes.ThreeDsAuthenticator
         />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added a separate list for threeds authenticators for prod . 
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/2733f88d-b662-4d74-8c0a-777cda160ff2">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
Enable the threeds_authenticator feature flag and the is_live_mode flag. Under the Connectors section, there will be a dedicated area for the 3DS authenticator, which should include Netcetera.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [X] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
