### PR TITLE
fix: error on sdk page when no payment connector connected

### DIFF
--- a/src/screens/SDKPayment/SDKPage.res
+++ b/src/screens/SDKPayment/SDKPage.res
@@ -86,6 +86,10 @@ let make = () => {
     defaultBusinessProfile->SDKPaymentUtils.initialValueForForm
   )
   let connectorList = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
+
+  let filterConnectorList =
+    connectorList->RoutingUtils.filterConnectorList(~retainInList=PaymentConnector)
+
   React.useEffect(() => {
     let paymentIntentOptional = filtersFromUrl->Dict.get("payment_intent_client_secret")
     if paymentIntentOptional->Option.isSome {
@@ -153,7 +157,7 @@ let make = () => {
               initialValues
             />
           </div>
-        } else if connectorList->Array.length <= 0 {
+        } else if filterConnectorList->Array.length <= 0 {
           <HelperComponents.BluredTableComponent
             infoText={"Connect to a payment processor to make your first payment"}
             buttonText={"Connect a connector"}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

error on sdk page when no payment connector connected but other category connector are connected

current 
![image](https://github.com/user-attachments/assets/0fa63871-f8eb-4244-99d4-c63858257eb7)

fixed
![image](https://github.com/user-attachments/assets/4c1948a2-3b74-49ee-9db9-751628b23d06)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- connect any connector other than payment connector (eg FRM, 3ds)
- go to sdk page to try a test payment
- it should show connect a new connector screen

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
