### PR TITLE
chore: empty points generator function for graphs

### DIFF
--- a/src/screens/NewAnalytics/NewAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/NewAnalyticsUtils.res
@@ -1,2 +1,39 @@
 //Logic utils
 
+open NewAnalyticsTypes
+let getBucketSize = (granularity: granularity) => {
+  switch granularity {
+  | #hour_wise => "hour"
+  | #day_wise => "day"
+  | #week_wise => "week"
+  }
+}
+
+let fillMissingDataPoints = (
+  ~data,
+  ~startDate,
+  ~endDate,
+  ~timeKey="time_bucket",
+  ~defaultValue: Dict.t<JSON.t>,
+  ~granularity: granularity,
+) => {
+  open LogicUtils
+  let dataPoints = Dict.make()
+  let startingPoint = startDate->DayJs.getDayJsForString
+  let endingPoint = endDate->DayJs.getDayJsForString
+  let gap = granularity->getBucketSize
+
+  for x in 1 to endingPoint.diff(startingPoint.toString(), gap) {
+    let newDict = defaultValue->Dict.copy
+    let timeVal = startingPoint.add(x, gap).endOf(gap).format("YYYY-MM-DD HH:MM:SS")
+    newDict->Dict.set(timeKey, timeVal->JSON.Encode.string)
+    dataPoints->Dict.set(timeVal, newDict->JSON.Encode.object)
+  }
+
+  data->Array.forEach(value => {
+    let dataDict = value->getDictFromJsonObject
+    dataPoints->Dict.set(dataDict->getString(timeKey, ""), value)
+  })
+
+  dataPoints->Dict.valuesToArray
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
this function will. take the response for graphs and generate the missing points for days or weeks or hours 
![image](https://github.com/user-attachments/assets/a0fc1592-ac76-4801-9179-d691919de1cd)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the line chart should have a complete time range on the x axis with missing points leading to 0 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
