### PR TITLE
fix: Customer ID remove key

### DIFF
--- a/src/screens/Disputes/DisputesUtils.res
+++ b/src/screens/Disputes/DisputesUtils.res
@@ -184,7 +184,7 @@ let itemToObjMapper = dict => {
   }
 }
 
-let initialFilters = (json, filtervalues, _) => {
+let initialFilters = (json, filtervalues, _, _, _) => {
   let connectorFilter = filtervalues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
 
   let filterDict = json->getDictFromJsonObject

--- a/src/screens/HSwitchRemoteFilter.res
+++ b/src/screens/HSwitchRemoteFilter.res
@@ -161,7 +161,7 @@ module RemoteTableFilters = {
 
     let getURL = useGetURL()
     let {userInfo: transactionEntity} = React.useContext(UserInfoProvider.defaultContext)
-    let {removeKeys} = React.useContext(FilterContext.filterContext)
+    let {removeKeys, filterKeys, setfilterKeys} = React.useContext(FilterContext.filterContext)
     let {filterValue, updateExistingKeys, filterValueJson, reset} =
       FilterContext.filterContext->React.useContext
     let defaultFilters = {""->JSON.Encode.string}
@@ -265,7 +265,7 @@ module RemoteTableFilters = {
       ->Dict.fromArray
 
     let remoteFilters = React.useMemo(() => {
-      filterData->initialFilters(getAllFilter, removeKeys)
+      filterData->initialFilters(getAllFilter, removeKeys, filterKeys, setfilterKeys)
     }, [getAllFilter])
 
     let initialDisplayFilters =

--- a/src/screens/Order/OrderUIUtils.res
+++ b/src/screens/Order/OrderUIUtils.res
@@ -273,7 +273,7 @@ let itemToObjMapper = dict => {
   }
 }
 
-let initialFilters = (json, filtervalues, removeKeys) => {
+let initialFilters = (json, filtervalues, removeKeys, filterKeys, setfilterKeys) => {
   open LogicUtils
 
   let connectorFilter = filtervalues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
@@ -283,6 +283,7 @@ let initialFilters = (json, filtervalues, removeKeys) => {
   let arr = filterDict->Dict.keysToArray
   let onDeleteClick = name => {
     [name]->removeKeys
+    setfilterKeys(_ => filterKeys->Array.filter(item => item !== name))
   }
   if connectorFilter->Array.length !== 0 {
     arr->Array.push("connector_label")

--- a/src/screens/Payouts/PayoutsUtils.res
+++ b/src/screens/Payouts/PayoutsUtils.res
@@ -130,7 +130,7 @@ let getOptionsForPayoutFilters = (dict, filterValues) => {
   newArr
 }
 
-let initialFilters = (json, _, _) => {
+let initialFilters = (json, _, _, _, _) => {
   open LogicUtils
 
   let dropdownValue =

--- a/src/screens/Refunds/RefundUtils.res
+++ b/src/screens/Refunds/RefundUtils.res
@@ -185,7 +185,7 @@ let itemToObjMapper = dict => {
   }
 }
 
-let initialFilters = (json, filtervalues, _) => {
+let initialFilters = (json, filtervalues, _, _, _) => {
   open LogicUtils
 
   let connectorFilter = filtervalues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Fixed issue where removing the customer_id filter cleared all other applied filters.
- The change ensures that only the customer_id filter is removed, while the other filters remain applied and visible.


https://github.com/user-attachments/assets/18c6cb3d-73c2-4eb9-8c26-90899f65412c


## Motivation and Context

User experience

## How did you test it?

Attached video

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
