### PR TITLE
feat: change password feature

### DIFF
--- a/src/entryPoints/AuthModule/Common/CommonAuthForm.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthForm.res
@@ -43,3 +43,15 @@ module ResetPasswordForm = {
     </>
   }
 }
+
+module ChangePasswordForm = {
+  @react.component
+  let make = () => {
+    open CommonInputFields
+    <>
+      <FormRenderer.FieldRenderer field=oldPasswordField labelClass fieldWrapperClass />
+      <FormRenderer.FieldRenderer field=newPasswordField labelClass fieldWrapperClass />
+      <FormRenderer.FieldRenderer field=confirmNewPasswordField labelClass fieldWrapperClass />
+    </>
+  }
+}

--- a/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
@@ -38,5 +38,6 @@ type subCode =
   | UR_42
   | UR_48
   | UR_49
+  | UR_06
 
 type modeType = TestButtonMode | LiveButtonMode

--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -130,6 +130,7 @@ let errorSubCodeMapper = (subCode: string) => {
   | "UR_42" => UR_42
   | "UR_48" => UR_48
   | "UR_49" => UR_49
+  | "UR_06" => UR_06
   | _ => UR_00
   }
 }

--- a/src/entryPoints/AuthModule/Common/CommonInputFields.res
+++ b/src/entryPoints/AuthModule/Common/CommonInputFields.res
@@ -17,6 +17,47 @@ let emailField = FormRenderer.makeFieldInfo(
     ),
 )
 
+let oldPasswordField = FormRenderer.makeFieldInfo(
+  ~label="Old Password",
+  ~name="old_password",
+  ~placeholder="Enter your Old Password",
+  ~type_="password",
+  ~customInput=InputFields.passwordMatchField(
+    ~leftIcon={
+      <Icon name="password-lock" size=13 />
+    },
+  ),
+  ~isRequired=false,
+)
+
+let newPasswordField = FormRenderer.makeFieldInfo(
+  ~label="New Password",
+  ~name="new_password",
+  ~placeholder="Enter your New Password",
+  ~type_="password",
+  ~customInput=InputFields.passwordMatchField(
+    ~leftIcon={
+      <Icon name="password-lock" size=13 />
+    },
+  ),
+  ~isRequired=false,
+)
+
+let confirmNewPasswordField = FormRenderer.makeFieldInfo(
+  ~label="Confirm Password",
+  ~name="confirm_password",
+  ~placeholder="Re-enter your Password",
+  ~type_="password",
+  ~customInput=InputFields.textInput(
+    ~type_="password",
+    ~autoComplete="off",
+    ~leftIcon={
+      <Icon name="password-lock" size=13 />
+    },
+  ),
+  ~isRequired=false,
+)
+
 let createPasswordField = FormRenderer.makeFieldInfo(
   ~label="Password",
   ~name="create_password",

--- a/src/entryPoints/AuthModule/TwoFaAuth/TwoFaUtils.res
+++ b/src/entryPoints/AuthModule/TwoFaAuth/TwoFaUtils.res
@@ -24,7 +24,9 @@ let validateTotpForm = (values: JSON.t, keys: array<string>) => {
         Dict.set(
           errors,
           key,
-          `${key->LogicUtils.capitalizeString} cannot be empty`->JSON.Encode.string,
+          `${key
+            ->LogicUtils.capitalizeString
+            ->LogicUtils.snakeToTitle} cannot be empty`->JSON.Encode.string,
         )
       }
     }
