### PR TITLE
chore: enable we domain for fiuu apple pay

### DIFF
--- a/src/screens/Connectors/ConnectorMetaData/ApplePay/ApplePayIntegration.res
+++ b/src/screens/Connectors/ConnectorMetaData/ApplePay/ApplePayIntegration.res
@@ -114,7 +114,8 @@ module Landing = {
       {switch connector->ConnectorUtils.getConnectorNameTypeFromString {
       | Processors(STRIPE)
       | Processors(BANKOFAMERICA)
-      | Processors(CYBERSOURCE) =>
+      | Processors(CYBERSOURCE)
+      | Processors(FIUU) =>
         <div
           className="p-6 m-2 cursor-pointer"
           onClick={_ => setApplePayIntegrationType(_ => #simplified)}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

enabling web domain for fiuu processor 

![image](https://github.com/user-attachments/assets/92f227d0-d430-4a66-a81c-5d7dde8aa8a0)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- go to connectors
- start configure fiuu
- on payment methods page, go to apple pay
- able to proceed with web domain

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
