### PR TITLE
fix: list users views in users page

### DIFF
--- a/src/screens/APIUtils/APIUtils.res
+++ b/src/screens/APIUtils/APIUtils.res
@@ -496,7 +496,11 @@ let useGetURL = () => {
     | USER_MANAGEMENT_V2 => {
         let userUrl = `user`
         switch userRoleTypes {
-        | USER_LIST => `${userUrl}/user/v2/list`
+        | USER_LIST =>
+          switch queryParamerters {
+          | Some(queryParams) => `${userUrl}/user/v2/list?${queryParams}`
+          | None => `${userUrl}/user/v2/list`
+          }
         | ROLE_LIST => `${userUrl}/role/v2/list`
         | _ => ""
         }

--- a/src/screens/APIUtils/APIUtils.res
+++ b/src/screens/APIUtils/APIUtils.res
@@ -501,7 +501,11 @@ let useGetURL = () => {
           | Some(queryParams) => `${userUrl}/user/v2/list?${queryParams}`
           | None => `${userUrl}/user/v2/list`
           }
-        | ROLE_LIST => `${userUrl}/role/v2/list`
+        | ROLE_LIST =>
+          switch queryParamerters {
+          | Some(queryParams) => `${userUrl}/role/v2/list?${queryParams}`
+          | None => `${userUrl}/role/v2/list`
+          }
         | _ => ""
         }
       }

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -169,7 +169,8 @@ let useOMPData = () => {
   let orgList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.orgListAtom)
   let profileList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.profileListAtom)
   let {userInfo} = React.useContext(UserInfoProvider.defaultContext)
-  let getList: unit => OMPSwitchTypes.ompList = () => {
+
+  let getList: unit => OMPSwitchTypes.ompList = _ => {
     {
       orgList,
       merchantList,

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -137,7 +137,6 @@ let useInternalSwitch = () => {
   let orgSwitch = useOrgSwitch()
   let merchSwitch = useMerchantSwitch()
   let profileSwitch = useProfileSwitch()
-  let showToast = ToastState.useShowToast()
 
   let {userInfo: {orgId: currentOrgId}} = React.useContext(UserInfoProvider.defaultContext)
 
@@ -158,9 +157,33 @@ let useInternalSwitch = () => {
     } catch {
     | Exn.Error(e) => {
         let err = Exn.message(e)->Option.getOr("Failed to switch!")
-        showToast(~message=err, ~toastType=ToastError)
         Exn.raiseError(err)
       }
     }
   }
+}
+
+let useList = () => {
+  open OMPSwitchUtils
+  let merchantList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
+  let orgList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.orgListAtom)
+  let profileList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.profileListAtom)
+  let {userInfo} = React.useContext(UserInfoProvider.defaultContext)
+  let getList: unit => OMPSwitchTypes.ompList = () => {
+    {
+      orgList,
+      merchantList,
+      profileList,
+    }
+  }
+
+  let getNameForId = entityType =>
+    switch entityType {
+    | #Organization => currentOMPName(orgList, userInfo.orgId)
+    | #Merchant => currentOMPName(merchantList, userInfo.merchantId)
+    | #Profile => currentOMPName(profileList, userInfo.profileId)
+    | _ => ""
+    }
+
+  (getList, getNameForId)
 }

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -163,7 +163,7 @@ let useInternalSwitch = () => {
   }
 }
 