@@ -39,6 +41,7 @@ let validateTotpForm = (values: JSON.t, keys: array<string>) => {
     // password check
     switch key {
     | "password" => CommonAuthUtils.passwordKeyValidation(value, key, "password", errors)
+    | "new_password" => CommonAuthUtils.passwordKeyValidation(value, key, "new_password", errors)
     | _ => CommonAuthUtils.passwordKeyValidation(value, key, "create_password", errors)
     }
 
@@ -48,6 +51,15 @@ let validateTotpForm = (values: JSON.t, keys: array<string>) => {
       key,
       "comfirm_password",
       "create_password",
+      valuesDict,
+      errors,
+    )
+    //confirm password check for #change_password
+    CommonAuthUtils.confirmPasswordCheck(
+      value,
+      key,
+      "confirm_password",
+      "new_password",
       valuesDict,
       errors,
     )

--- a/src/screens/Settings/HSwitchProfile/HSwitchProfileSettings.res
+++ b/src/screens/Settings/HSwitchProfile/HSwitchProfileSettings.res
@@ -4,6 +4,102 @@ let sectionHeadingClass = "font-semibold text-fs-18"
 let p1Leading1TextClass = HSwitchUtils.getTextClass((P1, Regular))
 let p3RegularTextClass = `${HSwitchUtils.getTextClass((P3, Regular))} text-gray-700 opacity-50`
 
+module ChangePasswordModal = {
+  @react.component
+  let make = (~setShowModal) => {
+    open APIUtils
+    open LogicUtils
+    open CommonAuthUtils
+    let getURL = useGetURL()
+    let showToast = ToastState.useShowToast()
+    let updateDetails = useUpdateMethod(~showErrorToast=false)
+    let fetchApi = AuthHooks.useApiFetcher()
+    let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+    let onSubmit = async (values, _) => {
+      let valuesDict = values->getDictFromJsonObject
+      let oldPassword = getString(valuesDict, "old_password", "")
+      let newPassword = getString(valuesDict, "new_password", "")
+      try {
+        let url = getURL(~entityName=USERS, ~userType=#CHANGE_PASSWORD, ~methodType=Post)
+        let body =
+          [
+            ("old_password", oldPassword->JSON.Encode.string),
+            ("new_password", newPassword->JSON.Encode.string),
+          ]->getJsonFromArrayOfJson
+        let _ = await updateDetails(url, body, Post)
+        showToast(~message="Password Changed Successfully", ~toastType=ToastSuccess)
+        let logoutUrl = getURL(~entityName=USERS, ~methodType=Post, ~userType=#SIGNOUT)
+        let _ = fetchApi(logoutUrl, ~method_=Post, ~xFeatureRoute)
+        setShowModal(_ => false)
+      } catch {
+      | Exn.Error(e) => {
+          let err = Exn.message(e)->Option.getOr("Something went wrong")
+          let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
+          let errorMessage = err->safeParse->getDictFromJsonObject->getString("message", "")
+          setShowModal(_ => false)
+          if errorCode->errorSubCodeMapper === UR_06 {
+            showToast(~message=errorMessage, ~toastType=ToastError)
+          } else {
+            showToast(~message="Password Change Failed, Try again", ~toastType=ToastError)
+          }
+        }
+      }
+      Nullable.null
+    }
+
+    <Modal
+      modalHeading="Change Password"
+      setShowModal
+      showModal=true
+      closeOnOutsideClick=true
+      modalClass="w-full md:w-4/12 mx-auto my-auto">
+      <Form
+        key="auth"
+        validate={values =>
+          TwoFaUtils.validateTotpForm(values, ["old_password", "new_password", "confirm_password"])}
+        onSubmit>
+        <div className="flex flex-col gap-6 m-2">
+          <div
+            className="flex flex-col justify-evenly gap-5 h-full w-full !overflow-visible text-grey-600">
+            <CommonAuthForm.ChangePasswordForm />
+            <div id="auth-submit-btn" className="flex flex-col gap-2">
+              <FormRenderer.SubmitButton
+                customSumbitButtonStyle="!w-full !rounded"
+                text="Confirm"
+                userInteractionRequired=true
+                showToolTip=false
+                loadingText="Loading..."
+              />
+            </div>
+          </div>
+        </div>
+      </Form>
+    </Modal>
+  }
+}
+
+module ChangePassword = {
+  @react.component
+  let make = () => {
+    let (showModal, setShowModal) = React.useState(_ => false)
+    <div className="flex gap-10 items-center">
+      <p className="text-hyperswitch_black text-base  w-1/5"> {"Password:"->React.string} </p>
+      <div className="flex flex-col gap-5 items-start md:flex-row md:items-center flex-wrap">
+        <p className="text-hyperswitch_black opacity-50 text-base font-semibold break-all">
+          {"********"->React.string}
+        </p>
+        <Button
+          text={"Change Password"}
+          buttonType=Secondary
+          buttonSize={Small}
+          onClick={_ => setShowModal(_ => true)}
+        />
+        {showModal ? <ChangePasswordModal setShowModal /> : React.null}
+      </div>
+    </div>
+  }
+}
+
 module ResetPassword = {
   @react.component
   let make = () => {
@@ -123,8 +219,6 @@ module BasicDetailsSection = {
     let {name: userName, email} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
     let userTitle = LogicUtils.userNameToTitle(userName)
 
-    let isPlayground = HSLocalStorage.getIsPlaygroundFromLocalStorage()
-
     let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     <div>
       <div className="border bg-gray-50 rounded-t-lg w-full px-10 py-6">
@@ -144,8 +238,11 @@ module BasicDetailsSection = {
           <p className=subTitleClass> {email->React.string} </p>
         </div>
         <hr />
-        <RenderIf condition={!isPlayground && featureFlagDetails.email}>
+        <RenderIf condition={featureFlagDetails.email}>
           <ResetPassword />
+        </RenderIf>
+        <RenderIf condition={!featureFlagDetails.email}>
+          <ChangePassword />
         </RenderIf>
       </div>
     </div>

--- a/src/utils/Modal.res
+++ b/src/utils/Modal.res
@@ -69,7 +69,8 @@ module ModalHeading = {
         </div>
       | None => React.null
       }}
-      <div className={`flex ${headerAlignmentClass} ${justifyClass} ${headerTextClass}`}>
+      <div
+        className={`flex items-center ${headerAlignmentClass} ${justifyClass} ${headerTextClass}`}>
         <div className=modalParentHeadingClass>
           {if showCloseIcon && showCloseOnLeft && !showBackIcon {
             onCloseClick->ModalUtils.getCloseIcon


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

It implements conditional availability for the "Change Password" feature based on the status of the Email feature flag. When the Email feature flag is turned off, the "Change Password" option is now available to users, allowing password updates without email-based actions.

## Motivation and Context

Allowing password updates without email dependency

## How did you test it?

Tested it locally with backend.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
