### PR TITLE
fix: table text-wrap removed

### DIFF
--- a/src/components/TableUtils.res
+++ b/src/components/TableUtils.res
@@ -688,7 +688,7 @@ module TableCell = {
     | Text(x) | DropDown(x) => {
         let x = x->isEmptyString ? "NA" : x
         <AddDataAttributes attributes=[("data-desc", x), ("data-testid", x->String.toLowerCase)]>
-          <div > {highlightedText(x, highlightText)} </div>
+          <div> {highlightedText(x, highlightText)} </div>
         </AddDataAttributes>
       }
 

--- a/src/components/TableUtils.res
+++ b/src/components/TableUtils.res
@@ -688,7 +688,7 @@ module TableCell = {
     | Text(x) | DropDown(x) => {
         let x = x->isEmptyString ? "NA" : x
         <AddDataAttributes attributes=[("data-desc", x), ("data-testid", x->String.toLowerCase)]>
-          <div className="text-nowrap"> {highlightedText(x, highlightText)} </div>
+          <div > {highlightedText(x, highlightText)} </div>
         </AddDataAttributes>
       }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed no text-wrap class from card cells to keep content wrapped, improving layout consistency.

## Motivation and Context

Improving layout consistency.

## How did you test it?

Tested the code manually in payment cards.
<img width="981" alt="Screenshot 2024-10-01 at 7 37 25 AM" src="https://github.com/user-attachments/assets/da3c6388-7ad2-4c6c-a98d-3af0c100dfcd">

<img width="512" alt="Screenshot 2024-09-30 at 8 42 49 PM" src="https://github.com/user-attachments/assets/324860ca-f32a-4a8a-83ba-ee7df82e12ad">

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

