### PR TITLE
fix: smart retries tooltip bug fix

### DIFF
--- a/src/components/HSwitchSingleStatTableWidget.res
+++ b/src/components/HSwitchSingleStatTableWidget.res
@@ -221,7 +221,7 @@ let make = (
               </>
             } else {
               <div
-                className="w-full border flex justify-center border-dashed text-sm opacity-70 rounded-lg p-5">
+                className="w-full border flex justify-center border-dashed text-sm opacity-70 rounded-lg px-5 py-2">
                 {"No Data"->React.string}
               </div>
             }}

--- a/src/screens/Analytics/PaymentsAnalytics/SmartRetryAnalytics.res
+++ b/src/screens/Analytics/PaymentsAnalytics/SmartRetryAnalytics.res
@@ -267,20 +267,19 @@ let make = (~filterKeys, ~moduleName) => {
       {"Note: Only date range filters are supported currently for Smart Retry metrics"->React.string}
     </div>
     <div className="relative">
-      <div>
-        <DynamicSingleStat
-          entity={singleStatEntity}
-          startTimeFilterKey
-          endTimeFilterKey
-          filterKeys
-          moduleName
-          showPercentage=false
-          statSentiment={singleStatEntity.statSentiment->Option.getOr(Dict.make())}
-        />
-      </div>
-      <div className="absolute top-0 w-full h-full grid grid-cols-3 grid-rows-2">
-        <div className="col-span-2 " />
-        <div className="row-span-2 h-full">
+      <DynamicSingleStat
+        entity={singleStatEntity}
+        startTimeFilterKey
+        endTimeFilterKey
+        filterKeys
+        moduleName
+        showPercentage=false
+        statSentiment={singleStatEntity.statSentiment->Option.getOr(Dict.make())}
+      />
+      <div
+        className="absolute top-0 w-full h-full grid grid-cols-3 grid-rows-2 pointer-events-none">
+        <div className="col-span-2 h-96 " />
+        <div className="row-span-2 h-full !pointer-events-auto">
           <DynamicSingleStat
             entity=singleStatAMountEntity
             startTimeFilterKey


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
smart retry tool tip info was not visible on hover and this pr will fix that
![Screenshot 2024-08-28 at 4 20 34 PM](https://github.com/user-attachments/assets/b38975ce-50c2-41d3-b812-3bd61b6e3ed3)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
on hover info icon of smart retry tile on payment analytics page the info should show up like in screen shot shown
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