-let useList = () => {
+let useOMPData = () => {
   open OMPSwitchUtils
   let merchantList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
   let orgList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.orgListAtom)

--- a/src/screens/OMPSwitch/OMPSwitchTypes.res
+++ b/src/screens/OMPSwitch/OMPSwitchTypes.res
@@ -5,3 +5,9 @@ type opmView = {
   entity: UserInfoTypes.entity,
 }
 type ompViews = array<opmView>
+
+type ompList = {
+  orgList: array<ompListTypes>,
+  merchantList: array<ompListTypes>,
+  profileList: array<ompListTypes>,
+}

--- a/src/screens/UserManagement/UserRevamp/ListRoles.res
+++ b/src/screens/UserManagement/UserRevamp/ListRoles.res
@@ -1,5 +1,5 @@
 @react.component
-let make = () => {
+let make = (~userModuleEntity: UserManagementTypes.userModuleTypes) => {
   open APIUtils
   open ListRolesTableEntity
   let getURL = useGetURL()
@@ -18,7 +18,9 @@ let make = () => {
         ~entityName=USER_MANAGEMENT_V2,
         ~methodType=Get,
         ~userRoleTypes=ROLE_LIST,
-        ~queryParamerters=Some("groups=true"),
+        ~queryParamerters=userModuleEntity == #Default
+          ? None
+          : Some(`entity_type=${(userModuleEntity :> string)->String.toLowerCase}`),
       )
       let res = await fetchDetails(userDataURL)
       let rolesData = res->LogicUtils.getArrayDataFromJson(itemToObjMapperForRoles)
@@ -32,7 +34,7 @@ let make = () => {
   React.useEffect(() => {
     getRolesAvailable()->ignore
     None
-  }, [])
+  }, [userModuleEntity])
 
   <div className="relative mt-5 flex flex-col gap-6">
     <PageLoaderWrapper screenState={screenStateRoles}>

--- a/src/screens/UserManagement/UserRevamp/ListUsers.res
+++ b/src/screens/UserManagement/UserRevamp/ListUsers.res
@@ -13,6 +13,11 @@ let make = () => {
   let (screenStateUsers, setScreenStateUsers) = React.useState(_ => PageLoaderWrapper.Loading)
   let (userOffset, setUserOffset) = React.useState(_ => 0)
   let (searchText, setSearchText) = React.useState(_ => "")
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
+  let (
+    userModuleEntity: UserManagementTypes.userModuleTypes,
+    setUserModuleEntity,
+  ) = React.useState(_ => #Default)
 
   let getUserData = async () => {
     setScreenStateUsers(_ => PageLoaderWrapper.Loading)
@@ -21,6 +26,9 @@ let make = () => {
         ~entityName=USER_MANAGEMENT_V2,
         ~methodType=Get,
         ~userRoleTypes=USER_LIST,
+        ~queryParamerters=userModuleEntity == #Default
+          ? None
+          : Some(`keys=${(userModuleEntity :> string)->String.toLowerCase}`),
       )
       let res = await fetchDetails(userDataURL)
       let userData = res->getArrayDataFromJson(itemToObjMapperForUser)
@@ -35,7 +43,7 @@ let make = () => {
   React.useEffect(() => {
     getUserData()->ignore
     None
-  }, [])
+  }, [userModuleEntity])
 
   let filterLogicForUsers = ReactDebounce.useDebounced(ob => {
     let (searchText, arr) = ob
@@ -53,7 +61,7 @@ let make = () => {
   }, ~wait=200)
 
   <PageLoaderWrapper screenState={screenStateUsers}>
-    <div className="relative mt-5 w-full">
+    <div className="relative mt-5 w-full flex flex-col gap-12">
       <div className="absolute right-0 z-10">
         <ACLButton
           access={userPermissionJson.usersManage}
@@ -66,6 +74,11 @@ let make = () => {
           customButtonStyle="w-fit !rounded-md"
         />
       </div>
+      <UserManagementHelper.UserOmpView
+        views={UserManagementUtils.getUserManagementViewValues(~checkUserEntity)}
+        userModuleEntity
+        setUserModuleEntity
+      />
       <LoadedTable
         title="Users"
         hideTitle=true

--- a/src/screens/UserManagement/UserRevamp/ListUsers.res
+++ b/src/screens/UserManagement/UserRevamp/ListUsers.res
@@ -1,7 +1,7 @@
 open ListUserTableEntity
 
 @react.component
-let make = () => {
+let make = (~userModuleEntity: UserManagementTypes.userModuleTypes) => {
   open APIUtils
   open LogicUtils
   let getURL = useGetURL()
@@ -13,11 +13,6 @@ let make = () => {
   let (screenStateUsers, setScreenStateUsers) = React.useState(_ => PageLoaderWrapper.Loading)
   let (userOffset, setUserOffset) = React.useState(_ => 0)
   let (searchText, setSearchText) = React.useState(_ => "")
-  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
-  let (
-    userModuleEntity: UserManagementTypes.userModuleTypes,
-    setUserModuleEntity,
-  ) = React.useState(_ => #Default)
 
   let getUserData = async () => {
     setScreenStateUsers(_ => PageLoaderWrapper.Loading)
@@ -74,11 +69,6 @@ let make = () => {
           customButtonStyle="w-fit !rounded-md"
         />
       </div>
-      <UserManagementHelper.UserOmpView
-        views={UserManagementUtils.getUserManagementViewValues(~checkUserEntity)}
-        userModuleEntity
-        setUserModuleEntity
-      />
       <LoadedTable
         title="Users"
         hideTitle=true

--- a/src/screens/UserManagement/UserRevamp/ListUsers.res
+++ b/src/screens/UserManagement/UserRevamp/ListUsers.res
@@ -28,7 +28,7 @@ let make = () => {
         ~userRoleTypes=USER_LIST,
         ~queryParamerters=userModuleEntity == #Default
           ? None
-          : Some(`keys=${(userModuleEntity :> string)->String.toLowerCase}`),
+          : Some(`entity_type=${(userModuleEntity :> string)->String.toLowerCase}`),
       )
       let res = await fetchDetails(userDataURL)
       let userData = res->getArrayDataFromJson(itemToObjMapperForUser)

--- a/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
@@ -207,3 +207,59 @@ module SwitchMerchantForUserAction = {
     />
   }
 }
+
+module UserOmpView = {
+  @react.component
+  let make = (
+    ~views: array<UserManagementTypes.ompViewType>,
+    ~userModuleEntity: UserManagementTypes.userModuleTypes,
+    ~setUserModuleEntity,
+  ) => {
+    let (_, getNameForId) = OMPSwitchHooks.useList()
+
+    let cssBasedOnIndex = index => {
+      if index == 0 {
+        "rounded-l-md"
+      } else if index == views->Array.length - 1 {
+        "rounded-r-md"
+      } else {
+        ""
+      }
+    }
+
+    let getName = entityType => {
+      let name = getNameForId(entityType)
+      name->String.length > 10
+        ? name
+          ->String.substring(~start=0, ~end=10)
+          ->String.concat("...")
+        : name
+    }
+
+    let onChange = entity => {
+      setUserModuleEntity(_ => entity)
+    }
+
+    let labelBasedOnEntity: UserManagementTypes.ompViewType => string = value =>
+      switch value.entity {
+      | #Default => value.label
+      | _ => `${value.label} (${value.entity->getName})`
+      }
+
+    <div className="flex">
+      <div className="flex h-fit">
+        {views
+        ->Array.mapWithIndex((value, index) => {
+          let selectedStyle = userModuleEntity == value.entity ? `bg-blue-200` : ""
+
+          <div
+            onClick={_ => onChange(value.entity)->ignore}
+            className={`text-sm py-2 px-3 ${selectedStyle} border text-blue-500 border-blue-500 ${index->cssBasedOnIndex} cursor-pointer`}>
+            {`${value->labelBasedOnEntity}`->React.string}
+          </div>
+        })
+        ->React.array}
+      </div>
+    </div>
+  }
+}

--- a/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
@@ -215,7 +215,7 @@ module UserOmpView = {
     ~userModuleEntity: UserManagementTypes.userModuleTypes,
     ~setUserModuleEntity,
   ) => {
-    let (_, getNameForId) = OMPSwitchHooks.useList()
+    let (_, getNameForId) = OMPSwitchHooks.useOMPData()
 
     let cssBasedOnIndex = index => {
       if index == 0 {

--- a/src/screens/UserManagement/UserRevamp/UserManagementLanding.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementLanding.res
@@ -18,7 +18,7 @@ let make = () => {
   ]
 
   <div className="flex flex-col overflow-y-scroll">
-    <div className="flex justify-between">
+    <div className="flex justify-between items-center">
       <PageUtils.PageHeading
         title={"Team management"}
         subTitle="Manage user roles and invite members of your organisation"

--- a/src/screens/UserManagement/UserRevamp/UserManagementLanding.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementLanding.res
@@ -1,20 +1,34 @@
 @react.component
 let make = () => {
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
+  let (
+    userModuleEntity: UserManagementTypes.userModuleTypes,
+    setUserModuleEntity,
+  ) = React.useState(_ => #Default)
+
   let tabList: array<Tabs.tab> = [
     {
       title: "Users",
-      renderContent: () => <ListUsers />,
+      renderContent: () => <ListUsers userModuleEntity />,
     },
     {
       title: "Roles",
-      renderContent: () => <ListRoles />,
+      renderContent: () => <ListRoles userModuleEntity />,
     },
   ]
 
   <div className="flex flex-col overflow-y-scroll">
-    <PageUtils.PageHeading
-      title={"Team management"} subTitle="Manage user roles and invite members of your organisation"
-    />
+    <div className="flex justify-between">
+      <PageUtils.PageHeading
+        title={"Team management"}
+        subTitle="Manage user roles and invite members of your organisation"
+      />
+      <UserManagementHelper.UserOmpView
+        views={UserManagementUtils.getUserManagementViewValues(~checkUserEntity)}
+        userModuleEntity
+        setUserModuleEntity
+      />
+    </div>
     <div className="relative">
       <Tabs
         tabs=tabList

--- a/src/screens/UserManagement/UserRevamp/UserManagementTypes.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementTypes.res
@@ -78,3 +78,10 @@ type allSelectionType = [#All_Merchants | #All_Profiles]
 type userActionType = SwitchUser | ManageUser | NoActionAccess
 
 type userStatusTypes = Active | InviteSent | None
+
+type userModuleTypes = [UserInfoTypes.entity | #Default]
+
+type ompViewType = {
+  label: string,
+  entity: userModuleTypes,
+}

--- a/src/screens/UserManagement/UserRevamp/UserManagementUtils.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementUtils.res
@@ -145,3 +145,32 @@ let tabIndeToVariantMapper = index => {
   | _ => RolesTab
   }
 }
+
+let getUserManagementViewValues = (~checkUserEntity) => {
+  open UserManagementTypes
+
+  let org = {
+    label: "Organization",
+    entity: #Organization,
+  }
+  let merchant = {
+    label: "Merchant",
+    entity: #Merchant,
+  }
+  let profile = {
+    label: "Profile",
+    entity: #Profile,
+  }
+  let default = {
+    label: "My Team",
+    entity: #Default,
+  }
+
+  if checkUserEntity([#Organization]) {
+    [default, org, merchant, profile]
+  } else if checkUserEntity([#Merchant]) {
+    [default, merchant, profile]
+  } else {
+    [default]
+  }
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
View changes in users module
<img width="1317" alt="image" src="https://github.com/user-attachments/assets/25cc2829-abf2-4f8e-990c-aafcc6522c8b">


## Motivation and Context
Closes change 1 of https://github.com/juspay/hyperswitch-control-center/issues/1448
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
User management page have views [My Team , Organisation , Merchant , Profile]. 
My team will consist of all the values for that user based on entity of the user 
Organisation,Merchant & Profile will contain the users at entity organisation , merchant and profile respectively 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
