### PR TITLE
fix: sankey flow chart count fix

### DIFF
--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycleUtils.res
@@ -53,37 +53,28 @@ let paymentsLifeCycleMapper = (
   let refunded = data.refunded
   let partialRefunded = data.partialRefunded
 
-  let success = disputed + refunded + partialRefunded
-
-  let normalSuccess = data.normalSuccess
-  let failure = data.normalFailure
-
+  let success =
+    disputed +
+    refunded +
+    partialRefunded +
+    (isSmartRetryEnabled ? data.smartRetriedSuccess : 0) +
+    data.normalSuccess
+  let failure = data.normalFailure + (isSmartRetryEnabled ? data.smartRetriedFailure * 2 : 0)
   let pending = data.pending
   let cancelled = data.cancelled
-
   let dropoff =
     data.pmAwaited + data.customerAwaited + data.merchantAwaited + data.confirmationAwaited
 
   let processedData = [
-    ("Payments Initiated", "Normal Success", normalSuccess, "#E4EFFF"),
+    ("Payments Initiated", "Success", success, "#E4EFFF"),
     ("Payments Initiated", "Failed", failure, "#F7E0E0"),
     ("Payments Initiated", "Pending", pending, "#E4EFFF"),
     ("Payments Initiated", "Cancelled", cancelled, "#F7E0E0"),
     ("Payments Initiated", "Drop-offs", dropoff, "#F7E0E0"),
-    ("Normal Success", "Success", success, "#E4EFFF"),
     ("Success", "Dispute Raised", disputed, "#F7E0E0"),
     ("Success", "Refunds Issued", refunded, "#E4EFFF"),
     ("Success", "Partial Refunded", partialRefunded, "#E4EFFF"),
   ]
-
-  let processedData = if isSmartRetryEnabled {
-    processedData->Array.concat([
-      ("Failed", "Success", data.smartRetriedSuccess, "#E4EFFF"),
-      ("Failed", "Smart Retrie dFailure", data.smartRetriedFailure, "#F7E0E0"),
-    ])
-  } else {
-    processedData
-  }
 
   let sankeyNodes = [
     {
@@ -160,8 +151,8 @@ let paymentsLifeCycleMapper = (
     "#91B7EE",
     "#EC6262",
     "#EC6262",
-    "#91B7EE",
     "#EC6262",
+    "#91B7EE",
   ]
 
   {data: processedData, nodes: sankeyNodes, title, colors}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
the payment count for same date range from list api vs payment life cycle api 
<img width="571" alt="Screenshot 2024-11-11 at 6 15 25 PM" src="https://github.com/user-attachments/assets/739c6092-ab02-4658-b307-45648b2186b1">
<img width="660" alt="Screenshot 2024-11-11 at 6 15 30 PM" src="https://github.com/user-attachments/assets/7dd0540e-cc11-4a81-ac25-d66189ce96e3">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?
when u select the same date range in operatiin tab and analytics tab the payment initiated should be same
- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
