### PR TITLE
fix: compare date range days count fix

### DIFF
--- a/src/utils/DateRangeUtils.res
+++ b/src/utils/DateRangeUtils.res
@@ -82,17 +82,18 @@ let getPredefinedStartAndEndDate = (
     ->Js.Date.getDate
   let prevDate = (customDate->DayJs.getDayJsForJsDate).subtract(6, "month").toString()
   let daysInSixMonth = (customDate->DayJs.getDayJsForJsDate).diff(prevDate, "day")->Int.toFloat
-  let count = switch value {
-  | Today => 1.0
-  | Yesterday => 1.0
-  | Tomorrow => 1.0
-  | LastMonth => daysInMonth
-  | LastSixMonths => daysInSixMonth
-  | ThisMonth => customDate->Js.Date.getDate
-  | NextMonth => daysInMonth
-  | Day(val) => val
-  | Hour(val) => val /. 24.0 +. 1.
-  }
+  let count =
+    switch value {
+    | Today => 1.0
+    | Yesterday => 1.0
+    | Tomorrow => 1.0
+    | LastMonth => daysInMonth
+    | LastSixMonths => daysInSixMonth
+    | ThisMonth => customDate->Js.Date.getDate
+    | NextMonth => daysInMonth
+    | Day(val) => val
+    | Hour(val) => val /. 24.0 +. 1.
+    } +. 1.0
 
   let date =
     customTimezoneToISOString(


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
the primary and compare date range the days count should be same 
<img width="519" alt="Screenshot 2024-11-11 at 6 47 35 PM" src="https://github.com/user-attachments/assets/37d93a17-60d9-4406-9843-48e499d4e372">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the primary and compare date range the days count should be same 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
