### PR TITLE
fix: omp views changes in analytics & ops

### DIFF
--- a/src/screens/Analytics/Analytics.res
+++ b/src/screens/Analytics/Analytics.res
@@ -465,7 +465,6 @@ open AnalyticsTypes
 @react.component
 let make = (
   ~pageTitle="",
-  ~pageSubTitle="",
   ~startTimeFilterKey: string,
   ~endTimeFilterKey: string,
   ~chartEntity: nestedEntityType,
@@ -679,7 +678,7 @@ let make = (
     | Some(chartEntity) =>
       <div>
         <div className="flex items-center justify-between">
-          <PageUtils.PageHeading title=pageTitle subTitle=pageSubTitle />
+          <PageUtils.PageHeading title=pageTitle />
           // Refactor required
           <RenderIf condition={moduleName == "Refunds" || moduleName == "Disputes"}>
             <OMPSwitchHelper.OMPViews

--- a/src/screens/Analytics/AuthenticationAnalytics/AuthenticationAnalytics.res
+++ b/src/screens/Analytics/AuthenticationAnalytics/AuthenticationAnalytics.res
@@ -57,13 +57,11 @@ let make = () => {
   })
 
   let title = "Authentication Analytics"
-  let subTitle = "Know more about how well your users are able to authenticate payments"
 
   <div>
-    <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+    <PageLoaderWrapper screenState customUI={<NoData title />}>
       <Analytics
         pageTitle=title
-        pageSubTitle=subTitle
         filterUri=None
         key="AuthenticationAnalytics"
         moduleName="Authentication"

--- a/src/screens/Analytics/DisputeAnalytics/DisputeAnalytics.res
+++ b/src/screens/Analytics/DisputeAnalytics/DisputeAnalytics.res
@@ -43,17 +43,16 @@ let make = () => {
   })
 
   let title = "Disputes Analytics"
-  let subTitle = "Gain Insights, monitor performance and make Informed Decisions with Dispute Analytics."
+
   let analyticsfilterUrl = getURL(~entityName=ANALYTICS_FILTERS, ~methodType=Post, ~id=Some(domain))
   let disputeAnalyticsUrl = getURL(
     ~entityName=ANALYTICS_PAYMENTS,
     ~methodType=Post,
     ~id=Some(domain),
   )
-  <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+  <PageLoaderWrapper screenState customUI={<NoData title />}>
     <Analytics
       pageTitle=title
-      pageSubTitle=subTitle
       filterUri=Some(analyticsfilterUrl)
       key="DisputesAnalytics"
       moduleName="Disputes"

