### PR TITLE
fix: changes to enable card-network

### DIFF
--- a/src/screens/Order/OrderUIUtils.res
+++ b/src/screens/Order/OrderUIUtils.res
@@ -274,11 +274,7 @@ let initialFilters = (json, filtervalues) => {
 
   let connectorFilter = filtervalues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
 
-  // TODO: Remove the card-network delete once card-network issue is fixed
-  let filterDict =
-    json
-    ->getDictFromJsonObject
-    ->DictionaryUtils.deleteKeys(["card_network"])
+  let filterDict = json->getDictFromJsonObject
 
   let filterArr = filterDict->itemToObjMapper
   let arr = filterDict->Dict.keysToArray


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Card-network was disabled from FE . This will enable the card-network filter from FE

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
card-network should be visible in FE in filters 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
