### PR TITLE
fix: disputes table col ordering

### DIFF
--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
@@ -51,7 +51,7 @@ type cols =
   | SignFlag
   | Timestamp
 
-let visibleColumns = [DisputeId, PaymentId, Connector, DisputeAmount, Currency, DisputeStatus]
+let visibleColumns = [DisputeId, PaymentId, DisputeStatus, DisputeAmount, Currency, Connector]
 
 let colMapper = (col: cols) => {
   switch col {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
global search result page dispute table ordering similar to other table in the page 
col in order `DisputeId-> PaymentId -> DisputeStatus -> DisputeAmount -> Currency -> Connector`
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
col in order `DisputeId-> PaymentId -> DisputeStatus -> DisputeAmount -> Currency -> Connector`
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
