### PR TITLE
chore: removing api call not required on sdk page

### DIFF
--- a/src/screens/SDKPayment/WebSDK.res
+++ b/src/screens/SDKPayment/WebSDK.res
@@ -206,16 +206,6 @@ module CheckoutForm = {
       setBtnState(_ => Button.Normal)
     }
 
-    React.useEffect(() => {
-      hyper.retrievePaymentIntent(clientSecret)
-      ->then(_ => {
-        resolve()
-      })
-      ->ignore
-
-      None
-    }, [hyper])
-
     <div>
       {switch paymentStatus {
       | LOADING => <Loader />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removing this unnecessary api call in sdk page

Before
![image](https://github.com/user-attachments/assets/6a42fb9e-aafc-4ee0-89e4-a2d564faa905)

After
![image](https://github.com/user-attachments/assets/731c48a7-e075-4c63-9453-1df8b84d00f8)
![image](https://github.com/user-attachments/assets/24d009e7-dad4-4d47-9242-b1a7493c2ba2)



## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- go to sdk page
- try making a test payment 
- it should be successful

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
