### PR TITLE
feat: sanky flow chart change

### DIFF
--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycle.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycle.res
@@ -51,8 +51,15 @@ let make = (
       //   "confirmation_awaited": 0,
       // }->Identity.genericTypeToJson
       let paymentLifeCycleResponse = await updateDetails(url, paymentLifeCycleBody, Post)
-      setData(_ => paymentLifeCycleResponse->PaymentsLifeCycleUtils.paymentLifeCycleResponseMapper)
-      setScreenState(_ => PageLoaderWrapper.Success)
+
+      if paymentLifeCycleResponse->PaymentsLifeCycleUtils.getTotalPayments > 0 {
+        setData(_ =>
+          paymentLifeCycleResponse->PaymentsLifeCycleUtils.paymentLifeCycleResponseMapper
+        )
+        setScreenState(_ => PageLoaderWrapper.Success)
+      } else {
+        setScreenState(_ => PageLoaderWrapper.Custom)
+      }
     } catch {
     | _ => setScreenState(_ => PageLoaderWrapper.Custom)
     }

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
@@ -3,69 +3,88 @@ open LogicUtils
 open PaymentsLifeCycleTypes
 let paymentLifeCycleResponseMapper = (json: JSON.t) => {
   let valueDict = json->getDictFromJsonObject
-  // response need to be changed to snake_case
-  // {
-  //   normalSuccess: valueDict->getInt("normal_success", 0),
-  //   normalFailure: valueDict->getInt("normal_failure", 0),
-  //   cancelled: valueDict->getInt("cancelled", 0),
-  //   smartRetriedSuccess: valueDict->getInt("smart_retried_success", 0),
-  //   smartRetriedFailure: valueDict->getInt("smart_retried_failure", 0),
-  //   pending: valueDict->getInt("pending", 0),
-  //   partialRefunded: valueDict->getInt("partial_refunded", 0),
-  //   refunded: valueDict->getInt("refunded", 0),
-  //   disputed: valueDict->getInt("disputed", 0),
-  //   pmAwaited: valueDict->getInt("pm_awaited", 0),
-  //   customerAwaited: valueDict->getInt("customer_awaited", 0),
-  //   merchantAwaited: valueDict->getInt("merchant_awaited", 0),
-  //   confirmationAwaited: valueDict->getInt("confirmation_awaited", 0),
-  // }
+
   {
-    normalSuccess: 15,
-    normalFailure: 10,
-    cancelled: 5,
-    smartRetriedSuccess: 5,
-    smartRetriedFailure: 5,
-    pending: 5,
-    partialRefunded: 5,
-    refunded: 5,
-    disputed: 5,
-    pmAwaited: 5,
-    customerAwaited: 5,
-    merchantAwaited: 5,
-    confirmationAwaited: 5,
+    normalSuccess: valueDict->getInt("normal_success", 0),
+    normalFailure: valueDict->getInt("normal_failure", 0),
+    cancelled: valueDict->getInt("cancelled", 0),
+    smartRetriedSuccess: valueDict->getInt("smart_retried_success", 0),
+    smartRetriedFailure: valueDict->getInt("smart_retried_failure", 0),
+    pending: valueDict->getInt("pending", 0),
+    partialRefunded: valueDict->getInt("partial_refunded", 0),
+    refunded: valueDict->getInt("refunded", 0),
+    disputed: valueDict->getInt("disputed", 0),
+    pmAwaited: valueDict->getInt("pm_awaited", 0),
+    customerAwaited: valueDict->getInt("customer_awaited", 0),
+    merchantAwaited: valueDict->getInt("merchant_awaited", 0),
+    confirmationAwaited: valueDict->getInt("confirmation_awaited", 0),
   }
+}
+
+let getTotalPayments = json => {
+  let data = json->paymentLifeCycleResponseMapper
+
+  let total =
+    data.normalSuccess +
+    data.normalFailure +
+    data.cancelled +
+    data.smartRetriedSuccess +
+    data.smartRetriedFailure +
+    data.pending +
+    data.partialRefunded +
+    data.refunded +
+    data.disputed +
+    data.pmAwaited +
+    data.customerAwaited +
+    data.merchantAwaited +
+    data.confirmationAwaited
+
+  total
 }
 
 let paymentsLifeCycleMapper = (
   ~params: NewAnalyticsTypes.getObjects<paymentLifeCycle>,
 ): SankeyGraphTypes.sankeyPayload => {
   let {data, xKey} = params
-  let isSmartRetryEnabled =
-    xKey->getBoolFromString(true)->NewPaymentAnalyticsUtils.getSmartRetryMetricType
-  let success =
-    data.normalSuccess + (isSmartRetryEnabled === Smart_Retry ? data.smartRetriedSuccess : 0)
-  let failure =
-    data.normalFailure + (isSmartRetryEnabled === Smart_Retry ? data.smartRetriedFailure : 0)
-  let refunded = data.refunded
-  let pending = data.pending // Attempted Pending
-  let cancelled = data.cancelled
-  let customerAwaited = data.customerAwaited // DropOff2
-  let attemptedPayments = pending + customerAwaited + success + failure
-  let pmAwaited = data.pmAwaited // Dropoff1
-  let _totalPayment = pmAwaited + attemptedPayments + cancelled
+
+  let isSmartRetryEnabled = xKey->getBoolFromString(true)
 
   let disputed = data.disputed
+  let refunded = data.refunded
+  let partialRefunded = data.partialRefunded
+
+  let success = disputed + refunded + partialRefunded
+
+  let normalSuccess = data.normalSuccess
+  let failure = data.normalFailure
+
+  let pending = data.pending
+  let cancelled = data.cancelled
+
+  let dropoff =
+    data.pmAwaited + data.customerAwaited + data.merchantAwaited + data.confirmationAwaited
 
   let processedData = [
-    ("Payments Initiated", "Success", success, "#E4EFFF"),
+    ("Payments Initiated", "Normal Success", normalSuccess, "#E4EFFF"),
     ("Payments Initiated", "Failed", failure, "#F7E0E0"),
-    ("Payments Initiated", "Pending", failure, "#F7E0E0"),
-    ("Payments Initiated", "Cancelled", customerAwaited, "#E4EFFF"),
-    ("Payments Initiated", "Drop-offs", 20, "#F7E0E0"),
+    ("Payments Initiated", "Pending", pending, "#E4EFFF"),
+    ("Payments Initiated", "Cancelled", cancelled, "#F7E0E0"),
+    ("Payments Initiated", "Drop-offs", dropoff, "#F7E0E0"),
+    ("Normal Success", "Success", success, "#E4EFFF"),
     ("Success", "Dispute Raised", disputed, "#F7E0E0"),
     ("Success", "Refunds Issued", refunded, "#E4EFFF"),
-    ("Success", "Partial Refunded", refunded, "#E4EFFF"),
+    ("Success", "Partial Refunded", partialRefunded, "#E4EFFF"),
   ]
+
+  let processedData = if isSmartRetryEnabled {
+    processedData->Array.concat([
+      ("Failed", "Success", data.smartRetriedSuccess, "#E4EFFF"),
+      ("Failed", "Smart Retrie dFailure", data.smartRetriedFailure, "#F7E0E0"),
+    ])
+  } else {
+    processedData
+  }
+
   let sankeyNodes = [
     {
       id: "Payments Initiated",
@@ -103,7 +122,14 @@ let paymentsLifeCycleMapper = (
       },
     },
     {
-      id: "Non-terminal state",
+      id: "Pending",
+      dataLabels: {
+        align: "left",
+        x: 20,
+      },
+    },
+    {
+      id: "Cancelled",
       dataLabels: {
         align: "left",
         x: 20,
@@ -127,7 +153,16 @@ let paymentsLifeCycleMapper = (
   let title = {
     text: "",
   }
-  let colors = ["#91B7EE"] // , "#91B7EE", "#91B7EE", "#EC6262", "#91B7EE", "#EC6262", "#BA3535"
+  let colors = [
+    "#91B7EE",
+    "#91B7EE",
+    "#EC6262",
+    "#91B7EE",
+    "#EC6262",
+    "#EC6262",
+    "#91B7EE",
+    "#EC6262",
+  ]
 
   {data: processedData, nodes: sankeyNodes, title, colors}
 }

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
@@ -4,20 +4,35 @@ open PaymentsLifeCycleTypes
 let paymentLifeCycleResponseMapper = (json: JSON.t) => {
   let valueDict = json->getDictFromJsonObject
   // response need to be changed to snake_case
+  // {
+  //   normalSuccess: valueDict->getInt("normal_success", 0),
+  //   normalFailure: valueDict->getInt("normal_failure", 0),
+  //   cancelled: valueDict->getInt("cancelled", 0),
+  //   smartRetriedSuccess: valueDict->getInt("smart_retried_success", 0),
+  //   smartRetriedFailure: valueDict->getInt("smart_retried_failure", 0),
+  //   pending: valueDict->getInt("pending", 0),
+  //   partialRefunded: valueDict->getInt("partial_refunded", 0),
+  //   refunded: valueDict->getInt("refunded", 0),
+  //   disputed: valueDict->getInt("disputed", 0),
+  //   pmAwaited: valueDict->getInt("pm_awaited", 0),
+  //   customerAwaited: valueDict->getInt("customer_awaited", 0),
+  //   merchantAwaited: valueDict->getInt("merchant_awaited", 0),
+  //   confirmationAwaited: valueDict->getInt("confirmation_awaited", 0),
+  // }
   {
-    normalSuccess: valueDict->getInt("normal_success", 0),
-    normalFailure: valueDict->getInt("normal_failure", 0),
-    cancelled: valueDict->getInt("cancelled", 0),
-    smartRetriedSuccess: valueDict->getInt("smart_retried_success", 0),
-    smartRetriedFailure: valueDict->getInt("smart_retried_failure", 0),
-    pending: valueDict->getInt("pending", 0),
-    partialRefunded: valueDict->getInt("partial_refunded", 0),
-    refunded: valueDict->getInt("refunded", 0),
-    disputed: valueDict->getInt("disputed", 0),
-    pmAwaited: valueDict->getInt("pm_awaited", 0),
-    customerAwaited: valueDict->getInt("customer_awaited", 0),
-    merchantAwaited: valueDict->getInt("merchant_awaited", 0),
-    confirmationAwaited: valueDict->getInt("confirmation_awaited", 0),
+    normalSuccess: 15,
+    normalFailure: 10,
+    cancelled: 5,
+    smartRetriedSuccess: 5,
+    smartRetriedFailure: 5,
+    pending: 5,
+    partialRefunded: 5,
+    refunded: 5,
+    disputed: 5,
+    pmAwaited: 5,
+    customerAwaited: 5,
+    merchantAwaited: 5,
+    confirmationAwaited: 5,
   }
 }
 
@@ -43,11 +58,13 @@ let paymentsLifeCycleMapper = (
 
   let processedData = [
     ("Payments Initiated", "Success", success, "#E4EFFF"),
-    ("Payments Initiated", "Non-terminal state", customerAwaited, "#E4EFFF"),
+    ("Payments Initiated", "Failed", failure, "#F7E0E0"),
+    ("Payments Initiated", "Pending", failure, "#F7E0E0"),
+    ("Payments Initiated", "Cancelled", customerAwaited, "#E4EFFF"),
+    ("Payments Initiated", "Drop-offs", 20, "#F7E0E0"),
     ("Success", "Dispute Raised", disputed, "#F7E0E0"),
     ("Success", "Refunds Issued", refunded, "#E4EFFF"),
-    ("Payments Initiated", "Failed", failure, "#F7E0E0"),
-    ("Payments Initiated", "Drop-offs", pmAwaited, "#F7E0E0"),
+    ("Success", "Partial Refunded", refunded, "#E4EFFF"),
   ]
   let sankeyNodes = [
     {
@@ -79,6 +96,13 @@ let paymentsLifeCycleMapper = (
       },
     },
     {
+      id: "Partial Refunded",
+      dataLabels: {
+        align: "right",
+        x: 115,
+      },
+    },
+    {
       id: "Non-terminal state",
       dataLabels: {
         align: "left",
@@ -103,7 +127,7 @@ let paymentsLifeCycleMapper = (
   let title = {
     text: "",
   }
-  let colors = ["#91B7EE", "#91B7EE", "#91B7EE", "#EC6262", "#91B7EE", "#EC6262", "#BA3535"]
+  let colors = ["#91B7EE"] // , "#91B7EE", "#91B7EE", "#EC6262", "#91B7EE", "#EC6262", "#BA3535"
 
   {data: processedData, nodes: sankeyNodes, title, colors}
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
changed the sanky flow chart and the modification in the nodes values calcualtion formaulas 

for response 
<pre>
 {
    normalSuccess: 50,
    normalFailure: 30,
    smartRetriedSuccess: 15,
    smartRetriedFailure: 15,
    cancelled: 10,
    pending: 10,
    partialRefunded: 10,
    refunded: 45,
    disputed: 10,
    pmAwaited: 4,
    customerAwaited: 4,
    merchantAwaited: 1,
    confirmationAwaited: 1,
  }
</pre>

with smart retry 
<img width="1008" alt="Screenshot 2024-11-07 at 2 55 19 PM" src="https://github.com/user-attachments/assets/f4ff6596-8142-4089-98af-5db1d2e7b482">

without smart retry 
<img width="988" alt="Screenshot 2024-11-07 at 2 55 29 PM" src="https://github.com/user-attachments/assets/4517010a-ab5a-442a-bc5f-45e138de6fb7">

<!-- Describe your changes in detail -->

base flow chart 
<img width="769" alt="image" src="https://github.com/user-attachments/assets/8aa95050-3861-4d04-a09c-7555700c98fa">


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the flow chart should match the payment list data 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
