### PR TITLE
fix: pagination rows per page selector fix

### DIFF
--- a/src/components/Paginator.res
+++ b/src/components/Paginator.res
@@ -38,7 +38,7 @@ let make = (
   }, (shouldRefetch, handleRefetch))
 
   let selectInputOption = {
-    [5, 10, 15, 25, 50]
+    [5, 10, 15, 20, 50]
     ->Array.filter(val => val <= totalResults)
     ->Array.map(Int.toString)
     ->SelectBox.makeOptions


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
table items per page is not used to show `20` prev but now it will start showing cause most of the table have limit set to 20
![Screenshot 2024-08-29 at 5 15 09 PM](https://github.com/user-attachments/assets/593f2ad1-8c88-4fc3-aff0-9d1f4239e7d3)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
