### PR TITLE
feat: analytics payment processed currency conversion

### DIFF
--- a/src/screens/NewAnalytics/Graphs/LineGraph/LineGraphTypes.res
+++ b/src/screens/NewAnalytics/Graphs/LineGraph/LineGraphTypes.res
@@ -54,7 +54,7 @@ type chart = {
 type dataObj = {
   showInLegend: showInLegend,
   name: name,
-  data: array<int>,
+  data: array<float>,
   color: color,
 }
 

--- a/src/screens/NewAnalytics/PaymentAnalytics/NewPaymentAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/NewPaymentAnalyticsUtils.res
@@ -21,14 +21,27 @@ let getColor = index => {
   ["#1059C1B2", "#0EB025B2"]->Array.get(index)->Option.getOr("#1059C1B2")
 }
 
+let getAmountValue = (data, ~id) => {
+  switch data->getOptionFloat(id) {
+  | Some(value) => value /. 100.0
+  | _ => 0.0
+  }
+}
+
 let getLineGraphObj = (
   ~array: array<JSON.t>,
   ~key: string,
   ~name: string,
   ~color,
+  ~isAmount=false,
 ): LineGraphTypes.dataObj => {
   let data = array->Array.map(item => {
-    item->getDictFromJsonObject->getInt(key, 0)
+    let dict = item->getDictFromJsonObject
+    if isAmount {
+      dict->getAmountValue(~id=key)
+    } else {
+      dict->getFloat(key, 0.0)
+    }
   })
   let dataObj: LineGraphTypes.dataObj = {
     showInLegend: true,

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionTypes.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionTypes.res
@@ -9,13 +9,13 @@ type overviewColumns =
   | Total_Dispute
 
 type dataObj = {
-  total_smart_retried_amount: float,
-  total_smart_retried_amount_without_smart_retries: float,
+  total_smart_retried_amount_usd: float,
+  total_smart_retried_amount_without_smart_retries_usd: float,
   total_success_rate: float,
   total_success_rate_without_smart_retries: float,
-  total_payment_processed_amount: float,
+  total_payment_processed_amount_usd: float,
   total_payment_processed_count: int,
-  total_payment_processed_amount_without_smart_retries: float,
+  total_payment_processed_amount_without_smart_retries_usd: float,
   total_payment_processed_count_without_smart_retries: int,
   refund_processed_amount: float,
   total_dispute: int,

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
@@ -2,12 +2,12 @@ open NewPaymentsOverviewSectionTypes
 
 let getStringFromVariant = value => {
   switch value {
-  | Total_Smart_Retried_Amount => "total_smart_retried_amount"
-  | Total_Smart_Retried_Amount_Without_Smart_Retries => "total_smart_retried_amount_without_smart_retries"
+  | Total_Smart_Retried_Amount => "total_smart_retried_amount_usd"
+  | Total_Smart_Retried_Amount_Without_Smart_Retries => "total_smart_retried_amount_without_smart_retries_usd"
   | Total_Success_Rate => "total_success_rate"
   | Total_Success_Rate_Without_Smart_Retries => "total_success_rate_without_smart_retries"
-  | Total_Payment_Processed_Amount => "total_payment_processed_amount"
-  | Total_Payment_Processed_Amount_Without_Smart_Retries => "total_payment_processed_amount_without_smart_retries"
+  | Total_Payment_Processed_Amount => "total_payment_processed_amount_usd"
+  | Total_Payment_Processed_Amount_Without_Smart_Retries => "total_payment_processed_amount_without_smart_retries_usd"
   | Refund_Processed_Amount => "refund_processed_amount"
   | Total_Dispute => "total_dispute"
   }
@@ -15,13 +15,13 @@ let getStringFromVariant = value => {
 
 let defaultValue =
   {
-    total_smart_retried_amount: 0.0,
-    total_smart_retried_amount_without_smart_retries: 0.0,
+    total_smart_retried_amount_usd: 0.0,
+    total_smart_retried_amount_without_smart_retries_usd: 0.0,
     total_success_rate: 0.0,
     total_success_rate_without_smart_retries: 0.0,
-    total_payment_processed_amount: 0.0,
+    total_payment_processed_amount_usd: 0.0,
     total_payment_processed_count: 0,
-    total_payment_processed_amount_without_smart_retries: 0.0,
+    total_payment_processed_amount_without_smart_retries_usd: 0.0,
     total_payment_processed_count_without_smart_retries: 0,
     refund_processed_amount: 0.0,
     total_dispute: 0,
@@ -54,15 +54,24 @@ let parseResponse = (response, key) => {
 
 open NewAnalyticsTypes
 let setValue = (dict, ~data, ~ids: array<overviewColumns>) => {
+  open NewPaymentAnalyticsUtils
   open LogicUtils
 
   ids->Array.forEach(id => {
-    dict->Dict.set(
-      id->getStringFromVariant,
+    let key = id->getStringFromVariant
+    let value = switch id {
+    | Total_Smart_Retried_Amount
+    | Total_Smart_Retried_Amount_Without_Smart_Retries
+    | Total_Payment_Processed_Amount
+    | Total_Payment_Processed_Amount_Without_Smart_Retries =>
+      data->getAmountValue(~id=id->getStringFromVariant)->JSON.Encode.float
+    | _ =>
       data
       ->getFloat(id->getStringFromVariant, 0.0)
-      ->JSON.Encode.float,
-    )
+      ->JSON.Encode.float
+    }
+
+    dict->Dict.set(key, value)
   })
 }
 

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
@@ -87,6 +87,14 @@ module PaymentsProcessedHeader = {
       ~key=selectedMetric.value->getMetaDataMapper(~isSmartRetryEnabled),
     )
 
+    let (primaryValue, secondaryValue) = if (
+      selectedMetric.value->getMetaDataMapper(~isSmartRetryEnabled)->isAmountMetric
+    ) {
+      (primaryValue /. 100.0, secondaryValue /. 100.0)
+    } else {
+      (primaryValue, secondaryValue)
+    }
+
     let (value, direction) = calculatePercentageChange(~primaryValue, ~secondaryValue)
 
     let setViewType = value => {

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedTypes.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedTypes.res
@@ -10,13 +10,13 @@ type paymentsProcessedCols =
   | Time_Bucket
 
 type paymentsProcessedObject = {
-  payment_processed_amount: float,
+  payment_processed_amount_usd: float,
   payment_processed_count: int,
-  payment_processed_amount_without_smart_retries: float,
+  payment_processed_amount_without_smart_retries_usd: float,
   payment_processed_count_without_smart_retries: int,
-  total_payment_processed_amount: float,
+  total_payment_processed_amount_usd: float,
   total_payment_processed_count: int,
-  total_payment_processed_amount_without_smart_retries: float,
+  total_payment_processed_amount_without_smart_retries_usd: float,
   total_payment_processed_count_without_smart_retries: int,
   time_bucket: string,
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
diaplying the analytics amount metrics in USD in FE

primary changes will be picking the `_usd` key in the place of normal amount key 
eg `total_smart_retried_amount` -> `total_smart_retried_amount_usd` etc

<img width="345" alt="Screenshot 2024-11-06 at 8 26 20 PM" src="https://github.com/user-attachments/assets/1d4a6ece-b1d1-4fc1-9fe8-2b96441b04f2">
<img width="973" alt="Screenshot 2024-11-06 at 8 26 26 PM" src="https://github.com/user-attachments/assets/5c24d67d-19f2-41a1-9c4b-d0df9004d42c">


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the amount values which is displayed in FE will be in USD for overview `total payments` and `payment processe` module when amount is selected 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
