### PR TITLE
feat: add functionality to force two-fa

### DIFF
--- a/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TotpSetup.res
@@ -4,7 +4,7 @@ let p3Regular = HSwitchUtils.getTextClass((P3, Regular))
 
 module EnterAccessCode = {
   @react.component
-  let make = (~setTwoFaPageState, ~onClickVerifyAccessCode, ~errorHandling) => {
+  let make = (~setTwoFaPageState, ~onClickVerifyAccessCode, ~errorHandling, ~isSkippable) => {
     let showToast = ToastState.useShowToast()
     let verifyRecoveryCodeLogic = TotpHooks.useVerifyRecoveryCode()
     let (recoveryCode, setRecoveryCode) = React.useState(_ => "")
@@ -75,13 +75,15 @@ module EnterAccessCode = {
           </p>
         </div>
         <div className="flex justify-end gap-4">
-          <Button
-            text="Skip now"
-            buttonType={Secondary}
-            buttonSize=Small
-            onClick={_ => onClickVerifyAccessCode(~skip_2fa=true)->ignore}
-            dataTestId="skip-now"
-          />
+          <RenderIf condition={isSkippable}>
+            <Button
+              text="Skip now"
+              buttonType={Secondary}
+              buttonSize=Small
+              onClick={_ => onClickVerifyAccessCode(~skip_2fa=true)->ignore}
+              dataTestId="skip-now"
+            />
+          </RenderIf>
           <Button
             text="Verify recovery code"
             buttonType=Primary
@@ -110,6 +112,7 @@ module ConfigureTotpScreen = {
     ~setTwoFaPageState,
     ~terminateTwoFactorAuth,
     ~errorHandling,
+    ~isSkippable,
   ) => {
     open TwoFaTypes
 
@@ -207,13 +210,15 @@ module ConfigureTotpScreen = {
           </RenderIf>
         </div>
         <div className="flex justify-end gap-4">
-          <Button
-            text="Skip now"
-            buttonType={Secondary}
-            buttonSize=Small
-            onClick={_ => skipTotpSetup()->ignore}
-            dataTestId="skip-now"
-          />
+          <RenderIf condition={isSkippable}>
+            <Button
+              text="Skip now"
+              buttonType={Secondary}
+              buttonSize=Small
+              onClick={_ => skipTotpSetup()->ignore}
+              dataTestId="skip-now"
+            />
+          </RenderIf>
           <Button
             text=buttonText
             buttonType=Primary
@@ -234,7 +239,7 @@ module ConfigureTotpScreen = {
 }
 
 @react.component
-let make = (~setTwoFaPageState, ~twoFaPageState, ~errorHandling) => {
+let make = (~setTwoFaPageState, ~twoFaPageState, ~errorHandling, ~isSkippable) => {
   open HSwitchUtils
   open TwoFaTypes
 
@@ -333,7 +338,13 @@ let make = (~setTwoFaPageState, ~twoFaPageState, ~errorHandling) => {
         {switch twoFaPageState {
         | TOTP_SHOW_QR =>
           <ConfigureTotpScreen
-            isQrVisible totpUrl twoFaStatus setTwoFaPageState terminateTwoFactorAuth errorHandling
+            isQrVisible
+            totpUrl
+            twoFaStatus
+            setTwoFaPageState
+            terminateTwoFactorAuth
+            errorHandling
+            isSkippable
           />
         | TOTP_SHOW_RC =>
           <TotpRecoveryCodes
@@ -341,7 +352,10 @@ let make = (~setTwoFaPageState, ~twoFaPageState, ~errorHandling) => {
           />
         | TOTP_INPUT_RECOVERY_CODE =>
           <EnterAccessCode
-            setTwoFaPageState onClickVerifyAccessCode={terminateTwoFactorAuth} errorHandling
+            setTwoFaPageState
+            onClickVerifyAccessCode={terminateTwoFactorAuth}
+            errorHandling
+            isSkippable
           />
         }}
         <div className="text-grey-200 flex gap-2">

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaLanding.res
@@ -80,6 +80,7 @@ let make = () => {
   let (twoFaStatus, setTwoFaStatus) = React.useState(_ => TwoFaNotExpired)
   let (twoFaPageState, setTwoFaPageState) = React.useState(_ => TOTP_SHOW_QR)
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+  let (isSkippable, setIsSkippable) = React.useState(_ => true)
 
   let handlePageBasedOnAttempts = responseDict => {
     switch responseDict {
@@ -108,6 +109,7 @@ let make = () => {
       let response = await fetchDetails(url)
       let responseDict = response->TwoFaUtils.jsonTocheckTwofaResponseType
       handlePageBasedOnAttempts(responseDict.status)
+      setIsSkippable(_ => responseDict.isSkippable)
       setScreenState(_ => PageLoaderWrapper.Success)
     } catch {
     | _ => {
@@ -130,7 +132,7 @@ let make = () => {
     {switch twoFaStatus {
     | TwoFaExpired(expiredType) =>
       <AttemptsExpiredComponent expiredType setTwoFaPageState setTwoFaStatus />
-    | TwoFaNotExpired => <TotpSetup twoFaPageState setTwoFaPageState errorHandling />
+    | TwoFaNotExpired => <TotpSetup twoFaPageState setTwoFaPageState errorHandling isSkippable />
     }}
   </PageLoaderWrapper>
 }

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaTypes.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaTypes.res
@@ -15,7 +15,10 @@ type twoFatype = {
   recoveryCode: twoFaValueType,
 }
 
-type checkTwofaResponseType = {status: option<twoFatype>}
+type checkTwofaResponseType = {
+  status: option<twoFatype>,
+  isSkippable: bool,
+}
 
 type expiredTypes =
   | TOTP_ATTEMPTS_EXPIRED

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaUtils.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaUtils.res
@@ -75,9 +75,12 @@ let jsonToTwoFaValueType: Dict.t<'a> => TwoFaTypes.twoFaValueType = dict => {
 
 let jsonTocheckTwofaResponseType: JSON.t => TwoFaTypes.checkTwofaResponseType = json => {
   open LogicUtils
-  let jsonToDict = json->getDictFromJsonObject->Dict.get("status")
+  let jsonToDict = json->getDictFromJsonObject
 
-  let statusValue = switch jsonToDict {
+  let statusValueDict = jsonToDict->Dict.get("status")
+  let isSkippable = jsonToDict->getBool("is_skippable", true)
+
+  let statusValue = switch statusValueDict {
   | Some(json) => {
       let dict = json->getDictFromJsonObject
       let twoFaValue: TwoFaTypes.twoFatype = {
@@ -91,5 +94,6 @@ let jsonTocheckTwofaResponseType: JSON.t => TwoFaTypes.checkTwofaResponseType = 
 
   {
     status: statusValue,
+    isSkippable,
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Earlier there was no way to force two-fa . With this change there will be a way to force two-fa if backend sends is-skippable as false 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- force-two-factor-auth from backend as false 
then there should be a skip button available in FE 

- force-two-factor-auth from backend as true 
then there should not be a skip button available in FE 

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
Tested in local 
- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
