### PR TITLE
Fix: Filter routing connector list

### DIFF
--- a/src/screens/PayoutRouting/PayoutRoutingConfigure.res
+++ b/src/screens/PayoutRouting/PayoutRoutingConfigure.res
@@ -57,7 +57,7 @@ let make = (~routingType) => {
           baseUrlForRedirection
         />
       | DEFAULTFALLBACK =>
-        <DefaultRouting urlEntityName=PAYOUT_DEFAULT_FALLBACK baseUrlForRedirection />
+        <DefaultRouting urlEntityName=PAYOUT_DEFAULT_FALLBACK baseUrlForRedirection connectorList />
       | _ => React.null
       }}
     </History.BreadCrumbWrapper>

--- a/src/screens/Routing/DefaultRouting.res
+++ b/src/screens/Routing/DefaultRouting.res
@@ -174,7 +174,7 @@ let make = (
                   <p> {connectorName->React.string} </p>
                   <p className="text-sm opacity-50 "> {`(${connectorLabel})`->React.string} </p>
                   <RenderIf condition={isDisabled}>
-                    <p className="text-sm opacity-50 "> {`(disabled)`->React.string} </p>
+                    <p className="text-sm opacity-50 "> {"(disabled)"->React.string} </p>
                   </RenderIf>
                 </div>
               </div>

--- a/src/screens/Routing/DefaultRouting.res
+++ b/src/screens/Routing/DefaultRouting.res
@@ -2,7 +2,11 @@ open APIUtils
 open MerchantAccountUtils
 
 @react.component
-let make = (~urlEntityName, ~baseUrlForRedirection) => {
+let make = (
+  ~urlEntityName,
+  ~baseUrlForRedirection,
+  ~connectorList: array<ConnectorTypes.connectorPayload>,
+) => {
   open LogicUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
@@ -15,23 +19,30 @@ let make = (~urlEntityName, ~baseUrlForRedirection) => {
   let (gateways, setGateways) = React.useState(() => [])
   let (defaultRoutingResponse, setDefaultRoutingResponse) = React.useState(_ => [])
   let modalObj = RoutingUtils.getModalObj(DEFAULTFALLBACK, "default")
-  let typedConnectorValue = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
   let {globalUIConfig: {backgroundColor}} = React.useContext(ThemeProvider.themeContext)
+
   let settingUpConnectorsState = routingRespArray => {
     let profileList =
       routingRespArray->Array.filter(value =>
         value->getDictFromJsonObject->getString("profile_id", "") === profile
       )
 
-    let connectorList =
+    let connectors =
       profileList
       ->Array.get(0)
       ->Option.getOr(JSON.Encode.null)
       ->getDictFromJsonObject
       ->getArrayFromDict("connectors", [])
 
-    if connectorList->Array.length > 0 {
-      setGateways(_ => connectorList)
+    let gatewayConnectors = connectors->Array.filter(connectorsItem => {
+      connectorList->Array.some(connectorListItem => {
+        connectorListItem.merchant_connector_id ===
+          connectorsItem->getDictFromJsonObject->getString("merchant_connector_id", "")
+      })
+    })
+
+    if gatewayConnectors->Array.length > 0 {
+      setGateways(_ => gatewayConnectors)
       setScreenState(_ => PageLoaderWrapper.Success)
     } else {
       setScreenState(_ => PageLoaderWrapper.Custom)
@@ -135,9 +146,20 @@ let make = (~urlEntityName, ~baseUrlForRedirection) => {
             let merchantConnectorId =
               gateway->getDictFromJsonObject->getString("merchant_connector_id", "")
             let connectorLabel = ConnectorTableUtils.getConnectorObjectFromListViaId(
-              typedConnectorValue,
+              connectorList,
               merchantConnectorId,
             ).connector_label
+
+            let connector =
+              connectorList
+              ->Array.filter(item =>
+                item.merchant_connector_id ===
+                  gateway->getDictFromJsonObject->getString("merchant_connector_id", "")
+              )
+              ->Array.get(0)
+              ->Option.getOr(Dict.make()->ConnectorListMapper.getProcessorPayloadType)
+
+            let isDisabled = connector.disabled
 
             <div
               className={`h-14 px-3 flex flex-row items-center justify-between text-jp-gray-900 dark:text-jp-gray-600 border-jp-gray-500 dark:border-jp-gray-960
@@ -151,6 +173,9 @@ let make = (~urlEntityName, ~baseUrlForRedirection) => {
                 <div className="flex gap-1 items-center">
                   <p> {connectorName->React.string} </p>
                   <p className="text-sm opacity-50 "> {`(${connectorLabel})`->React.string} </p>
+                  <RenderIf condition={isDisabled}>
+                    <p className="text-sm opacity-50 "> {`(disabled)`->React.string} </p>
+                  </RenderIf>
                 </div>
               </div>
             </div>

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -53,7 +53,8 @@ let make = (~routingType) => {
           urlEntityName=ROUTING
           baseUrlForRedirection
         />
-      | DEFAULTFALLBACK => <DefaultRouting urlEntityName=DEFAULT_FALLBACK baseUrlForRedirection />
+      | DEFAULTFALLBACK =>
+        <DefaultRouting urlEntityName=DEFAULT_FALLBACK baseUrlForRedirection connectorList />
       | _ => <> </>
       }}
     </History.BreadCrumbWrapper>

--- a/src/screens/Routing/VolumeSplitRouting.res
+++ b/src/screens/Routing/VolumeSplitRouting.res
@@ -97,7 +97,7 @@ module VolumeRoutingView = {
       ->Array.filter(item => item.profile_id === profile)
       ->Array.map((item): SelectBox.dropdownOption => {
         {
-          label: item.connector_label,
+          label: item.disabled ? `${item.connector_label} (disabled)` : item.connector_label,
           value: item.merchant_connector_id,
         }
       })

--- a/src/screens/RoutingRevamp/AdvancedRouting.res
+++ b/src/screens/RoutingRevamp/AdvancedRouting.res
@@ -745,7 +745,7 @@ let make = (
     ->Array.filter(item => item.profile_id === profile)
     ->Array.map((item): SelectBox.dropdownOption => {
       {
-        label: item.connector_label,
+        label: item.disabled ? `${item.connector_label} (disabled)` : item.connector_label,
         value: item.merchant_connector_id,
       }
     })


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
- Show only payment processors in default fallback routing connectors list
- indicate the disabled connectors in connector dropdown and list in payment and payout routing in Workflow module

![image](https://github.com/user-attachments/assets/33d8c4a1-4584-4a04-a193-b44bf35a7927)
![image](https://github.com/user-attachments/assets/990f4dcb-ba79-4c48-941d-c439bf48a8fe)
![image](https://github.com/user-attachments/assets/5b118b0b-cdd5-466b-be29-3ef571b4cdb1)
![image](https://github.com/user-attachments/assets/0d0ad63b-f84d-4c14-b174-a4b229857a4f)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Connect any connector other than payment connector
Go to Workflow > Routing > Default Fallback > Manage
Connectors other than Payment connectors are not visible in list
Now disable any connected payment connected and check the list again
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
