### PR TITLE
fix: show role name for custom roles

### DIFF
--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -102,6 +102,7 @@ let make = () => {
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let roleTypeValue =
     ReactFinalForm.useField(`role_id`).input.value->getStringFromJson("")->getNonEmptyString
+  let (roleNameValue, setRoleNameValue) = React.useState(_ => "")
   let (options, setOptions) = React.useState(_ => []->SelectBox.makeOptions)
   let (dropDownLoaderState, setDropDownLoaderState) = React.useState(_ =>
     DropdownWithLoading.Success
@@ -121,6 +122,7 @@ let make = () => {
         ~methodType=Get,
       )
       let res = await fetchDetails(url)
+      setRoleNameValue(_ => res->getDictFromJsonObject->getString("role_name", ""))
       setRoleDict(prevDict => {
         prevDict->Dict.set(roleTypeValue->Option.getOr(""), res)
         prevDict
@@ -195,19 +197,19 @@ let make = () => {
         // <FormValuesSpy />
       </div>
       <div className="p-6 flex flex-col gap-2 col-span-3">
-        {switch roleTypeValue {
-        | Some(role) =>
+        {switch (roleTypeValue, roleNameValue) {
+        | (Some(role_id), role_name) =>
           <>
             <p className={`${p1MediumTextClass} !font-semibold py-2`}>
-              {`Role Description - '${role->snakeToTitle}'`->React.string}
+              {`Role Description - '${role_name->snakeToTitle}'`->React.string}
             </p>
             <PageLoaderWrapper screenState>
               <div className="border rounded-md p-4 flex flex-col">
-                <RoleAccessOverview roleDict role={roleTypeValue->Option.getOr("")} />
+                <RoleAccessOverview roleDict role={role_id} />
               </div>
             </PageLoaderWrapper>
           </>
-        | None =>
+        | (_, _) =>
           <>
             <p className={`${p1MediumTextClass} !font-semibold`}>
               {"Role Description"->React.string}

--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -197,19 +197,19 @@ let make = () => {
         // <FormValuesSpy />
       </div>
       <div className="p-6 flex flex-col gap-2 col-span-3">
-        {switch (roleTypeValue, roleNameValue) {
-        | (Some(role_id), role_name) =>
+        {switch roleTypeValue {
+        | Some(role) =>
           <>
             <p className={`${p1MediumTextClass} !font-semibold py-2`}>
-              {`Role Description - '${role_name->snakeToTitle}'`->React.string}
+              {`Role Description - '${roleNameValue->snakeToTitle}'`->React.string}
             </p>
             <PageLoaderWrapper screenState>
               <div className="border rounded-md p-4 flex flex-col">
-                <RoleAccessOverview roleDict role={role_id} />
+                <RoleAccessOverview roleDict role />
               </div>
             </PageLoaderWrapper>
           </>
-        | (_, _) =>
+        | None =>
           <>
             <p className={`${p1MediumTextClass} !font-semibold`}>
               {"Role Description"->React.string}

--- a/src/screens/UserManagement/UserRevamp/UserInfo.res
+++ b/src/screens/UserManagement/UserRevamp/UserInfo.res
@@ -95,7 +95,7 @@ module TableRowForUserDetails = {
         </RenderIf>
         <td className=tableElementCss> {profileName->React.string} </td>
         <td className=tableElementCss>
-          {value.roleId->snakeToTitle->capitalizeString->React.string}
+          {value.roleName->snakeToTitle->capitalizeString->React.string}
         </td>
         <td className=tableElementCss>
           <p className={`${statusColor} px-4 py-1 w-fit rounded-full`}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Earlier custom roles description showed role id instead of role name.

**Before :** 

<img width="1274" alt="Screenshot 2024-11-08 at 4 34 26 PM" src="https://github.com/user-attachments/assets/6da3202c-ab6f-4941-897e-51e8a2db329e">

<img width="1274" alt="Screenshot 2024-11-08 at 4 38 54 PM" src="https://github.com/user-attachments/assets/235431c8-0ae5-4cdc-baa4-b6f6d571bc8f">



**After :**

<img width="1198" alt="Screenshot 2024-11-08 at 4 36 12 PM" src="https://github.com/user-attachments/assets/33a85bbe-5fef-4249-a8e8-59f339798794">

<img width="1261" alt="Screenshot 2024-11-08 at 4 33 08 PM" src="https://github.com/user-attachments/assets/fc724c67-b8b3-4a9e-87e1-2ea5666e356f">

## Motivation and Context


This PR updates the role description to show the role name instead of the role ID for better clarity. It helps make the UI more user-friendly and easier to understand.

## How did you test it?

Tested locally and working as expected

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
