### PR TITLE
fix: Horizontal Scrollbar to Tables

### DIFF
--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -888,7 +888,22 @@ let make = (
       ? ""
       : "overflow-scroll"
   let parentBorderRadius = !isHighchartLegend ? "rounded-lg" : ""
+  let sidebarScrollbarCss = `
+      @supports (-webkit-appearance: none) {
+        .sidebar-scrollbar {
+          scrollbar-color: #8a8c8f;
+        }
 
+        .sidebar-scrollbar::-webkit-scrollbar-thumb {
+          background-color: #8a8c8f;
+          border-radius: 3px;
+        }
+
+        .sidebar-scrollbar::-webkit-scrollbar-track {
+          display: none;
+        }
+      }
+    `
   <div
     className={`flex flex-row items-stretch ${scrollBarClass} loadedTable ${parentMinWidthClass} ${customBorderClass->Option.getOr(
         parentBorderRadius,
@@ -905,8 +920,9 @@ let make = (
     } //replaced "overflow-auto" -> to be tested with master
   >
     <RenderIf condition={frozenUpto > 0}> {frozenTable} </RenderIf>
+    <style> {React.string(sidebarScrollbarCss)} </style>
     <div
-      className={`flex-1 ${overflowClass} no-scrollbar ${childMinWidthClass} ${nonFrozenTableParentClass}`}>
+      className={`flex-1 ${overflowClass} no-scrollbar ${childMinWidthClass} ${nonFrozenTableParentClass} sidebar-scrollbar`}>
       nonFrozenTable
     </div>
     {switch customizeColumnNewTheme {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

No visibility of horizontal scrollbar in tables scroll leading to confusion.

## Motivation and Context

Better User experience

## How did you test it?

Tested locally: In Payments , refunds and Disputes , when adding more columns than can fit in the visible area, a horizontal scrollbar appears.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
