### PR TITLE
feat: add auto retries in payment settings

### DIFF
--- a/src/screens/Developer/APIKeys/DeveloperUtils.res
+++ b/src/screens/Developer/APIKeys/DeveloperUtils.res
@@ -187,6 +187,14 @@ let threeDsRequestorUrl = FormRenderer.makeFieldInfo(
   ~isRequired=false,
 )
 
+let maxAutoRetries = FormRenderer.makeFieldInfo(
+  ~label="Max Auto Retries",
+  ~name="max_auto_retries_enabled",
+  ~placeholder="Enter number of max auto retries",
+  ~customInput=InputFields.textInput(~autoComplete="off"),
+  ~isRequired=false,
+)
+
 module ErrorUI = {
   @react.component
   let make = (~text) => {

--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -351,7 +351,7 @@ let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
 
   let (busiProfieDetails, setBusiProfie) = React.useState(_ => businessProfileDetails)
 
-  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
+  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (enableCustomHttpHeaders, setCustomHttpHeaders) = React.useState(_ => false)
   let bgClass = webhookOnly ? "" : "bg-white dark:bg-jp-gray-lightgray_background"
   let fetchBusinessProfiles = BusinessProfileHook.useFetchBusinessProfiles()

--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -356,6 +356,14 @@ let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
   let bgClass = webhookOnly ? "" : "bg-white dark:bg-jp-gray-lightgray_background"
   let fetchBusinessProfiles = BusinessProfileHook.useFetchBusinessProfiles()
 
+  React.useEffect(() => {
+    if businessProfileDetails.profile_id->LogicUtils.isNonEmptyString {
+      setBusiProfie(_ => businessProfileDetails)
+      setScreenState(_ => Success)
+    }
+    None
+  }, [businessProfileDetails.profile_id])
+
   let threedsConnectorList =
     HyperswitchAtom.connectorListAtom
     ->Recoil.useRecoilValueFromAtom

--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -290,6 +290,49 @@ module CollectDetails = {
   }
 }
 
+module AutoRetries = {
+  @react.component
+  let make = () => {
+    open FormRenderer
+    open DeveloperUtils
+    open LogicUtils
+    let formState: ReactFinalForm.formState = ReactFinalForm.useFormState(
+      ReactFinalForm.useFormSubscription(["values"])->Nullable.make,
+    )
+    let form = ReactFinalForm.useForm()
+    let errorClass = "text-sm leading-4 font-medium text-start ml-1 mt-2"
+
+    let isAutoRetryEnabled =
+      formState.values->getDictFromJsonObject->getBool("is_auto_retries_enabled", false)
+
+    if !isAutoRetryEnabled {
+      form.change("max_auto_retries_enabled", JSON.Encode.null->Identity.genericTypeToJson)
+    }
+
+    <>
+      <DesktopRow>
+        <FieldRenderer
+          labelClass="!text-base !text-grey-700 font-semibold"
+          fieldWrapperClass="max-w-xl"
+          field={makeFieldInfo(
+            ~name="is_auto_retries_enabled",
+            ~label="Auto Retries",
+            ~customInput=InputFields.boolInput(~isDisabled=false, ~boolCustomClass="rounded-lg"),
+          )}
+        />
+      </DesktopRow>
+      <RenderIf condition={isAutoRetryEnabled}>
+        <FieldRenderer
+          field={maxAutoRetries}
+          errorClass
+          labelClass="!text-base !text-grey-700 font-semibold"
+          fieldWrapperClass="max-w-xl mx-4"
+        />
+      </RenderIf>
+    </>
+  }
+}
+
 @react.component
 let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
   open DeveloperUtils
@@ -325,7 +368,9 @@ let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
 
   let fieldsToValidate = () => {
     let defaultFieldsToValidate =
-      [WebhookUrl, ReturnUrl]->Array.filter(urlField => urlField === WebhookUrl || !webhookOnly)
+      [WebhookUrl, ReturnUrl, MaxAutoRetries]->Array.filter(urlField =>
+        urlField === WebhookUrl || !webhookOnly
+      )
     defaultFieldsToValidate
   }
 
@@ -468,6 +513,7 @@ let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
                     />
                   </DesktopRow>
                 </RenderIf>
+                <AutoRetries />
                 <ReturnUrl />
                 <WebHook enableCustomHttpHeaders setCustomHttpHeaders />
                 <DesktopRow>

--- a/src/screens/Developer/PaymentSettings/PaymentSettingsListEntity.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettingsListEntity.res
@@ -58,7 +58,7 @@ let itemToObjMapper = dict => {
     outgoing_webhook_custom_http_headers: None,
     is_connector_agnostic_mit_enabled: None,
     is_auto_retries_enabled: dict->getOptionBool("is_auto_retries_enabled"),
-    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled")
+    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled"),
   }
 }
 

