### PR TITLE
fix: sankey ui fixes

### DIFF
--- a/src/screens/NewAnalytics/Graphs/SankyGraph/SankeyGraphTypes.res
+++ b/src/screens/NewAnalytics/Graphs/SankyGraph/SankeyGraphTypes.res
@@ -1,4 +1,6 @@
-type point = {sum: string, id: string}
+type temp = {name: int}
+type options = {dataLabels: temp}
+type point = {sum: string, id: string, options: options}
 type nodeFormatter = {point: point}
 
 external asTooltipPointFormatter: Js_OO.Callback.arity1<'a> => nodeFormatter => string = "%identity"
@@ -28,6 +30,7 @@ type x = int
 type nodeDataLabels = {
   align: align,
   x: x,
+  name: int,
 }
 
 type node = {

--- a/src/screens/NewAnalytics/Graphs/SankyGraph/SankeyGraphUtils.res
+++ b/src/screens/NewAnalytics/Graphs/SankyGraph/SankeyGraphUtils.res
@@ -3,7 +3,9 @@ open SankeyGraphTypes
 let valueFormatter = (
   @this
   (this: nodeFormatter) => {
-    let label = `<span style="font-size: 15px; font-weight: bold;">${this.point.sum}</span><br/> <span style="font-size: 13px;">${this.point.id}</span>`
+    let weight = this.point.options.dataLabels.name
+    let sum = weight->Int.toFloat->NewAnalyticsUtils.valueFormatter(Volume)
+    let label = `<span style="font-size: 15px; font-weight: bold;">${sum}</span><br/> <span style="font-size: 13px;">${this.point.id}</span>`
     label
   }
 )->asTooltipPointFormatter

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycle.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsLifeCycle/PaymentsLifeCycle.res
@@ -25,6 +25,7 @@ let make = (
   let isSmartRetryEnabled = filterValueJson->getString("is_smart_retry_enabled", "true")
 
   let getPaymentLieCycleData = async () => {
+    setScreenState(_ => PageLoaderWrapper.Loading)
     try {
       let url = getURL(~entityName=ANALYTICS_SANKEY, ~methodType=Post)
       let paymentLifeCycleBody =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
sankey values normalizarion so when values are too high the graph wont break and ui fixes 

before
<img width="581" alt="Screenshot 2024-11-12 at 6 20 24 PM" src="https://github.com/user-attachments/assets/1892eb6d-92f3-4173-95bb-825f67bd709c">
after 
<img width="582" alt="Screenshot 2024-11-12 at 6 19 27 PM" src="https://github.com/user-attachments/assets/447adb59-7c81-4e6a-a896-e0ee2f018f6e">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
sakey shoudn't break for large values and on date range the graph shoud't break
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
