### PR TITLE
fix: compare date range component minor fixes 

### DIFF
--- a/src/components/DateRangeCompareFields.res
+++ b/src/components/DateRangeCompareFields.res
@@ -505,7 +505,7 @@ module Base = {
         ~customTimezoneToISOString,
         ~format="YYYY-MM-DDTHH:mm:00[Z]",
       )
-      getStartEndDiff(startTimestamp, endTimestamp)
+      (startTimestamp, endTimestamp)
     }
 
     let predefinedOptionSelected = predefinedDays->Array.find(item => {
@@ -519,8 +519,8 @@ module Base = {
         endDateVal,
         "YYYY-MM-DDTHH:mm:00[Z]",
       )
-      let difference = getStartEndDiff(startDate, endDate)
-      getDiffForPredefined(item) === difference
+      let (startTimestamp, endTimestamp) = getDiffForPredefined(item)
+      (startTimestamp, endTimestamp) == (startDate, endDate)
     })
 
     let buttonText = switch predefinedOptionSelected {

--- a/src/components/DateRangeCompareFields.res
+++ b/src/components/DateRangeCompareFields.res
@@ -670,7 +670,6 @@ module Base = {
         textStyle
         iconBorderColor=customborderCSS
         customButtonStyle=customStyleForBtn
-        enableToolTip=false
         showLeftIcon=false
         isCompare=true
         comparison

--- a/src/components/DateRangeCompareFields.res
+++ b/src/components/DateRangeCompareFields.res
@@ -535,10 +535,9 @@ module Base = {
 
     let buttonType: option<Button.buttonType> = buttonType
 
-    let setDateTime = (~date, ~time, setLocalDate) => {
+    let setDateTime = (~date, setLocalDate) => {
       if date->isNonEmptyString {
-        let timestamp = changeTimeFormat(~date, ~time, ~customTimezoneToISOString, ~format)
-        setLocalDate(_ => timestamp)
+        setLocalDate(_ => date)
       }
     }
     let handleCompareOptionClick = value => {
@@ -563,13 +562,8 @@ module Base = {
           setIsDropdownExpanded(_ => false)
           setIsCustomSelected(_ => false)
 
-          let stDate = getFormattedDate(startDate, "YYYY-MM-DD")
-          let edDate = getFormattedDate(endDate, "YYYY-MM-DD")
-          let stTime = getFormattedDate(startDate, "HH:MM:00")
-          let endTime = getFormattedDate(endDate, "HH:MM:00")
-
-          setDateTime(~date=stDate, ~time=stTime, setLocalStartDate)
-          setDateTime(~date=edDate, ~time=endTime, setLocalEndDate)
+          setDateTime(~date=startDateVal, setLocalStartDate)
+          setDateTime(~date=endDateVal, setLocalEndDate)
           let _ = setTimeout(() => {
             setComparison(_ => (EnableComparison :> string))
           }, 0)
@@ -608,7 +602,7 @@ module Base = {
               dateRangeLimit={DateRangeUtils.getGapBetweenRange(
                 ~startDate=compareWithStartTime,
                 ~endDate=compareWithEndTime,
-              )}
+              ) + 1}
               calendarContaierStyle="md:mx-3 md:my-1 border-0 md:border"
               ?allowedDateRange
             />

--- a/src/container/NewAnalyticsContainer.res
+++ b/src/container/NewAnalyticsContainer.res
@@ -23,6 +23,7 @@ let make = () => {
     ~compareToEndTimeKey,
     ~origin="analytics",
     ~enableCompareTo=Some(true),
+    ~range=6,
     ~comparisonKey,
     (),
   )

--- a/src/screens/NewAnalytics/NewAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/NewAnalyticsUtils.res
@@ -90,16 +90,6 @@ let valueFormatter = (value, statType: valueType) => {
   | No_Type => value->Float.toString
   }
 }
-let getComparisionTimePeriod = (~startDate, ~endDate) => {
-  let startingPoint = startDate->DayJs.getDayJsForString
-  let endingPoint = endDate->DayJs.getDayJsForString
-  let gap = endingPoint.diff(startingPoint.toString(), "millisecond") // diff between points
-
-  let startTimeValue = startingPoint.subtract(gap, "millisecond").toDate()->Date.toISOString
-  let endTimeVal = endingPoint.subtract(gap, "millisecond").toDate()->Date.toISOString
-
-  (startTimeValue, endTimeVal)
-}
 
 let getMonthName = month => {
   switch month {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
things fixed in this pr
the compare date range matjing the primary date range 
showing proper predifined date label selected 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