--- a/src/screens/Developer/PaymentSettings/PaymentSettingsListEntity.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettingsListEntity.res
@@ -57,6 +57,8 @@ let itemToObjMapper = dict => {
     ),
     outgoing_webhook_custom_http_headers: None,
     is_connector_agnostic_mit_enabled: None,
+    is_auto_retries_enabled: dict->getOptionBool("is_auto_retries_enabled"),
+    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled")
   }
 }
 

--- a/src/screens/Settings/BusinessMapping/BusinessMappingEntity.res
+++ b/src/screens/Settings/BusinessMapping/BusinessMappingEntity.res
@@ -152,7 +152,7 @@ let itemToObjMapper = dict => {
     outgoing_webhook_custom_http_headers: None,
     is_connector_agnostic_mit_enabled: None,
     is_auto_retries_enabled: dict->getOptionBool("is_auto_retries_enabled"),
-    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled")
+    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled"),
   }
 }
 

--- a/src/screens/Settings/BusinessMapping/BusinessMappingEntity.res
+++ b/src/screens/Settings/BusinessMapping/BusinessMappingEntity.res
@@ -151,6 +151,8 @@ let itemToObjMapper = dict => {
     ),
     outgoing_webhook_custom_http_headers: None,
     is_connector_agnostic_mit_enabled: None,
+    is_auto_retries_enabled: dict->getOptionBool("is_auto_retries_enabled"),
+    max_auto_retries_enabled: dict->getOptionInt("max_auto_retries_enabled")
   }
 }
 

--- a/src/screens/Settings/HSwitchSettingTypes.res
+++ b/src/screens/Settings/HSwitchSettingTypes.res
@@ -104,6 +104,7 @@ type validationFields =
   | AuthetnticationConnectors(array<JSON.t>)
   | ThreeDsRequestorUrl
   | UnknownValidateFields(string)
+  | MaxAutoRetries
 
 type formStateType = Preview | Edit
 type fieldType = {
@@ -153,6 +154,8 @@ type profileEntity = {
   always_collect_billing_details_from_wallet_connector: option<bool>,
   is_connector_agnostic_mit_enabled: option<bool>,
   outgoing_webhook_custom_http_headers: option<Dict.t<JSON.t>>,
+  is_auto_retries_enabled: option<bool>,
+  max_auto_retries_enabled: option<int>,
 }
 
 type twoFaType = RecoveryCode | Totp

--- a/src/screens/Settings/MerchantAccountUtils.res
+++ b/src/screens/Settings/MerchantAccountUtils.res
@@ -19,6 +19,8 @@ let parseBussinessProfileJson = (profileRecord: profileEntity) => {
     collect_billing_details_from_wallet_connector,
     always_collect_billing_details_from_wallet_connector,
     always_collect_shipping_details_from_wallet_connector,
+    is_auto_retries_enabled,
+    max_auto_retries_enabled,
   } = profileRecord
 
   let profileInfo =
@@ -44,6 +46,9 @@ let parseBussinessProfileJson = (profileRecord: profileEntity) => {
     "always_collect_shipping_details_from_wallet_connector",
     always_collect_shipping_details_from_wallet_connector,
   )
+
+  profileInfo->setOptionBool("is_auto_retries_enabled", is_auto_retries_enabled)
+  profileInfo->setOptionInt("max_auto_retries_enabled", max_auto_retries_enabled)
 
   profileInfo->setDictNull("webhook_url", webhook_details.webhook_url)
   profileInfo->setOptionString("webhook_version", webhook_details.webhook_version)
@@ -189,6 +194,17 @@ let getBusinessProfilePayload = (values: JSON.t) => {
     "always_collect_billing_details_from_wallet_connector",
     valuesDict->getOptionBool("always_collect_billing_details_from_wallet_connector"),
   )
+
+  profileDetailsDict->setOptionBool(
+    "is_auto_retries_enabled",
+    valuesDict->getOptionBool("is_auto_retries_enabled"),
+  )
+
+  profileDetailsDict->setOptionInt(
+    "max_auto_retries_enabled",
+    valuesDict->getOptionInt("max_auto_retries_enabled"),
+  )
+
   profileDetailsDict->setOptionBool(
     "is_connector_agnostic_mit_enabled",
     valuesDict->getOptionBool("is_connector_agnostic_mit_enabled"),
@@ -308,6 +324,7 @@ let validationFieldsMapper = key => {
   | AuthetnticationConnectors(_) => "authentication_connectors"
   | ThreeDsRequestorUrl => "three_ds_requestor_url"
   | UnknownValidateFields(key) => key
+  | MaxAutoRetries => "max_auto_retries_enabled"
   }
 }
 
@@ -394,6 +411,14 @@ let validateCustom = (key, errors, value, isLiveMode) => {
         Dict.set(errors, key->validationFieldsMapper, "Please Enter Valid URL"->JSON.Encode.string)
       }
     }
