### PR TITLE
chore: disable cookies from frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## 2024.10.25.0
+
+### Bug Fixes
+
+- Auto retry bug ([#1639](https://github.com/juspay/hyperswitch-control-center/pull/1639)) ([`46f4de6`](https://github.com/juspay/hyperswitch-control-center/commit/46f4de64f0c68e587a62c876b56e94a5e25ec26d))
+- Merchant account credentials not shown in profile view ([#1626](https://github.com/juspay/hyperswitch-control-center/pull/1626)) ([`9108801`](https://github.com/juspay/hyperswitch-control-center/commit/9108801555d2e3e03908dbe33f4a52ce9c0503a3))
+
+### Miscellaneous Tasks
+
+- TwoFa restriction after multiple failed attempts before login ([#1594](https://github.com/juspay/hyperswitch-control-center/pull/1594)) ([`9ff488b`](https://github.com/juspay/hyperswitch-control-center/commit/9ff488b8edc99af45fc8f77ab1f56e6cef34a838))
+- Add merchant specific config ([#1643](https://github.com/juspay/hyperswitch-control-center/pull/1643)) ([`aac4ada`](https://github.com/juspay/hyperswitch-control-center/commit/aac4adabf17e96ef7d02fe91048fca8b668030a8))
+
+**Full Changelog:** [`2024.10.24.0...2024.10.25.0`](https://github.com/juspay/hyperswitch-control-center/compare/2024.10.24.0...2024.10.25.0)
+
+- - -
+
 ## 2024.10.24.0
 
 ### Testing

--- a/src/hooks/AuthHooks.res
+++ b/src/hooks/AuthHooks.res
@@ -98,7 +98,7 @@ let useApiFetcher = () => {
           Fetch.RequestInit.make(
             ~method_,
             ~body?,
-            ~credentials=Omit,
+            ~credentials=Omit, // change to SameOrigin (enable cookies) after backend fixes are done for cookies
             ~headers=getHeaders(~headers, ~uri, ~contentType, ~token, ~xFeatureRoute),
           ),
         )

--- a/src/hooks/AuthHooks.res
+++ b/src/hooks/AuthHooks.res
@@ -98,7 +98,7 @@ let useApiFetcher = () => {
           Fetch.RequestInit.make(
             ~method_,
             ~body?,
-            ~credentials=SameOrigin,
+            ~credentials=Omit,
             ~headers=getHeaders(~headers, ~uri, ~contentType, ~token, ~xFeatureRoute),
           ),
         )

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,7 +8,13 @@ const appName = process.env.appName;
 const integ = process.env.integ;
 
 let port = 9000;
-let proxy = {};
+let proxy = {
+  "/api": {
+    target: "http://localhost:8080",
+    pathRewrite: { "^/api": "" },
+    changeOrigin: true,
+  },
+};
 
 let configMiddleware = (req, res, next) => {
   if (req.path.includes("/config/feature") && req.method == "GET") {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,6 +8,7 @@ const appName = process.env.appName;
 const integ = process.env.integ;
 
 let port = 9000;
+// proxy is setup to make frontend and backend url same for local testing
 let proxy = {
   "/api": {
     target: "http://localhost:8080",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR disabled cookies from frontend for the upcoming changes regarding making frontend and backend url same
Additionally, it sets proxy in webpack.dev.js to test the above thing in local

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Sign in to dashboard
Check in Application Storage under cookies 
Cookies will not be set after this change

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
