### PR TITLE
ci: git checkout token for open source contribution

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -30,13 +30,13 @@ echo
 echo "*****~~~~~ Commit message validation! ~~~~~*****"
 echo
 # Define your commit message convention (e.g., starts with "feat:", "fix:", etc.)
-commit_regex="^(Merge branch|(feat|fix|chore|refactor|docs|test|style|enhancement):).+"
+commit_regex="^(Merge branch|(feat|fix|chore|refactor|docs|test|style|enhancement|ci):).+"
 
 
 
 if ! echo "$commit_msg" | grep -Ei "$commit_regex" ; then
     echo "Aborting commit. Your commit message does not follow the conventional format."
-    echo "The commit message should begin with one of the following keywords followed by a colon: 'feat', 'fix', 'chore', 'refactor', 'docs', 'test' or 'style'. For example, it should be formatted like this: 'feat: <subject> - <description>'"
+    echo "The commit message should begin with one of the following keywords followed by a colon: 'feat', 'fix', 'chore', 'refactor', 'docs', 'test', 'ci' or 'style'. For example, it should be formatted like this: 'feat: <subject> - <description>'"
     exit 1
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_RELEASE_PAT || github.token }}
 
       - name: "Setup node"
         uses: actions/setup-node@v4

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.AUTO_RELEASE_PAT }}
+          token: ${{ secrets.AUTO_RELEASE_PAT || github.token }}
 
       - name: Clear Docker cache
         run: |

--- a/.github/workflows/eslint-check.yml
+++ b/.github/workflows/eslint-check.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_RELEASE_PAT || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/pr-title-spell-check.yml
+++ b/.github/workflows/pr-title-spell-check.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_RELEASE_PAT || github.token }}
 
       - name: Store PR title in a file
         shell: bash

--- a/.github/workflows/release-stable-version.yml
+++ b/.github/workflows/release-stable-version.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_RELEASE_PAT || github.token }}
 
       - name: Check if the input is valid CalVer tag
         shell: bash


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

For Open Source contribution we were not able to run checks as it's showing unable to checkout the code.

## How did you test it?

Will test this after merging the PR and make sure it works.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
