### PR TITLE
fix: disable edit for profile level user (Business section)

### DIFF
--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -107,6 +107,7 @@ let useProfileSwitch = () => {
   open APIUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
+  let showToast = ToastState.useShowToast()
   let {getUserInfo} = useUserInfo()
   let {setAuthStatus} = React.useContext(AuthInfoProvider.authStatusContext)
   let {userInfo: userInfoDefault} = React.useContext(UserInfoProvider.defaultContext)
@@ -121,6 +122,7 @@ let useProfileSwitch = () => {
         let responseDict = await updateDetails(url, body, Post)
         setAuthStatus(LoggedIn(Auth(AuthUtils.getAuthInfo(responseDict))))
         let userInfoRes = await getUserInfo()
+        showToast(~message=`Your profile has been switched successfully.`, ~toastType=ToastSuccess)
         userInfoRes
       } else {
         userInfoDefault

--- a/src/screens/Settings/BusinessDetails.res
+++ b/src/screens/Settings/BusinessDetails.res
@@ -2,7 +2,6 @@ open HSwitchSettingTypes
 open MerchantAccountUtils
 open APIUtils
 open SettingsFieldsInfo
-open CommonAuthTypes
 module InfoOnlyView = {
   @react.component
   let make = (~heading, ~subHeading="Default value") => {

--- a/src/screens/Settings/BusinessDetails.res
+++ b/src/screens/Settings/BusinessDetails.res
@@ -158,7 +158,7 @@ let make = () => {
               onClick={_ => setFormState(_ => Edit)}
               buttonType=Primary
               buttonSize={Small}
-              buttonState={!checkUserEntity([#Profile]) ? Normal : Disabled}
+              buttonState={checkUserEntity([#Profile]) ?Disabled :Normal}
               customButtonStyle="rounded-sm"
             />
           | Edit =>

--- a/src/screens/Settings/BusinessDetails.res
+++ b/src/screens/Settings/BusinessDetails.res
@@ -2,7 +2,7 @@ open HSwitchSettingTypes
 open MerchantAccountUtils
 open APIUtils
 open SettingsFieldsInfo
-
+open CommonAuthTypes
 module InfoOnlyView = {
   @react.component
   let make = (~heading, ~subHeading="Default value") => {
@@ -68,6 +68,13 @@ let make = () => {
   let (formState, setFormState) = React.useState(_ => Preview)
   let (fetchState, setFetchState) = React.useState(_ => PageLoaderWrapper.Loading)
   let {merchantId} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
+  let authorizationLogic = {
+    switch userHasAccess(~groupAccess=MerchantDetailsManage) {
+    | NoAccess => NoAccess
+    | Access => checkUserEntity([#Profile]) ? NoAccess : Access
+    }
+  }
   let onSubmit = async (values, _) => {
     try {
       setFetchState(_ => Loading)
@@ -153,7 +160,7 @@ let make = () => {
           {switch formState {
           | Preview =>
             <ACLButton
-              authorization={userHasAccess(~groupAccess=MerchantDetailsManage)}
+              authorization={authorizationLogic}
               text="Edit"
               onClick={_ => setFormState(_ => Edit)}
               buttonType=Primary

--- a/src/screens/Settings/BusinessDetails.res
+++ b/src/screens/Settings/BusinessDetails.res
@@ -69,12 +69,6 @@ let make = () => {
   let (fetchState, setFetchState) = React.useState(_ => PageLoaderWrapper.Loading)
   let {merchantId} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
   let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
-  let authorizationLogic = {
-    switch userHasAccess(~groupAccess=MerchantDetailsManage) {
-    | NoAccess => NoAccess
-    | Access => checkUserEntity([#Profile]) ? NoAccess : Access
-    }
-  }
   let onSubmit = async (values, _) => {
     try {
       setFetchState(_ => Loading)
@@ -160,11 +154,12 @@ let make = () => {
           {switch formState {
           | Preview =>
             <ACLButton
-              authorization={authorizationLogic}
+              authorization={userHasAccess(~groupAccess=MerchantDetailsManage)}
               text="Edit"
               onClick={_ => setFormState(_ => Edit)}
               buttonType=Primary
               buttonSize={Small}
+              buttonState={!checkUserEntity([#Profile]) ? Normal : Disabled}
               customButtonStyle="rounded-sm"
             />
           | Edit =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Disabled Edit for Profile level users in business details.

https://github.com/user-attachments/assets/af6cf365-c55e-4f24-9e1a-0c761839318a


## Motivation and Context

To enforce stricter access control within our application. Profile-level users typically have limited permissions that do not include the ability to modify business-critical information. This enhances security , maintains consistency and improves user experience.

## How did you test it?
I checked the enable/disable of edit business section between different level users. It was working as expected.


## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
