### PR TITLE
fix: payment processed USD string fix

### DIFF
--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
@@ -109,10 +109,17 @@ module PaymentsProcessedHeader = {
       setGranularity(_ => value)
     }
 
+    let metricType = switch selectedMetric.value->getVariantValueFromString {
+    | Payment_Processed_Amount => Amount
+    | _ => Volume
+    }
+
+    let suffix = metricType == Amount ? "USD" : ""
+
     <div className="w-full px-7 py-8 grid grid-cols-1">
       <div className="flex gap-2 items-center">
         <div className="text-3xl font-600">
-          {`${primaryValue->valueFormatter(Amount)} USD`->React.string} // TODO:Currency need to be picked from filter
+          {`${primaryValue->valueFormatter(metricType)} ${suffix}`->React.string} // TODO:Currency need to be picked from filter
         </div>
         <RenderIf condition={comparison == EnableComparison}>
           <StatisticsCard value direction />

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedUtils.res
@@ -72,6 +72,13 @@ let paymentsProcessedMapper = (
   let title = {
     text: "Payments Processed",
   }
+
+  open NewAnalyticsTypes
+  let metricType = switch xKey->getVariantValueFromString {
+  | Payment_Processed_Amount => Amount
+  | _ => Volume
+  }
+
   {
     categories: primaryCategories,
     data: lineGraphData,
@@ -80,7 +87,7 @@ let paymentsProcessedMapper = (
     tooltipFormatter: tooltipFormatter(
       ~secondaryCategories,
       ~title="Payments Processed",
-      ~metricType=Amount,
+      ~metricType,
       ~comparison,
     ),
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
USD string fix when count is selected 
<img width="991" alt="Screenshot 2024-11-12 at 6 48 33 PM" src="https://github.com/user-attachments/assets/584fb354-3ce2-4988-9570-1bdf2945a4a9">
<img width="979" alt="Screenshot 2024-11-12 at 6 48 40 PM" src="https://github.com/user-attachments/assets/b272965b-171b-4326-8648-21151f0893d0">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the USD string should show only when amount tab is selected and for Count is should not come
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
