### PR TITLE
fix: connected list on top in  3DS connectors  , tax processors and PM authentication processors

### DIFF
--- a/src/screens/PMAuthenticationProcessor/PMAuthenticationConnectorList.res
+++ b/src/screens/PMAuthenticationProcessor/PMAuthenticationConnectorList.res
@@ -35,14 +35,6 @@ let make = () => {
     />
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-10">
-        <ProcessorCards
-          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
-            ~connectorType=ConnectorTypes.PMAuthenticationProcessor,
-          )}
-          connectorsAvailableForIntegration=ConnectorUtils.pmAuthenticationConnectorList
-          urlPrefix="pm-authentication-processor/new"
-          connectorType=ConnectorTypes.PMAuthenticationProcessor
-        />
         <RenderIf condition={configuredConnectors->Array.length > 0}>
           <LoadedTable
             title="Connected Processors"
@@ -59,6 +51,14 @@ let make = () => {
             collapseTableRow=false
           />
         </RenderIf>
+        <ProcessorCards
+          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
+            ~connectorType=ConnectorTypes.PMAuthenticationProcessor,
+          )}
+          connectorsAvailableForIntegration=ConnectorUtils.pmAuthenticationConnectorList
+          urlPrefix="pm-authentication-processor/new"
+          connectorType=ConnectorTypes.PMAuthenticationProcessor
+        />
       </div>
     </PageLoaderWrapper>
   </div>

--- a/src/screens/TaxProcessor/TaxProcessorList.res
+++ b/src/screens/TaxProcessor/TaxProcessorList.res
@@ -34,14 +34,6 @@ let make = () => {
     />
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-10">
-        <ProcessorCards
-          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
-            ~connectorType=ConnectorTypes.TaxProcessor,
-          )}
-          connectorsAvailableForIntegration=ConnectorUtils.taxProcessorList
-          urlPrefix="tax-processor/new"
-          connectorType=ConnectorTypes.TaxProcessor
-        />
         <RenderIf condition={configuredConnectors->Array.length > 0}>
           <LoadedTable
             title="Connected Processors"
@@ -58,6 +50,14 @@ let make = () => {
             collapseTableRow=false
           />
         </RenderIf>
+        <ProcessorCards
+          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
+            ~connectorType=ConnectorTypes.TaxProcessor,
+          )}
+          connectorsAvailableForIntegration=ConnectorUtils.taxProcessorList
+          urlPrefix="tax-processor/new"
+          connectorType=ConnectorTypes.TaxProcessor
+        />
       </div>
     </PageLoaderWrapper>
   </div>

--- a/src/screens/ThreeDsProcessors/ThreeDsConnectorList.res
+++ b/src/screens/ThreeDsProcessors/ThreeDsConnectorList.res
@@ -36,16 +36,6 @@ let make = () => {
     />
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-10">
-        <ProcessorCards
-          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
-            ~connectorType=ConnectorTypes.ThreeDsAuthenticator,
-          )}
-          connectorsAvailableForIntegration={featureFlagDetails.isLiveMode
-            ? ConnectorUtils.threedsAuthenticatorListForLive
-            : ConnectorUtils.threedsAuthenticatorList}
-          urlPrefix="3ds-authenticators/new"
-          connectorType=ConnectorTypes.ThreeDsAuthenticator
-        />
         <RenderIf condition={configuredConnectors->Array.length > 0}>
           <LoadedTable
             title="Connected Processors"
@@ -62,6 +52,16 @@ let make = () => {
             collapseTableRow=false
           />
         </RenderIf>
+        <ProcessorCards
+          configuredConnectors={configuredConnectors->ConnectorUtils.getConnectorTypeArrayFromListConnectors(
+            ~connectorType=ConnectorTypes.ThreeDsAuthenticator,
+          )}
+          connectorsAvailableForIntegration={featureFlagDetails.isLiveMode
+            ? ConnectorUtils.threedsAuthenticatorListForLive
+            : ConnectorUtils.threedsAuthenticatorList}
+          urlPrefix="3ds-authenticators/new"
+          connectorType=ConnectorTypes.ThreeDsAuthenticator
+        />
       </div>
     </PageLoaderWrapper>
   </div>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Connected processor list should be on top in pm-auth , tax processors and 3ds connectors with no search boxes.

BEFORE: 

<img width="1453" alt="Screenshot 2024-10-15 at 12 40 00 PM" src="https://github.com/user-attachments/assets/ed87b864-37b5-4a55-baeb-99f650c73575">

<img width="1454" alt="Screenshot 2024-10-15 at 12 42 03 PM" src="https://github.com/user-attachments/assets/2c17c5a9-7845-439d-9493-d51b17a62181">

AFTER:

<img width="1454" alt="Screenshot 2024-10-15 at 12 40 17 PM" src="https://github.com/user-attachments/assets/d5fdb3ba-6612-410b-8c94-b790ca13a8ab">

<img width="1452" alt="Screenshot 2024-10-15 at 12 42 10 PM" src="https://github.com/user-attachments/assets/597b824b-3340-440f-b293-a9f2a3dbc1a9">




## Motivation and Context

For better user experience and accessibility.

## How did you test it?

Tested display as shown in desc.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
