### PR TITLE
fix: list profile api

### DIFF
--- a/src/screens/OMPSwitch/ProfileSwitch.res
+++ b/src/screens/OMPSwitch/ProfileSwitch.res
@@ -202,9 +202,7 @@ let make = () => {
   }
 
   React.useEffect(() => {
-    if businessProfiles->Array.length !== 0 {
-      getProfileList()->ignore
-    }
+    getProfileList()->ignore
     None
   }, [businessProfiles])
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
bugfix in case of user does not have access to connector module, list profile api is not getting called due to condition of non empty business profiles

## Motivation and Context

bugfix

## How did you test it?

- check list profile api should call at least once on homepage to load profile dropdown options
- it might get called a couple of times due to dependency on other variables



## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
