### PR TITLE
fix: compare filter date display fix to ISO format

### DIFF
--- a/src/components/DateRangeCompareFields.res
+++ b/src/components/DateRangeCompareFields.res
@@ -562,7 +562,7 @@ module Base = {
           setCalendarVisibility(_ => false)
           setIsDropdownExpanded(_ => false)
           setIsCustomSelected(_ => false)
-          let (startDate, endDate) = getComparisionTimePeriod(~startDate, ~endDate)
+
           let stDate = getFormattedDate(startDate, "YYYY-MM-DD")
           let edDate = getFormattedDate(endDate, "YYYY-MM-DD")
           let stTime = getFormattedDate(startDate, "HH:MM:00")

--- a/src/components/DateRangeHelper.res
+++ b/src/components/DateRangeHelper.res
@@ -3,16 +3,25 @@ open DateRangeUtils
 module CompareOption = {
   @react.component
   let make = (~value: compareOption, ~comparison, ~startDateVal, ~endDateVal, ~onClick) => {
+    let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
+
     let previousPeriod = React.useMemo(() => {
-      let (startDate, endDate) = getComparisionTimePeriod(
-        ~startDate=startDateVal,
-        ~endDate=endDateVal,
+      let startDateStr = formatDateString(
+        ~dateVal=startDateVal,
+        ~buttonText="",
+        ~defaultLabel=startDateVal,
+        ~isoStringToCustomTimeZone,
       )
-      let format = "MMM DD, YYYY"
-      let startDateStr = getFormattedDate(startDate, format)
-      let endDateStr = getFormattedDate(endDate, format)
+      let endDateStr = formatDateString(
+        ~dateVal=endDateVal,
+        ~buttonText="",
+        ~defaultLabel=endDateVal,
+        ~isoStringToCustomTimeZone,
+      )
+
       `${startDateStr} - ${endDateStr}`
     }, [comparison])
+
     <div
       onClick={_ => onClick(value)}
       className={`text-center md:text-start min-w-max bg-white w-full   hover:bg-jp-gray-100 hover:bg-opacity-75 cursor-pointer mx-2 rounded-md p-2 text-sm font-medium text-grey-900 `}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
display comparision values in the ISO format in the button text 
<img width="543" alt="Screenshot 2024-11-06 at 10 14 04 PM" src="https://github.com/user-attachments/assets/1c9c3645-3805-4273-b8a7-e61ed8da9146">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the comparision date should be ISO format but should send to BE in the UTC format 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
