### PR TITLE
fix: analytics refunds amount usd conversion fix

### DIFF
--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSection.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSection.res
@@ -79,7 +79,7 @@ let make = (~entity: moduleEntity) => {
       let primaryResponseDisputes = await updateDetails(disputesUrl, primaryBodyDisputes, Post)
 
       let primaryDataPayments = primaryResponsePayments->parseResponse("metaData")
-      let primaryDataRefunds = primaryResponseRefunds->parseResponse("queryData")
+      let primaryDataRefunds = primaryResponseRefunds->parseResponse("metaData")
       let primaryDataDisputes = primaryResponseDisputes->parseResponse("queryData")
 
       primaryData->setValue(
@@ -94,7 +94,7 @@ let make = (~entity: moduleEntity) => {
         ],
       )
 
-      primaryData->setValue(~data=primaryDataRefunds, ~ids=[Refund_Processed_Amount])
+      primaryData->setValue(~data=primaryDataRefunds, ~ids=[Total_Refund_Processed_Amount])
       primaryData->setValue(~data=primaryDataDisputes, ~ids=[Total_Dispute])
 
       let secondaryBodyPayments = getPayload(
@@ -137,7 +137,7 @@ let make = (~entity: moduleEntity) => {
           )
 
           let secondaryDataPayments = secondaryResponsePayments->parseResponse("metaData")
-          let secondaryDataRefunds = secondaryResponseRefunds->parseResponse("queryData")
+          let secondaryDataRefunds = secondaryResponseRefunds->parseResponse("metaData")
           let secondaryDataDisputes = secondaryResponseDisputes->parseResponse("queryData")
 
           secondaryData->setValue(
@@ -152,7 +152,7 @@ let make = (~entity: moduleEntity) => {
             ],
           )
 
-          secondaryData->setValue(~data=secondaryDataRefunds, ~ids=[Refund_Processed_Amount])
+          secondaryData->setValue(~data=secondaryDataRefunds, ~ids=[Total_Refund_Processed_Amount])
           secondaryData->setValue(~data=secondaryDataDisputes, ~ids=[Total_Dispute])
           secondaryData->JSON.Encode.object
         }
@@ -195,7 +195,9 @@ let make = (~entity: moduleEntity) => {
         <OverViewStat
           data responseKey={Total_Payment_Processed_Amount->getKeyForModule(~metricType)}
         />
-        <OverViewStat data responseKey={Refund_Processed_Amount->getKeyForModule(~metricType)} />
+        <OverViewStat
+          data responseKey={Total_Refund_Processed_Amount->getKeyForModule(~metricType)}
+        />
         <OverViewStat data responseKey={Total_Dispute->getKeyForModule(~metricType)} />
       </div>
     </div>

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionTypes.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionTypes.res
@@ -5,7 +5,7 @@ type overviewColumns =
   | Total_Success_Rate_Without_Smart_Retries
   | Total_Payment_Processed_Amount
   | Total_Payment_Processed_Amount_Without_Smart_Retries
-  | Refund_Processed_Amount
+  | Total_Refund_Processed_Amount
   | Total_Dispute
 
 type dataObj = {
@@ -17,7 +17,7 @@ type dataObj = {
   total_payment_processed_count: int,
   total_payment_processed_amount_without_smart_retries_in_usd: float,
   total_payment_processed_count_without_smart_retries: int,
-  refund_processed_amount: float,
+  total_refund_processed_amount_in_usd: float,
   total_dispute: int,
 }
 

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
@@ -8,7 +8,7 @@ let getStringFromVariant = value => {
   | Total_Success_Rate_Without_Smart_Retries => "total_success_rate_without_smart_retries"
   | Total_Payment_Processed_Amount => "total_payment_processed_amount_in_usd"
   | Total_Payment_Processed_Amount_Without_Smart_Retries => "total_payment_processed_amount_without_smart_retries_in_usd"
-  | Refund_Processed_Amount => "refund_processed_amount"
+  | Total_Refund_Processed_Amount => "total_refund_processed_amount_in_usd"
   | Total_Dispute => "total_dispute"
   }
 }
@@ -23,7 +23,7 @@ let defaultValue =
     total_payment_processed_count: 0,
     total_payment_processed_amount_without_smart_retries_in_usd: 0.0,
     total_payment_processed_count_without_smart_retries: 0,
-    refund_processed_amount: 0.0,
+    total_refund_processed_amount_in_usd: 0.0,
     total_dispute: 0,
   }
   ->Identity.genericTypeToJson
@@ -63,7 +63,8 @@ let setValue = (dict, ~data, ~ids: array<overviewColumns>) => {
     | Total_Smart_Retried_Amount
     | Total_Smart_Retried_Amount_Without_Smart_Retries
     | Total_Payment_Processed_Amount
-    | Total_Payment_Processed_Amount_Without_Smart_Retries =>
+    | Total_Payment_Processed_Amount_Without_Smart_Retries
+    | Total_Refund_Processed_Amount =>
       data->getAmountValue(~id=id->getStringFromVariant)->JSON.Encode.float
     | _ =>
       data
@@ -92,7 +93,7 @@ let getInfo = (~responseKey: overviewColumns) => {
       description: "The total amount of payments processed in the selected time range",
       valueType: Amount,
     }
-  | Refund_Processed_Amount => {
+  | Total_Refund_Processed_Amount => {
       titleText: "Total Refunds Processed",
       description: "The total amount of refund payments processed in the selected time range",
       valueType: Amount,
@@ -123,7 +124,7 @@ let getKeyForModule = (field, ~metricType) => {
   | (Total_Success_Rate, Default) => Total_Success_Rate_Without_Smart_Retries
   | (Total_Payment_Processed_Amount, Default) =>
     Total_Payment_Processed_Amount_Without_Smart_Retries
-  | (Refund_Processed_Amount, _) => Refund_Processed_Amount
+  | (Total_Refund_Processed_Amount, _) => Total_Refund_Processed_Amount
   | (Total_Dispute, _) | _ => Total_Dispute
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
picking from refunds amount from metadat rather than from query data for correct value display 
<img width="244" alt="Screenshot 2024-11-20 at 8 20 03 PM" src="https://github.com/user-attachments/assets/c6e4bc55-9c15-4699-92f4-8c6563c5c012">
<img width="430" alt="Screenshot 2024-11-20 at 8 20 12 PM" src="https://github.com/user-attachments/assets/820a91ea-1561-49f3-9dbb-e2ca278dfe8c">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the refunds amoutn displayed in the analytics overview section should be in USD 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
