### PR TITLE
fix: global search filters access check

### DIFF
--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
@@ -19,6 +19,7 @@ let make = () => {
   let (categorieSuggestionResponse, setCategorieSuggestionResponse) = React.useState(_ =>
     Dict.make()->JSON.Encode.object
   )
+  let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let (searchResults, setSearchResults) = React.useState(_ => [])
   let merchentDetails = HSwitchUtils.useMerchantDetailsValue()
   let isReconEnabled = merchentDetails.recon_status === Active
@@ -148,7 +149,9 @@ let make = () => {
   }, [showModal])
 
   React.useEffect(() => {
-    getCategoryOptions()->ignore
+    if userHasAccess(~groupAccess=AnalyticsView) === Access {
+      getCategoryOptions()->ignore
+    }
 
     let onKeyPress = event => {
       let metaKey = event->ReactEvent.Keyboard.metaKey


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
checking if the user has a acess to view rhe filetrs suggestions on global search 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
if the uer doesn't have a acess he should be shown a suggestions for filters selected 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
