### PR TITLE
fix: user management revamp bugs

### DIFF
--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -291,7 +291,9 @@ let make = () => {
                             </FilterContext>
                           </AccessControl>
                         | list{"developer-api-keys"} =>
-                          <AccessControl permission=userPermissionJson.merchantDetailsManage>
+                          <AccessControl
+                            permission=userPermissionJson.merchantDetailsManage
+                            isEnabled={!checkUserEntity([#Profile])}>
                             <KeyManagement.KeysManagement />
                           </AccessControl>
                         | list{"developer-system-metrics"} =>

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -519,18 +519,26 @@ let paymentSettings = () => {
 
 let developers = (isDevelopersEnabled, systemMetrics, ~permissionJson, ~checkUserEntity) => {
   let isInternalUser = checkUserEntity([#Internal])
+  let isProfileUser = checkUserEntity([#Profile])
   let apiKeys = apiKeys(permissionJson)
   let paymentSettings = paymentSettings()
   let systemMetric = systemMetric(permissionJson)
+
+  let defaultDevelopersOptions = [paymentSettings]
+
+  if isInternalUser && systemMetrics {
+    defaultDevelopersOptions->Array.push(systemMetric)
+  }
+  if !isProfileUser {
+    defaultDevelopersOptions->Array.push(apiKeys)
+  }
 
   isDevelopersEnabled
     ? Section({
         name: "Developers",
         icon: "developer",
         showSection: true,
-        links: isInternalUser && systemMetrics
-          ? [apiKeys, paymentSettings, systemMetric]
-          : [apiKeys, paymentSettings],
+        links: defaultDevelopersOptions,
       })
     : emptyComponent
 }

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -120,6 +120,7 @@ let useProfileSwitch = () => {
         let responseDict = await updateDetails(url, body, Post)
         setAuthStatus(LoggedIn(Auth(AuthUtils.getAuthInfo(responseDict))))
         let userInfoRes = await getUserInfo()
+        RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/home"))
         userInfoRes
       } else {
         userInfoDefault

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -120,7 +120,6 @@ let useProfileSwitch = () => {
         let responseDict = await updateDetails(url, body, Post)
         setAuthStatus(LoggedIn(Auth(AuthUtils.getAuthInfo(responseDict))))
         let userInfoRes = await getUserInfo()
-        RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/home"))
         userInfoRes
       } else {
         userInfoDefault

--- a/src/screens/OMPSwitch/ProfileSwitch.res
+++ b/src/screens/OMPSwitch/ProfileSwitch.res
@@ -138,6 +138,7 @@ let make = () => {
     try {
       setShowSwitchingProfile(_ => true)
       let _ = await profileSwitch(~expectedProfileId=value, ~currentProfileId=profileId)
+      RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/home"))
       setShowSwitchingProfile(_ => false)
     } catch {
     | _ => {

--- a/src/screens/UserManagement/UserRevamp/ListRoles.res
+++ b/src/screens/UserManagement/UserRevamp/ListRoles.res
@@ -7,7 +7,7 @@ let make = () => {
   let (screenStateRoles, setScreenStateRoles) = React.useState(_ => PageLoaderWrapper.Loading)
   let (rolesAvailableData, setRolesAvailableData) = React.useState(_ => [])
   let (rolesOffset, setRolesOffset) = React.useState(_ => 0)
-
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let userPermissionJson = Recoil.useRecoilValueFromAtom(HyperswitchAtom.userPermissionAtom)
 
@@ -42,12 +42,13 @@ let make = () => {
           text={"Create custom roles"}
           buttonType=Primary
           onClick={_ => {
-            mixpanelEvent(~eventName="invite_users")
+            mixpanelEvent(~eventName="create_custom_role")
             RescriptReactRouter.push(
               GlobalVars.appendDashboardPath(~url="/users-v2/create-custom-role"),
             )
           }}
           customButtonStyle="w-fit !rounded-md"
+          buttonState={checkUserEntity([#Profile]) ? Disabled : Normal}
         />
       </div>
       <LoadedTable


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Issues covered in this PR : 
1. Remove Create custom role button for profile level users.
2. API Keys should be disabled for profile level users.
3. Issue when you switch from payment details to different profile at the top

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
1. Remove Create custom role button for profile level users.
     - create a profile level user 
     - go to users section , under the roles tab 
     - create custom role button should be disabled 
2. API Keys should be disabled for profile level users.
     -  create a profile level user 
     - In the sidebar you cannot see api keys 
4. Issue when you switch from payment details to different profile at the top

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