--- a/src/screens/Analytics/HSAnalyticsUtils.res
+++ b/src/screens/Analytics/HSAnalyticsUtils.res
@@ -175,9 +175,9 @@ let getStringListFromArrayDict = metrics => {
 
 module NoData = {
   @react.component
-  let make = (~title, ~subTitle) => {
+  let make = (~title) => {
     <div className="p-5">
-      <PageUtils.PageHeading title subTitle />
+      <PageUtils.PageHeading title />
       <NoDataFound message="No Data Available" renderType=Painting>
         <Button
           text={"Make a Payment"}

--- a/src/screens/Analytics/PaymentsAnalytics/PaymentAnalytics.res
+++ b/src/screens/Analytics/PaymentsAnalytics/PaymentAnalytics.res
@@ -126,7 +126,6 @@ let make = () => {
   }
 
   let title = "Payments Analytics"
-  let subTitle = "Gain Insights, monitor performance and make Informed Decisions with Payment Analytics."
 
   let formaPayload = (singleStatBodyEntity: DynamicSingleStat.singleStatBodyEntity) => {
     [
@@ -234,10 +233,10 @@ let make = () => {
   }
 
   open AnalyticsNew
-  <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+  <PageLoaderWrapper screenState customUI={<NoData title />}>
     <div className="flex flex-col gap-5">
       <div className="flex items-center justify-between ">
-        <PageUtils.PageHeading title subTitle />
+        <PageUtils.PageHeading title />
         <OMPSwitchHelper.OMPViews
           views={OMPSwitchUtils.analyticsViewList(~checkUserEntity)}
           selectedEntity={analyticsEntity}

--- a/src/screens/Analytics/RefundsAnalytics/RefundsAnalytics.res
+++ b/src/screens/Analytics/RefundsAnalytics/RefundsAnalytics.res
@@ -65,7 +65,6 @@ let make = () => {
   })
 
   let title = "Refunds Analytics"
-  let subTitle = "Uncover patterns and drive business performance through data-driven insights with refund analytics"
 
   let analyticsfilterUrl = getURL(~entityName=ANALYTICS_FILTERS, ~methodType=Post, ~id=Some(domain))
   let refundAnalyticsUrl = getURL(
@@ -73,10 +72,9 @@ let make = () => {
     ~methodType=Post,
     ~id=Some(domain),
   )
-  <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+  <PageLoaderWrapper screenState customUI={<NoData title />}>
     <Analytics
       pageTitle=title
-      pageSubTitle=subTitle
       filterUri=Some(analyticsfilterUrl)
       key="RefundsAnalytics"
       moduleName="Refunds"

--- a/src/screens/Analytics/SystemMetrics/SystemMetricsAnalytics.res
+++ b/src/screens/Analytics/SystemMetrics/SystemMetricsAnalytics.res
@@ -363,17 +363,16 @@ let make = () => {
 
   let tabKeys = getStringListFromArrayDict(dimensions)
   let title = "System Metrics"
-  let subTitle = "Gain Insights, monitor performance and make Informed Decisions with System Metrics."
+
   let analyticsfilterUrl = getURL(~entityName=ANALYTICS_FILTERS, ~methodType=Post, ~id=Some(domain))
   let systemMetricsAnalyticsUrl = getURL(
     ~entityName=ANALYTICS_PAYMENTS,
     ~methodType=Post,
     ~id=Some(domain),
   )
-  <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+  <PageLoaderWrapper screenState customUI={<NoData title />}>
     <SystemMetricsAnalytics
       pageTitle=title
-      pageSubTitle=subTitle
       filterUri={analyticsfilterUrl}
       key="SystemMetrics"
       moduleName="SystemMetrics"

--- a/src/screens/Analytics/UserJourneyAnalytics/UserJourneyAnalytics.res
+++ b/src/screens/Analytics/UserJourneyAnalytics/UserJourneyAnalytics.res
@@ -57,13 +57,11 @@ let make = () => {
   })
 
   let title = "Know your users"
-  let subTitle = "User Journey analytics is a level deeper into payment analytics and aims at providing you a wholesome understanding of the end users and their usage patterns."
 
   <div>
-    <PageLoaderWrapper screenState customUI={<NoData title subTitle />}>
+    <PageLoaderWrapper screenState customUI={<NoData title />}>
       <Analytics
         pageTitle=title
-        pageSubTitle=subTitle
         filterUri=Some(`${Window.env.apiBaseUrl}/analytics/v1/filters/sdk_events`)
         key="UserJourneyAnalytics"
         moduleName="UserJourney"

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -53,7 +53,13 @@ module OMPViews = {
     ~selectedEntity: UserInfoTypes.entity,
     ~onChange,
   ) => {
+    open OMPSwitchUtils
+
     let {userInfo} = React.useContext(UserInfoProvider.defaultContext)
+    let merchantList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
+    let orgList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.orgListAtom)
+    let profileList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.profileListAtom)
+
     let cssBasedOnIndex = index => {
       if index == 0 {
         "rounded-l-md"
@@ -64,15 +70,19 @@ module OMPViews = {
       }
     }
 
-    let getName = entityType =>
-      switch entityType {
-      | #Organization => userInfo.orgId
-      | #Merchant => userInfo.merchantId
-      | #Profile => userInfo.profileId
+    let getName = entityType => {
+      let name = switch entityType {
+      | #Organization => currentOMPName(orgList, userInfo.orgId)
+      | #Merchant => currentOMPName(merchantList, userInfo.merchantId)
+      | #Profile => currentOMPName(profileList, userInfo.profileId)
       | _ => ""
       }
-      ->String.substring(~start=0, ~end=10)
-      ->String.concat("...")
+      name->String.length > 10
+        ? name
+          ->String.substring(~start=0, ~end=10)
+          ->String.concat("...")
+        : name
+    }
 
     <div className="flex h-fit">
       {views

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -53,6 +53,7 @@ module OMPViews = {
     ~selectedEntity: UserInfoTypes.entity,
     ~onChange,
   ) => {
+    let {userInfo} = React.useContext(UserInfoProvider.defaultContext)
     let cssBasedOnIndex = index => {
       if index == 0 {
         "rounded-l-md"
@@ -63,6 +64,16 @@ module OMPViews = {
       }
     }
 
+    let getName = entityType =>
+      switch entityType {
+      | #Organization => userInfo.orgId
+      | #Merchant => userInfo.merchantId
+      | #Profile => userInfo.profileId
+      | _ => ""
+      }
+      ->String.substring(~start=0, ~end=10)
+      ->String.concat("...")
+
     <div className="flex h-fit">
       {views
       ->Array.mapWithIndex((value, index) => {
@@ -70,7 +81,7 @@ module OMPViews = {
         <div
           onClick={_ => onChange(value.entity)->ignore}
           className={`text-sm py-2 px-3 ${selectedStyle} border text-blue-500 border-blue-500 ${index->cssBasedOnIndex} cursor-pointer`}>
-          {value.lable->React.string}
+          {`${value.lable} (${value.entity->getName})`->React.string}
         </div>
       })
       ->React.array}

--- a/src/screens/OMPSwitch/OMPSwitchUtils.res
+++ b/src/screens/OMPSwitch/OMPSwitchUtils.res
@@ -54,12 +54,13 @@ let generateDropdownOptions = dropdownList => {
     dropdownList->Array.map((item): SelectBox.dropdownOption => {label: item.name, value: item.id})
   options
 }
+
 let org = {
-  lable: "All Merchant",
+  lable: "Organization",
   entity: #Organization,
 }
 let merchant = {
-  lable: "All Profile",
+  lable: "Merchant",
   entity: #Merchant,
 }
 let profile = {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Views change in analytics & payment operations
1. Payment ops
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/e2d0305c-2116-4db9-8c95-b142bae2842e">

2. analytics 
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/af87b2ab-8883-4543-bf9c-06945630a518">


## Motivation and Context
Closes change 3 & 4 of #1448 
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
1. Payment ops should have views with current mercant id and profile id 
2. Analytics should have view switch with current org , merchant and profile
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [X] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
