### PR TITLE
fix: remove dispute stage col

### DIFF
--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
@@ -4,7 +4,6 @@ type disputesObject = {
   dispute_id: string,
   dispute_amount: float,
   currency: string,
-  dispute_stage: string,
   dispute_status: string,
   payment_id: string,
   attempt_id: string,
@@ -30,7 +29,6 @@ type cols =
   | DisputeId
   | DisputeAmount
   | Currency
-  | DisputeStage
   | DisputeStatus
   | PaymentId
   | AttemptId
@@ -58,7 +56,6 @@ let colMapper = (col: cols) => {
   | DisputeId => "dispute_id"
   | DisputeAmount => "dispute_amount"
   | Currency => "currency"
-  | DisputeStage => "dispute_stage"
   | DisputeStatus => "dispute_status"
   | PaymentId => "payment_id"
   | AttemptId => "attempt_id"
@@ -87,7 +84,6 @@ let tableItemToObjMapper: Dict.t<JSON.t> => disputesObject = dict => {
     dispute_id: dict->getString(DisputeId->colMapper, "NA"),
     dispute_amount: dict->getFloat(DisputeAmount->colMapper, 0.0),
     currency: dict->getString(Currency->colMapper, "NA"),
-    dispute_stage: dict->getString(DisputeStage->colMapper, "NA"),
     dispute_status: dict->getString(DisputeStatus->colMapper, "NA"),
     payment_id: dict->getString(PaymentId->colMapper, "NA"),
     attempt_id: dict->getString(AttemptId->colMapper, "NA"),
@@ -125,7 +121,6 @@ let getHeading = colType => {
   | DisputeId => Table.makeHeaderInfo(~key, ~title="Dispute Id", ~dataType=TextType)
   | DisputeAmount => Table.makeHeaderInfo(~key, ~title="Dispute Amount", ~dataType=TextType)
   | Currency => Table.makeHeaderInfo(~key, ~title="Currency", ~dataType=TextType)
-  | DisputeStage => Table.makeHeaderInfo(~key, ~title="Dispute Stage", ~dataType=TextType)
   | DisputeStatus => Table.makeHeaderInfo(~key, ~title="Dispute Status", ~dataType=TextType)
   | PaymentId => Table.makeHeaderInfo(~key, ~title="Payment Id", ~dataType=TextType)
   | AttemptId => Table.makeHeaderInfo(~key, ~title="Attempt Id", ~dataType=TextType)
@@ -167,7 +162,6 @@ let getCell = (disputeObj, colType): Table.cell => {
       "",
     )
   | Currency => Text(disputeObj.currency)
-  | DisputeStage => Text(disputeObj.dispute_stage)
   | DisputeStatus =>
     Label({
       title: disputeObj.dispute_status->String.toUpperCase,

--- a/src/screens/Disputes/DisputeTypes.res
+++ b/src/screens/Disputes/DisputeTypes.res
@@ -5,7 +5,6 @@ type disputes = {
   attempt_id: string,
   amount: string,
   currency: string,
-  dispute_stage: string,
   dispute_status: string,
   connector: string,
   connector_status: string,
@@ -24,7 +23,6 @@ type disputesColsType =
   | AttemptId
   | Amount
   | Currency
-  | DisputeStage
   | DisputeStatus
   | Connector
   | ConnectorStatus
@@ -46,7 +44,6 @@ type disputeStatus =
   | DisputeLost
   | NotFound(string)
 
-type disputeStage = PreDispute | Dispute | PreArbitration | NotFound
 type disputeStatusType = Landing | EvidencePresent
 type filterTypes = {
   connector: array<string>,

--- a/src/screens/Disputes/DisputesEntity.res
+++ b/src/screens/Disputes/DisputesEntity.res
@@ -1,8 +1,8 @@
 open LogicUtils
 open DisputeTypes
 
-let defaultColumns = [DisputeId, Amount, DisputeStage, DisputeStatus, PaymentId, CreatedAt]
-let columnsInPaymentPage = [DisputeId, DisputeStage, ConnectorReason, DisputeStatus, CreatedAt]
+let defaultColumns = [DisputeId, Amount, DisputeStatus, PaymentId, CreatedAt]
+let columnsInPaymentPage = [DisputeId, ConnectorReason, DisputeStatus, CreatedAt]
 
 let allColumns = [
   Amount,
@@ -18,7 +18,6 @@ let allColumns = [
   CreatedAt,
   Currency,
   DisputeId,
-  DisputeStage,
   DisputeStatus,
   PaymentId,
 ]
@@ -59,8 +58,6 @@ let getHeading = colType => {
   | AttemptId => Table.makeHeaderInfo(~key="attempt_id", ~title="Attempt Id")
   | Amount => Table.makeHeaderInfo(~key="amount", ~title="Amount")
   | Currency => Table.makeHeaderInfo(~key="currency", ~title="Currency")
-  | DisputeStage =>
-    Table.makeHeaderInfo(~key="dispute_stage", ~title="Dispute Stage", ~dataType=DropDown)
   | DisputeStatus =>
     Table.makeHeaderInfo(~key="dispute_status", ~title="Dispute Status", ~dataType=DropDown)
   | Connector => Table.makeHeaderInfo(~key="connector", ~title="Connector")
@@ -101,16 +98,6 @@ let getCell = (disputesData, colType): Table.cell => {
   | AttemptId => DisplayCopyCell(disputesData.attempt_id)
   | Amount => Text(amountValue(disputesData.amount, disputesData.currency))
   | Currency => Text(disputesData.currency)
-  | DisputeStage =>
-    Label({
-      title: disputesData.dispute_stage->String.toUpperCase,
-      color: switch disputesData.dispute_stage->disputeStageVariantMapper {
-      | PreDispute => LabelOrange
-      | Dispute => LabelGreen
-      | PreArbitration => LabelYellow
-      | _ => LabelWhite
-      },
-    })
   | DisputeStatus =>
     Label({
       title: disputesData.dispute_status->String.toUpperCase,
@@ -145,7 +132,6 @@ let itemToObjMapper = dict => {
     attempt_id: dict->getString("attempt_id", ""),
     amount: dict->getString("amount", ""),
     currency: dict->getString("currency", ""),
-    dispute_stage: dict->getString("dispute_stage", ""),
     dispute_status: dict->getString("dispute_status", ""),
     connector: dict->getString("connector", ""),
     connector_status: dict->getString("connector_status", ""),

--- a/src/screens/Disputes/DisputesUtils.res
+++ b/src/screens/Disputes/DisputesUtils.res
@@ -1,14 +1,5 @@
 open DisputeTypes
 open LogicUtils
-let disputeStageVariantMapper = stage => {
-  switch stage {
-  | "pre_dispute" => PreDispute
-  | "dispute" => Dispute
-  | "pre-arbitration" => PreArbitration
-  | _ => NotFound
-  }
-}
-
 let disputeStatusVariantMapper = status => {
   switch status {
   | "dispute_opened" => DisputeOpened


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removing dispute stage as dispute status is sufficient to indicate the status.

<img width="1486" alt="Screenshot 2024-10-30 at 11 28 50 AM" src="https://github.com/user-attachments/assets/6d2f2a80-cbaa-466d-a50d-50bd718429f4">


## Motivation and Context

Dispute stage not needed

## How did you test it?

checked it in the dispute view table.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
