### PR TITLE
fix: date range compare component end time fix 00:00 to 59.59

### DIFF
--- a/src/utils/DateRangeUtils.res
+++ b/src/utils/DateRangeUtils.res
@@ -317,7 +317,7 @@ let getComparisionTimePeriod = (~startDate, ~endDate) => {
   let gap = endingPoint.diff(startingPoint.toString(), "millisecond") // diff between points
 
   let startTimeValue = startingPoint.subtract(gap, "millisecond").toDate()->Date.toISOString
-  let endTimeVal = endingPoint.subtract(gap, "millisecond").toDate()->Date.toISOString
+  let endTimeVal = startingPoint.subtract(1, "millisecond").toDate()->Date.toISOString
 
   (startTimeValue, endTimeVal)
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
date range compare component the end time won't overlap with prumary date range start value now 
<img width="534" alt="Screenshot 2024-11-29 at 1 38 48 PM" src="https://github.com/user-attachments/assets/83005283-e6fe-4425-a2c0-76b87c4db358">
<img width="540" alt="Screenshot 2024-11-29 at 1 49 50 PM" src="https://github.com/user-attachments/assets/a5afbac6-3dd3-453b-b27e-55bfe77b318a">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the date range should remains between primary and secondary and the end time of compare should not overlap with start time of primary date 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
