### PR TITLE
fix: table customise column bugfix

### DIFF
--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -250,7 +250,9 @@ module TableRow = {
           <div className=" sticky right-0">
             <tr>
               <td colSpan=12 className="bg-white border-jp-gray-940 !border-l !p-0">
-                <div className="flex flex-row items-center">
+                <div
+                  className="flex flex-row items-center"
+                  onClick={e => e->ReactEvent.Mouse.stopPropagation}>
                   <TableCell
                     cell=EllipsisText("", "w-14 h-14")
                     clearFormatting

--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -247,12 +247,10 @@ module TableRow = {
         })
         ->React.array}
         <RenderIf condition={showCustomizeColumn}>
-          <div className=" sticky right-0">
+          <div className="sticky right-0" onClick={e => e->ReactEvent.Mouse.stopPropagation}>
             <tr>
               <td colSpan=12 className="bg-white border-jp-gray-940 !border-l !p-0">
-                <div
-                  className="flex flex-row items-center"
-                  onClick={e => e->ReactEvent.Mouse.stopPropagation}>
+                <div className="flex flex-row items-center">
                   <TableCell
                     cell=EllipsisText("", "w-14 h-14")
                     clearFormatting

--- a/src/components/TableUtils.res
+++ b/src/components/TableUtils.res
@@ -685,11 +685,10 @@ module TableCell = {
           fontStyle
         />
       </AddDataAttributes>
-
     | Text(x) | DropDown(x) => {
         let x = x->isEmptyString ? "NA" : x
         <AddDataAttributes attributes=[("data-desc", x), ("data-testid", x->String.toLowerCase)]>
-          <div> {highlightedText(x, highlightText)} </div>
+          <div className="text-nowrap"> {highlightedText(x, highlightText)} </div>
         </AddDataAttributes>
       }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- undesired click on customize columns fixed
- height issue fix of table cell

before
![image](https://github.com/user-attachments/assets/f35c7346-1f2f-4473-a8f1-110d5af47348)

after
![image](https://github.com/user-attachments/assets/c565085e-bae8-4c0d-9a26-fe514bb07682)

## Motivation and Context
bugfix
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- click on the customise columns button cells, it does take you to payments page
- add CustomerID column, height of table cell remains same as before, 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
