### PR TITLE
fix: merchant account credentials not shown in profile view

### DIFF
--- a/src/container/MerchantAccountContainer.res
+++ b/src/container/MerchantAccountContainer.res
@@ -18,8 +18,9 @@ let make = () => {
   let setUpConnectoreContainer = async () => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-
-      let _ = await fetchMerchantAccountDetails()
+      if !checkUserEntity([#Profile]) {
+        let _ = await fetchMerchantAccountDetails()
+      }
       if userHasAccess(~groupAccess=ConnectorsView) === Access {
         if !featureFlagDetails.isLiveMode {
           let _ = await fetchConnectorListResponse()
@@ -67,6 +68,7 @@ let make = () => {
       }}
       <RenderIf
         condition={!featureFlagDetails.isLiveMode &&
+        !checkUserEntity([#Profile]) &&
         userHasAccess(~groupAccess=MerchantDetailsManage) === Access &&
         merchantDetailsTypedValue.merchant_name->Option.isNone}>
         <SbxOnboardingSurvey showModal=surveyModal setShowModal=setSurveyModal />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Initially we were conditionally not rendering merchant id and publishable key on home at user profile view but the credentials were shown in merchant account api response. Ideally profile user should not know any credentials and information regarding merchant.

## Motivation and Context

To enforce stricter access control.

## How did you test it?

I checked the if the profile view was rendering without any display of credentials .

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
