### PR TITLE
fix: prod intent website regex change

### DIFF
--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -123,7 +123,13 @@ let validateCustom = (key, errors, value) => {
       Dict.set(errors, key->getStringFromVariant, "Please enter valid email id"->JSON.Encode.string)
     }
   | Website =>
-    if !RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost") {
+    if (
+      !RegExp.test(
+        %re("/^(https?:\/\/)?([A-Za-z0-9-]+\.)*[A-Za-z0-9-]{1,63}\.[A-Za-z]{2,6}$/i"),
+        value,
+      ) ||
+      value->String.includes("localhost")
+    ) {
       Dict.set(errors, key->getStringFromVariant, "Please Enter Valid URL"->JSON.Encode.string)
     }
   | _ => ()


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
In production intent email form the website input we accept mandatorily asks for http:// which is not necessary
<!-- Describe your changes in detail -->
![image](https://github.com/user-attachments/assets/32a20471-40d6-4f01-8b8e-519821665634)

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
![image](https://github.com/user-attachments/assets/c823fcd9-a30c-4643-8a5a-ec38ca474db9)

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
websites tests 
Valid: https://calendar.google.com, http://www.example.com, example.co.uk, sub.example.com, example.com
Invalid: -example.com, example-.com, example.com-
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
