### PR TITLE
chore: pop-up modal extra prop addition

### DIFF
--- a/src/components/PopUpContainer.res
+++ b/src/components/PopUpContainer.res
@@ -45,10 +45,12 @@ let make = (~children) => {
 
       let (buttonText, confirmButtonIcon) = (popUp.handleConfirm.text, popUp.handleConfirm.icon)
 
-      let (cancelButtonText, showCloseIcon, cancelButtonIcon) = switch popUp.handleCancel {
-      | Some(obj) => (Some(obj.text), Some(true), obj.icon)
-      | None => (None, None, None)
+      let (cancelButtonText, cancelButtonIcon) = switch popUp.handleCancel {
+      | Some(obj) => (Some(obj.text), obj.icon)
+      | None => (None, None)
       }
+
+      let showCloseIcon = popUp.showCloseIcon
 
       let (popUpTypeActual, showIcon) = popUpType
       let showIcon = switch showIcon {

--- a/src/hooks/PopUpState.res
+++ b/src/hooks/PopUpState.res
@@ -15,6 +15,7 @@ type popUpProps = {
   handleCancel?: popupAction,
   handleConfirm: popupAction,
   popUpSize?: popUpSize,
+  showCloseIcon?: bool,
 }
 
 let defaultOpenPopUp: array<popUpProps> = []


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
New prop addition to remove close icon in pop-ups 

example : 
With `showCloseIcon = true` and `without passing showCloseIcon`
<img width="496" alt="image" src="https://github.com/user-attachments/assets/6d0ca862-060c-461a-a5d2-925f2a501e23">

with `showCloseIcon=false`
<img width="496" alt="image" src="https://github.com/user-attachments/assets/e4d0e361-67c0-4c51-b45c-0784a8d20893">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
cannot be tested as it is a chore change . 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
