### PR TITLE
fix: payouts pagination order fix

### DIFF
--- a/src/screens/Payouts/PayoutsList.res
+++ b/src/screens/Payouts/PayoutsList.res
@@ -11,7 +11,7 @@ let make = () => {
   let (totalCount, setTotalCount) = React.useState(_ => 0)
   let (searchText, setSearchText) = React.useState(_ => "")
   let (filters, setFilters) = React.useState(_ => None)
-  let defaultValue: LoadedTable.pageDetails = {offset: 0, resultsPerPage: 10}
+  let defaultValue: LoadedTable.pageDetails = {offset: 0, resultsPerPage: 20}
   let pageDetailDict = Recoil.useRecoilValueFromAtom(LoadedTable.table_pageDetails)
   let pageDetail = pageDetailDict->Dict.get("Payouts")->Option.getOr(defaultValue)
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
@@ -20,6 +20,7 @@ let make = () => {
     switch filters {
     | Some(dict) =>
       let filters = [("offset", offset->Int.toFloat->JSON.Encode.float)]->Dict.fromArray
+      filters->Dict.set("limit", 20->Int.toFloat->JSON.Encode.float)
       if !(searchText->isEmptyString) {
         filters->Dict.set("payout_id", searchText->String.trim->JSON.Encode.string)
       }
@@ -82,7 +83,7 @@ let make = () => {
           title="Payouts"
           actualData=payoutData
           entity={PayoutsEntity.payoutEntity}
-          resultsPerPage=10
+          resultsPerPage=20
           showSerialNumber=true
           totalResults={totalCount}
           offset


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
increased the table items limit from 10 to 20 items per page and fixed the page items ordering fix when the items per page is selected as 15
![Screenshot 2024-08-28 at 6 16 06 PM](https://github.com/user-attachments/assets/9c714cbb-5308-4f55-9706-21e215da6cb3)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
navigate to diff page and the items order should be in sequence , data should load 20 items per page max
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
