### PR TITLE
fix: filter sessionized metrics

### DIFF
--- a/src/screens/Analytics/AnalyticsUtils.res
+++ b/src/screens/Analytics/AnalyticsUtils.res
@@ -785,3 +785,12 @@ type getFilters = {
   endTime: string,
   filterValueFromUrl?: JSON.t,
 }
+
+let filterMetrics = metrics => {
+  metrics->Array.filter(ele => {
+    let metricName = ele->getDictFromJsonObject->getString("name", "")
+    !String.includes(metricName, "sessionized") &&
+    metricName != "failure_reasons" &&
+    metricName != "payments_distribution"
+  })
+}

--- a/src/screens/Analytics/DisputeAnalytics/DisputeAnalytics.res
+++ b/src/screens/Analytics/DisputeAnalytics/DisputeAnalytics.res
@@ -16,7 +16,12 @@ let make = () => {
     try {
       let infoUrl = getURL(~entityName=ANALYTICS_DISPUTES, ~methodType=Get, ~id=Some("dispute"))
       let infoDetails = await fetchDetails(infoUrl)
-      setMetrics(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("metrics", []))
+      let metrics =
+        infoDetails
+        ->getDictFromJsonObject
+        ->getArrayFromDict("metrics", [])
+        ->AnalyticsUtils.filterMetrics
+      setMetrics(_ => metrics)
       setDimensions(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("dimensions", []))
       setScreenState(_ => PageLoaderWrapper.Success)
     } catch {

--- a/src/screens/Analytics/PaymentsAnalytics/PaymentAnalytics.res
+++ b/src/screens/Analytics/PaymentsAnalytics/PaymentAnalytics.res
@@ -29,12 +29,7 @@ let make = () => {
         infoDetails
         ->getDictFromJsonObject
         ->getArrayFromDict("metrics", [])
-        ->Array.filter(ele => {
-          let metricName = ele->getDictFromJsonObject->getString("name", "")
-          !String.includes(metricName, "sessionized") &&
-          metricName != "failure_reasons" &&
-          metricName != "payments_distribution"
-        })
+        ->AnalyticsUtils.filterMetrics
       setMetrics(_ => ignoreSessionizedPayment)
       setDimensions(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("dimensions", []))
       setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/screens/Analytics/RefundsAnalytics/RefundsAnalytics.res
+++ b/src/screens/Analytics/RefundsAnalytics/RefundsAnalytics.res
@@ -16,7 +16,12 @@ let make = () => {
     try {
       let infoUrl = getURL(~entityName=ANALYTICS_REFUNDS, ~methodType=Get, ~id=Some(domain))
       let infoDetails = await fetchDetails(infoUrl)
-      setMetrics(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("metrics", []))
+      let metrics =
+        infoDetails
+        ->getDictFromJsonObject
+        ->getArrayFromDict("metrics", [])
+        ->AnalyticsUtils.filterMetrics
+      setMetrics(_ => metrics)
       setDimensions(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("dimensions", []))
       setScreenState(_ => PageLoaderWrapper.Success)
     } catch {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
filtering out the sessionized metircs for refunds and disputes page 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the metrics list shoud not contain sessionized metiics in refunds and dispute analytics page 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
