### PR TITLE
fix: check for disabled pm auth connector

### DIFF
--- a/src/screens/Connectors/ConnectorUIUtils/PaymentMethod.res
+++ b/src/screens/Connectors/ConnectorUIUtils/PaymentMethod.res
@@ -57,7 +57,7 @@ module CardRenderer = {
 
     let isProfileIdConfiguredPMAuth =
       pmAuthProcessorList
-      ->Array.filter(item => item.profile_id === currentProfile)
+      ->Array.filter(item => item.profile_id === currentProfile && item.disabled == false)
       ->Array.length > 0
 
     let shouldShowPMAuthSidebar =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
pm auth processor is disabled -> then sidebar for pm authentication should not be shown in bank debit pmts

## Motivation and Context
bugfix
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
now sidebar is not shown if pm auth is disabled
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
