### PR TITLE
chore: url path after OMP switch

### DIFF
--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -129,6 +129,7 @@ let make = () => {
   let fetchDetails = useGetMethod()
   let showToast = ToastState.useShowToast()
   let merchSwitch = OMPSwitchHooks.useMerchantSwitch()
+  let url = RescriptReactRouter.useUrl()
   let {userInfo: {merchantId}} = React.useContext(UserInfoProvider.defaultContext)
   let (showModal, setShowModal) = React.useState(_ => false)
   let (merchantList, setMerchantList) = Recoil.useRecoilState(HyperswitchAtom.merchantListAtom)
@@ -152,6 +153,7 @@ let make = () => {
     try {
       setShowSwitchingMerch(_ => true)
       let _ = await merchSwitch(~expectedMerchantId=value, ~currentMerchantId=merchantId)
+      RescriptReactRouter.replace(GlobalVars.extractModulePath(url))
       setShowSwitchingMerch(_ => false)
     } catch {
     | _ => {

--- a/src/screens/OMPSwitch/OrgSwitch.res
+++ b/src/screens/OMPSwitch/OrgSwitch.res
@@ -8,6 +8,7 @@ let make = () => {
   let fetchDetails = useGetMethod()
   let showToast = ToastState.useShowToast()
   let orgSwitch = OMPSwitchHooks.useOrgSwitch()
+  let url = RescriptReactRouter.useUrl()
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let {userInfo: {orgId}} = React.useContext(UserInfoProvider.defaultContext)
   let (orgList, setOrgList) = Recoil.useRecoilState(HyperswitchAtom.orgListAtom)
@@ -37,6 +38,7 @@ let make = () => {
     try {
       setShowSwitchingOrg(_ => true)
       let _ = await orgSwitch(~expectedOrgId=value, ~currentOrgId=orgId)
+      RescriptReactRouter.replace(GlobalVars.extractModulePath(url))
       setShowSwitchingOrg(_ => false)
     } catch {
     | _ => {

--- a/src/screens/OMPSwitch/ProfileSwitch.res
+++ b/src/screens/OMPSwitch/ProfileSwitch.res
@@ -152,6 +152,7 @@ let make = () => {
   let fetchDetails = useGetMethod()
   let showToast = ToastState.useShowToast()
   let profileSwitch = OMPSwitchHooks.useProfileSwitch()
+  let url = RescriptReactRouter.useUrl()
   let (showModal, setShowModal) = React.useState(_ => false)
   let {userInfo: {profileId}} = React.useContext(UserInfoProvider.defaultContext)
   let (profileList, setProfileList) = Recoil.useRecoilState(HyperswitchAtom.profileListAtom)
@@ -175,11 +176,12 @@ let make = () => {
   let addItemBtnStyle = "border border-t-0 w-full"
   let customScrollStyle = "max-h-72 overflow-scroll px-1 pt-1 border border-b-0"
   let dropdownContainerStyle = "min-w-[15rem] rounded-md border border-1"
+
   let profileSwitch = async value => {
     try {
       setShowSwitchingProfile(_ => true)
       let _ = await profileSwitch(~expectedProfileId=value, ~currentProfileId=profileId)
-      RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/home"))
+      RescriptReactRouter.replace(GlobalVars.extractModulePath(url))
       setShowSwitchingProfile(_ => false)
     } catch {
     | _ => {

--- a/src/utils/GlobalVars.res
+++ b/src/utils/GlobalVars.res
@@ -29,6 +29,15 @@ let appendDashboardPath = (~url) => {
   }
 }
 
+let extractModulePath = (url: RescriptReactRouter.url) => {
+  let currentPathList = url.path->List.toArray
+  let path = switch currentPathList->Array.get(0) {
+  | Some("dashboard") => currentPathList->Array.slice(~start=0, ~end=2)->Array.joinWith("/")
+  | _ => currentPathList->LogicUtils.getValueFromArray(0, "home")
+  }
+  appendTrailingSlash(path)
+}
+
 type hostType = Live | Sandbox | Local | Integ
 
 let hostName = Window.Location.hostname

--- a/src/utils/GlobalVars.res
+++ b/src/utils/GlobalVars.res
@@ -11,7 +11,8 @@ type appEnv = [#production | #sandbox | #integration | #development]
 let isLocalhost =
   Window.Location.hostname === "localhost" || Window.Location.hostname === "127.0.0.1"
 
-let dashboardBasePath = Some("/dashboard")
+let dashboardPrefix = "dashboard"
+let dashboardBasePath = Some(`/${dashboardPrefix}`)
 
 let appendTrailingSlash = url => {
   url->String.startsWith("/") ? url : `/${url}`
@@ -31,11 +32,13 @@ let appendDashboardPath = (~url) => {
 
 let extractModulePath = (url: RescriptReactRouter.url) => {
   let currentPathList = url.path->List.toArray
-  let path = switch currentPathList->Array.get(0) {
-  | Some("dashboard") => currentPathList->Array.slice(~start=0, ~end=2)->Array.joinWith("/")
-  | _ => currentPathList->LogicUtils.getValueFromArray(0, "home")
+
+  let modulePath = if currentPathList->Array.includes(dashboardPrefix) {
+    currentPathList->Array.slice(~start=0, ~end=2)->Array.joinWith("/")->appendTrailingSlash
+  } else {
+    currentPathList->Array.slice(~start=0, ~end=1)->Array.joinWith("/")->appendTrailingSlash
   }
-  appendTrailingSlash(path)
+  modulePath
 }
 
 type hostType = Live | Sandbox | Local | Integ


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
currently on profile switch user is always redirected to home page
with this change - on profile switch the user will land on the same subsection link 

for org and merchant switch 
currently: for the url that does not exist it shows error page and for others it goes to  home page
with this change: same behaviour as on profile switch (will land on the same subsection link )

suppose url is `/payments/pay_eHqoQH7t3efEazeiEXu2/pro_IJGV7MaFtoDvI9P5Ri0h` it will be redirected to `/payments`
and so on, this ensures that user does not see any error and still remains under same module after switch

## Motivation and Context

improving user experience

## How did you test it?

- observe url changes on different pages on profile switch

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
