### PR TITLE
feat: frontend invite limit

### DIFF
--- a/src/screens/UserManagement/UserRevamp/UserUtils.res
+++ b/src/screens/UserManagement/UserRevamp/UserUtils.res
@@ -46,6 +46,9 @@ let validateForm = (values, ~fieldsToValidate: array<string>) => {
             errors->Dict.set("email", "Please enter a valid email"->JSON.Encode.string)
           }
         })
+        if listofemails->Array.length > 10 {
+          errors->Dict.set("Invite limit exceeded", "Max 10 at a time."->JSON.Encode.string)
+        }
         ()
       }
     | String(roleType) =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Addition of max limit of 10 invites at a time in frontend.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
