### PR TITLE
fix: default routing connector list extraction changes

### DIFF
--- a/src/screens/Routing/DefaultRouting.res
+++ b/src/screens/Routing/DefaultRouting.res
@@ -27,12 +27,13 @@ let make = (
         value->getDictFromJsonObject->getString("profile_id", "") === profile
       )
 
-    let connectors =
-      profileList
-      ->Array.get(0)
-      ->Option.getOr(JSON.Encode.null)
+    let connectors = switch profileList->Array.get(0) {
+    | Some(json) =>
+      json
       ->getDictFromJsonObject
       ->getArrayFromDict("connectors", [])
+    | _ => routingRespArray
+    }
 
     let gatewayConnectors = connectors->Array.filter(connectorsItem => {
       connectorList->Array.some(connectorListItem => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
chaneged the connector list extraction chanes for default routing for new change and fallback for older code as well

![Screenshot 2024-11-19 at 3 53 58 PM](https://github.com/user-attachments/assets/ed9a125e-ac37-48c2-aa3f-d334d3a3e9ac)
![Screenshot 2024-11-19 at 3 55 03 PM](https://github.com/user-attachments/assets/7584ba35-ca50-46c4-ba24-160439f410ee)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the connector list for default routing should come for old code as well as new changes as well where coneecotr list inside profile id object or connector list direct array 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
