### PR TITLE
chore: TwoFa restriction after multiple failed attempts after logging in

### DIFF
--- a/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
@@ -36,5 +36,7 @@ type subCode =
   | UR_40
   | UR_41
   | UR_42
+  | UR_48
+  | UR_49
 
 type modeType = TestButtonMode | LiveButtonMode

--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -128,6 +128,8 @@ let errorSubCodeMapper = (subCode: string) => {
   | "UR_40" => UR_40
   | "UR_41" => UR_41
   | "UR_42" => UR_42
+  | "UR_48" => UR_48
+  | "UR_49" => UR_49
   | _ => UR_00
   }
 }

--- a/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
@@ -27,7 +27,7 @@ module EnterAccessCode = {
       | Exn.Error(e) => {
           let err = Exn.message(e)->Option.getOr("Something went wrong")
           let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
-          if errorCode == "UR_49" {
+          if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_49 {
             errorHandling(errorCode)
           }
           setRecoveryCode(_ => "")
@@ -142,7 +142,7 @@ module ConfigureTotpScreen = {
       | Exn.Error(e) => {
           let err = Exn.message(e)->Option.getOr("Something went wrong")
           let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
-          if errorCode == "UR_48" {
+          if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_48 {
             errorHandling(errorCode)
           }
           setOtp(_ => "")

--- a/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
@@ -28,7 +28,7 @@ module EnterAccessCode = {
           let err = Exn.message(e)->Option.getOr("Something went wrong")
           let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
           if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_49 {
-            errorHandling(errorCode)
+            errorHandling()
           }
           setRecoveryCode(_ => "")
           setButtonState(_ => Button.Normal)
@@ -143,7 +143,7 @@ module ConfigureTotpScreen = {
           let err = Exn.message(e)->Option.getOr("Something went wrong")
           let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
           if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_48 {
-            errorHandling(errorCode)
+            errorHandling()
           }
           setOtp(_ => "")
           setButtonState(_ => Button.Normal)

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
@@ -7,43 +7,57 @@ module AttemptsExpiredComponent = {
     open HSwitchUtils
     let {setAuthStatus} = React.useContext(AuthInfoProvider.authStatusContext)
 
-    let belowComponent = switch expiredType {
+    let expiredComponent = switch expiredType {
     | TOTP_ATTEMPTS_EXPIRED =>
-      <p className={`${p2Regular} text-jp-gray-700`}>
-        {"or "->React.string}
-        <span
-          className="cursor-pointer underline underline-offset-2 text-blue-600"
-          onClick={_ => {
-            setTwoFaStatus(_ => TwoFaNotExpired)
-            setTwoFaPageState(_ => TOTP_INPUT_RECOVERY_CODE)
-          }}>
-          {"Use recovery-code"->React.string}
-        </span>
-      </p>
+      <div
+        className="bg-white px-6 py-12 rounded-md border w-1/3 text-center font-semibold flex flex-col gap-4">
+        <p>
+          {"There have been multiple unsuccessful TOTP attempts for this account. Please wait a moment before trying again."->React.string}
+        </p>
+        <p className={`${p2Regular} text-jp-gray-700`}>
+          {"or "->React.string}
+          <span
+            className="cursor-pointer underline underline-offset-2 text-blue-600"
+            onClick={_ => {
+              setTwoFaStatus(_ => TwoFaNotExpired)
+              setTwoFaPageState(_ => TOTP_INPUT_RECOVERY_CODE)
+            }}>
+            {"Use recovery-code"->React.string}
+          </span>
+        </p>
+      </div>
+
     | RC_ATTEMPTS_EXPIRED =>
-      <p className={`${p2Regular} text-jp-gray-700`}>
-        {"or "->React.string}
-        <span
-          className="cursor-pointer underline underline-offset-2 text-blue-600"
-          onClick={_ => {
-            setTwoFaStatus(_ => TwoFaNotExpired)
-            setTwoFaPageState(_ => TOTP_SHOW_QR)
-          }}>
-          {"Use totp"->React.string}
-        </span>
-      </p>
-    | TWO_FA_EXPIRED => React.null
+      <div
+        className="bg-white px-6 py-12 rounded-md border w-1/3 text-center font-semibold flex flex-col gap-4">
+        <p>
+          {"There have been multiple unsuccessful Recovery code attempts for this account. Please wait a moment before trying again."->React.string}
+        </p>
+        <p className={`${p2Regular} text-jp-gray-700`}>
+          {"or "->React.string}
+          <span
+            className="cursor-pointer underline underline-offset-2 text-blue-600"
+            onClick={_ => {
+              setTwoFaStatus(_ => TwoFaNotExpired)
+              setTwoFaPageState(_ => TOTP_SHOW_QR)
+            }}>
+            {"Use totp"->React.string}
+          </span>
+        </p>
+      </div>
+
+    | TWO_FA_EXPIRED =>
+      <div
+        className="bg-white px-6 py-12 rounded-md border w-1/3 text-center font-semibold flex flex-col gap-4">
+        <p>
+          {"There have been multiple unsuccessful two-factor attempts for this account. Please wait a moment before trying again."->React.string}
+        </p>
+      </div>
     }
 
     <BackgroundImageWrapper>
       <div className="h-full w-full flex flex-col gap-4 items-center justify-center p-6 ">
-        <div
-          className="bg-white px-6 py-12 rounded-md border w-1/3 text-center font-semibold flex flex-col gap-4">
-          <p>
-            {"There have been multiple unsuccessful sign-in attempts for this account. Please wait a moment before trying again."->React.string}
-          </p>
-          {belowComponent}
-        </div>
+        {expiredComponent}
         <div className="text-grey-200 flex gap-2">
           {"Log in with a different account?"->React.string}
           <p
@@ -103,12 +117,8 @@ let make = () => {
     }
   }
 
-  let errorHandling = errorCode => {
-    if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_48 {
-      setTwoFaStatus(_ => TwoFaExpired(TOTP_ATTEMPTS_EXPIRED))
-    } else if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_49 {
-      setTwoFaStatus(_ => TwoFaExpired(RC_ATTEMPTS_EXPIRED))
-    }
+  let errorHandling = () => {
+    checkTwofaStatus()->ignore
   }
 
   React.useEffect(() => {

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
@@ -104,9 +104,9 @@ let make = () => {
   }
 
   let errorHandling = errorCode => {
-    if errorCode == "UR_48" {
+    if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_48 {
       setTwoFaStatus(_ => TwoFaExpired(TOTP_ATTEMPTS_EXPIRED))
-    } else if errorCode == "UR_49" {
+    } else if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_49 {
       setTwoFaStatus(_ => TwoFaExpired(RC_ATTEMPTS_EXPIRED))
     }
   }

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
@@ -52,8 +52,8 @@ let make = () => {
       />
     </div>
     {switch twofactorAuthType->HSwitchProfileUtils.getTwoFaEnumFromString {
-    | ResetTotp => <ResetTotp checkTwoFaStatusResponse />
-    | RegenerateRecoveryCode => <RegenerateRC checkTwoFaStatusResponse />
+    | ResetTotp => <ResetTotp checkTwoFaStatusResponse checkTwoFaStatus />
+    | RegenerateRecoveryCode => <RegenerateRC checkTwoFaStatusResponse checkTwoFaStatus />
     }}
   </PageLoaderWrapper>
 }

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
@@ -15,7 +15,6 @@ let make = () => {
 
   let checkTwoFaStatus = async () => {
     try {
-
       setScreenState(_ => PageLoaderWrapper.Loading)
       let url = getURL(
         ~entityName=USERS,

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/ModifyTwoFaSettings.res
@@ -1,7 +1,6 @@
 @react.component
 let make = () => {
   open APIUtils
-  open HSwitchProfileUtils
 
   let showToast = ToastState.useShowToast()
   let url = RescriptReactRouter.useUrl()
@@ -9,18 +8,22 @@ let make = () => {
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
 
-  let (checkStatusResponse, setCheckStatusResponse) = React.useState(_ =>
-    Dict.make()->typedValueForCheckStatus
+  let (checkTwoFaStatusResponse, setCheckTwoFaStatusResponse) = React.useState(_ =>
+    JSON.Encode.null->TwoFaUtils.jsonTocheckTwofaResponseType
   )
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
 
   let checkTwoFaStatus = async () => {
     try {
-      open LogicUtils
+
       setScreenState(_ => PageLoaderWrapper.Loading)
-      let url = getURL(~entityName=USERS, ~userType=#CHECK_TWO_FACTOR_AUTH_STATUS, ~methodType=Get)
-      let res = await fetchDetails(url)
-      setCheckStatusResponse(_ => res->getDictFromJsonObject->typedValueForCheckStatus)
+      let url = getURL(
+        ~entityName=USERS,
+        ~userType=#CHECK_TWO_FACTOR_AUTH_STATUS_V2,
+        ~methodType=Get,
+      )
+      let response = await fetchDetails(url)
+      setCheckTwoFaStatusResponse(_ => response->TwoFaUtils.jsonTocheckTwofaResponseType)
       setScreenState(_ => PageLoaderWrapper.Success)
     } catch {
     | _ => {
@@ -50,8 +53,8 @@ let make = () => {
       />
     </div>
     {switch twofactorAuthType->HSwitchProfileUtils.getTwoFaEnumFromString {
-    | ResetTotp => <ResetTotp checkStatusResponse />
-    | RegenerateRecoveryCode => <RegenerateRC checkStatusResponse />
+    | ResetTotp => <ResetTotp checkTwoFaStatusResponse />
+    | RegenerateRecoveryCode => <RegenerateRC checkTwoFaStatusResponse />
     }}
   </PageLoaderWrapper>
 }

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/RegenerateRC.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/RegenerateRC.res
@@ -1,9 +1,55 @@
-let h2TextStyle = HSwitchUtils.getTextClass((H2, Optional))
 let p2Regular = HSwitchUtils.getTextClass((P2, Regular))
-let p3Regular = HSwitchUtils.getTextClass((P3, Regular))
+let h2TextStyle = HSwitchUtils.getTextClass((H2, Optional))
 
+module TwoFaVerifyModal = {
+  @react.component
+  let make = (
+    ~showVerifyModal,
+    ~setShowVerifyModal,
+    ~errorMessage,
+    ~setErrorMessage,
+    ~otpInModal,
+    ~setOtpInModal,
+    ~buttonState,
+    ~verifyTOTP,
+    ~handleModalClose,
+  ) => {
+    <Modal
+      modalHeading="Verify OTP"
+      showModal=showVerifyModal
+      setShowModal=setShowVerifyModal
+      onCloseClickCustomFun={handleModalClose}
+      modalClass="w-fit m-auto">
+      <div className="flex flex-col gap-12">
+        <TwoFaHelper.Verify2FAModalComponent
+          twoFaState=Totp
+          setTwoFaState={_ => ()}
+          otp={otpInModal}
+          setOtp={setOtpInModal}
+          errorMessage
+          setErrorMessage
+          showOnlyTotp=true
+        />
+        <div className="flex flex-1 justify-end">
+          <Button
+            text={"Verify OTP"}
+            buttonType=Primary
+            buttonSize=Small
+            buttonState={otpInModal->String.length < 6 ? Disabled : buttonState}
+            onClick={_ => verifyTOTP()->ignore}
+            rightIcon={CustomIcon(
+              <Icon
+                name="thin-right-arrow" size=20 className="group-hover:scale-125 cursor-pointer"
+              />,
+            )}
+          />
+        </div>
+      </div>
+    </Modal>
+  }
+}
 @react.component
-let make = (~checkStatusResponse: HSwitchSettingTypes.checkStatusType) => {
+let make = (~checkTwoFaStatusResponse: TwoFaTypes.checkTwofaResponseType) => {
   open LogicUtils
   open APIUtils
 
@@ -17,6 +63,7 @@ let make = (~checkStatusResponse: HSwitchSettingTypes.checkStatusType) => {
   let (recoveryCodes, setRecoveryCodes) = React.useState(_ => [])
   let (errorMessage, setErrorMessage) = React.useState(_ => "")
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
+  let (twofaExpiredModal, setTwofaExpiredModal) = React.useState(_ => TwoFaTypes.TwoFaNotExpired)
 
   let generateRecoveryCodes = async () => {
     try {
@@ -57,6 +104,11 @@ let make = (~checkStatusResponse: HSwitchSettingTypes.checkStatusType) => {
     | Exn.Error(e) => {
         let err = Exn.message(e)->Option.getOr("Verification Failed")
         let errorMessage = err->safeParse->getDictFromJsonObject->getString("message", "")
+        let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
+        if errorCode->CommonAuthUtils.errorSubCodeMapper == UR_49 {
+          setTwofaExpiredModal(_ => TwoFaExpired(RC_ATTEMPTS_EXPIRED))
+          setShowVerifyModal(_ => true)
+        }
         setOtpInModal(_ => "")
         setErrorMessage(_ => errorMessage)
         setButtonState(_ => Button.Normal)
@@ -65,11 +117,18 @@ let make = (~checkStatusResponse: HSwitchSettingTypes.checkStatusType) => {
   }
 
   React.useEffect(() => {
-    if checkStatusResponse.totp {
-      generateRecoveryCodes()->ignore
-    } else {
-      setShowVerifyModal(_ => true)
+    switch checkTwoFaStatusResponse.status {
+    | Some(value) =>
+      if value.totp.attemptsRemaining == 0 {
+        setTwofaExpiredModal(_ => TwoFaExpired(TWO_FA_EXPIRED))
+      } else if value.totp.isCompleted {
+        generateRecoveryCodes()->ignore
+      } else {
+        setShowVerifyModal(_ => true)
+      }
+    | None => ()
     }
+
     None
   }, [])
 
@@ -103,40 +162,31 @@ let make = (~checkStatusResponse: HSwitchSettingTypes.checkStatusType) => {
     showToast(~message="Copied to Clipboard!", ~toastType=ToastSuccess)
   }
 
+  let handleConfirmAction = _ => {
+    handleModalClose()
+  }
+
   <PageLoaderWrapper screenState>
     <div>
-      <Modal
-        modalHeading="Verify OTP"
-        showModal=showVerifyModal
-        setShowModal=setShowVerifyModal
-        onCloseClickCustomFun={handleModalClose}
-        modalClass="w-fit m-auto">
-        <div className="flex flex-col gap-12">
-          <TwoFaHelper.Verify2FAModalComponent
-            twoFaState=Totp
-            setTwoFaState={_ => ()}
-            otp={otpInModal}
-            setOtp={setOtpInModal}
-            errorMessage
-            setErrorMessage
-            showOnlyTotp=true
-          />
-          <div className="flex flex-1 justify-end">
-            <Button
-              text={"Verify OTP"}
-              buttonType=Primary
-              buttonSize=Small
-              buttonState={otpInModal->String.length < 6 ? Disabled : buttonState}
-              onClick={_ => verifyTOTP()->ignore}
-              rightIcon={CustomIcon(
-                <Icon
-                  name="thin-right-arrow" size=20 className="group-hover:scale-125 cursor-pointer"
-                />,
-              )}
-            />
-          </div>
-        </div>
-      </Modal>
+      {switch twofaExpiredModal {
+      | TwoFaExpired(expiredType) =>
+        <TwoFaHelper.TwoFaWarningModal
+          expiredType handleConfirmAction handleOkAction={handleModalClose}
+        />
+
+      | TwoFaNotExpired =>
+        <TwoFaVerifyModal
+          showVerifyModal
+          setShowVerifyModal
+          errorMessage
+          setErrorMessage
+          otpInModal
+          setOtpInModal
+          buttonState
+          verifyTOTP
+          handleModalClose
+        />
+      }}
       <div className={`bg-white border h-40-rem w-133 rounded-2xl flex flex-col`}>
         <div className="p-6 border-b-2 flex justify-between items-center">
           <p className={`${h2TextStyle} text-grey-900`}>

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
@@ -57,3 +57,54 @@ module Verify2FAModalComponent = {
     </div>
   }
 }
+
+module TwoFaWarningModal = {
+  @react.component
+  let make = (~expiredType, ~handleConfirmAction, ~handleOkAction) => {
+    open TwoFaTypes
+    open PopUpState
+    let showPopUp = PopUpState.useShowPopUp()
+
+    {
+      switch expiredType {
+      | TOTP_ATTEMPTS_EXPIRED =>
+        showPopUp({
+          popUpType: (Warning, WithIcon),
+          heading: "Maximum Attempts Reached",
+          description: React.string(
+            "You have 0 OTP attempts remaining. To continue, please use your recovery code or wait sometime before trying again.",
+          ),
+          handleCancel: {text: "OK", onClick: {_ => handleOkAction()}},
+          handleConfirm: {
+            text: "Use recovery code",
+            onClick: {_ => handleConfirmAction(expiredType)},
+          },
+        })
+      | RC_ATTEMPTS_EXPIRED =>
+        showPopUp({
+          popUpType: (Warning, WithIcon),
+          heading: "Maximum Attempts Reached",
+          description: React.string(
+            "You've reached the maximum number of attempts using your recovery code. To continue, please use your totp or wait sometime before trying again.",
+          ),
+          handleCancel: {text: "OK", onClick: {_ => handleOkAction()}},
+          handleConfirm: {text: "Use totp code", onClick: {_ => handleConfirmAction(expiredType)}},
+        })
+      | TWO_FA_EXPIRED =>
+        showPopUp({
+          popUpType: (Warning, WithIcon),
+          heading: "Maximum Attempts Reached",
+          description: React.string(
+            "You have reached the maximum limit for both TOTP and recovery code attempts. Please wait sometime before attempting to perform this action again",
+          ),
+          handleConfirm: {
+            text: "OK",
+            onClick: {_ => handleConfirmAction(expiredType)},
+          },
+        })
+      }
+    }
+
+    React.null
+  }
+}

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
@@ -12,6 +12,7 @@ module Verify2FAModalComponent = {
     ~recoveryCode="",
     ~setRecoveryCode=_ => (),
     ~showOnlyTotp=false,
+    ~showOnlyRc=false,
   ) => {
     open HSwitchSettingTypes
     let handleOnClick = (~stateToSet) => {
@@ -41,14 +42,16 @@ module Verify2FAModalComponent = {
       | RecoveryCode =>
         <>
           <TwoFaElements.RecoveryCodesInput recoveryCode setRecoveryCode />
-          <p className={`${p2Regular} text-jp-gray-700`}>
-            {"Didn't get a code? "->React.string}
-            <span
-              className="cursor-pointer underline underline-offset-2 text-blue-600"
-              onClick={_ => handleOnClick(~stateToSet=Totp)}>
-              {"Use totp instead"->React.string}
-            </span>
-          </p>
+          <RenderIf condition={!showOnlyRc}>
+            <p className={`${p2Regular} text-jp-gray-700`}>
+              {"Didn't get a code? "->React.string}
+              <span
+                className="cursor-pointer underline underline-offset-2 text-blue-600"
+                onClick={_ => handleOnClick(~stateToSet=Totp)}>
+                {"Use totp instead"->React.string}
+              </span>
+            </p>
+          </RenderIf>
         </>
       }}
       <RenderIf condition={errorMessage->LogicUtils.isNonEmptyString}>
@@ -79,6 +82,7 @@ module TwoFaWarningModal = {
             text: "Use recovery code",
             onClick: {_ => handleConfirmAction(expiredType)},
           },
+          showCloseIcon: false,
         })
       | RC_ATTEMPTS_EXPIRED =>
         showPopUp({
@@ -89,6 +93,7 @@ module TwoFaWarningModal = {
           ),
           handleCancel: {text: "OK", onClick: {_ => handleOkAction()}},
           handleConfirm: {text: "Use totp code", onClick: {_ => handleConfirmAction(expiredType)}},
+          showCloseIcon: false,
         })
       | TWO_FA_EXPIRED =>
         showPopUp({
@@ -101,6 +106,7 @@ module TwoFaWarningModal = {
             text: "OK",
             onClick: {_ => handleConfirmAction(expiredType)},
           },
+          showCloseIcon: false,
         })
       }
     }

--- a/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
+++ b/src/screens/Settings/HSwitchProfile/TwoFaSettings/TwoFaHelper.res
@@ -72,7 +72,7 @@ module TwoFaWarningModal = {
           popUpType: (Warning, WithIcon),
           heading: "Maximum Attempts Reached",
           description: React.string(
-            "You have 0 OTP attempts remaining. To continue, please use your recovery code or wait sometime before trying again.",
+            "You've reached the maximum number of TOTP attempts. To continue, please use your recovery code or wait sometime before trying again.",
           ),
           handleCancel: {text: "OK", onClick: {_ => handleOkAction()}},
           handleConfirm: {
@@ -85,7 +85,7 @@ module TwoFaWarningModal = {
           popUpType: (Warning, WithIcon),
           heading: "Maximum Attempts Reached",
           description: React.string(
-            "You've reached the maximum number of attempts using your recovery code. To continue, please use your totp or wait sometime before trying again.",
+            "You've reached the maximum number of recovery code attempts. To continue, please use your TOTP or wait a while before trying again.",
           ),
           handleCancel: {text: "OK", onClick: {_ => handleOkAction()}},
           handleConfirm: {text: "Use totp code", onClick: {_ => handleConfirmAction(expiredType)}},
@@ -95,7 +95,7 @@ module TwoFaWarningModal = {
           popUpType: (Warning, WithIcon),
           heading: "Maximum Attempts Reached",
           description: React.string(
-            "You have reached the maximum limit for both TOTP and recovery code attempts. Please wait sometime before attempting to perform this action again",
+            "You have exceeded the maximum number of TOTP and recovery code attempts. Please wait a while before trying again.",
           ),
           handleConfirm: {
             text: "OK",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
The maximum number of incorrect attempts allowed after logging in has been introduced. Previously, there was no limit, but now after exceeding the limit, there will be a cool-down period of 5 minutes for TOTP and 10 minutes for recovery codes. This will come when user tries to change its totp or regenerate-recovery code 

Max attempts reached for totp :
<img width="528" alt="image" src="https://github.com/user-attachments/assets/8f1495da-b436-4236-abed-4a7d022efecc">

Max attempts reached for recovery code :
<img width="528" alt="image" src="https://github.com/user-attachments/assets/acaa5f0f-2b40-4479-ac52-15633f3370a6">

If both recovery code and totp is reached :
<img width="528" alt="image" src="https://github.com/user-attachments/assets/42eca082-f9ac-46ab-b9ba-3d6496707c7f">


## Motivation and Context

- Setup totp for a user 
- Go to profile section and change totp 
- In the verify modal , try wrong totp for 4 times after 5th time the above max attempts reached for totp modal should appear 

- Max attempts reached for recovery-code should give the above max attempts reached for recovery code modal should appear

- Same should happen for regenerate recovery code 

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