+  | MaxAutoRetries =>
+    if !RegExp.test(%re("/^[1-5]$/"), value) {
+      Dict.set(
+        errors,
+        key->validationFieldsMapper,
+        "Please enter integer value from 1 to 5"->JSON.Encode.string,
+      )
+    }
 
   | _ => ()
   }
@@ -464,6 +489,8 @@ let defaultValueForBusinessProfile = {
   always_collect_billing_details_from_wallet_connector: None,
   outgoing_webhook_custom_http_headers: None,
   is_connector_agnostic_mit_enabled: None,
+  is_auto_retries_enabled: None,
+  max_auto_retries_enabled: None,
 }
 
 let getValueFromBusinessProfile = businessProfileValue => {

--- a/src/utils/LogicUtils.res
+++ b/src/utils/LogicUtils.res
@@ -335,6 +335,9 @@ let setOptionArray = (dict, key, optionArray) =>
 let setOptionDict = (dict, key, optionDictValue) =>
   optionDictValue->Option.mapOr((), value => dict->Dict.set(key, value->JSON.Encode.object))
 
+let setOptionInt = (dict, key, optionInt) =>
+  optionInt->Option.mapOr((), int => dict->Dict.set(key, int->JSON.Encode.int))
+
 let capitalizeString = str => {
   String.toUpperCase(String.charAt(str, 0)) ++ Js.String2.substringToEnd(str, ~from=1)
 }

--- a/src/utils/Mappers/BusinessProfileMapper.res
+++ b/src/utils/Mappers/BusinessProfileMapper.res
@@ -54,6 +54,8 @@ let businessProfileTypeMapper = values => {
     outgoing_webhook_custom_http_headers: !(outgoingWebhookHeades->isEmptyDict)
       ? Some(outgoingWebhookHeades)
       : None,
+    is_auto_retries_enabled: jsonDict->getOptionBool("is_auto_retries_enabled"),
+    max_auto_retries_enabled: jsonDict->getOptionInt("max_auto_retries_enabled"),
   }
   businessProfile
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

New fields added in payment settings page
- Auto retries enabled
- Maximum number of Auto retries

![image](https://github.com/user-attachments/assets/ea96f8dd-6b84-41a3-94da-954ffd14aa41)
![image](https://github.com/user-attachments/assets/f6e19bda-e2c8-4012-9ede-d4cfd226ee9c)
![image](https://github.com/user-attachments/assets/e9b6a5df-3a70-4f21-8ce1-cb583cd20482)


## Motivation and Context
product requirement


## How did you test it?

Go to Payment Settings
Able to see Auto Retries toggle 
On enabling the toggle, user can enter Maximum number of auto-retries desired (validation for the field - values only accepted from 1 to 5)

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
