### PR TITLE
fix: new analytics api repeated fix

### DIFF
--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSection.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSection.res
@@ -172,7 +172,7 @@ let make = (~entity: moduleEntity) => {
       getData()->ignore
     }
     None
-  }, (startTimeVal, endTimeVal, compareToStartTime, compareToEndTime, comparison))
+  }, (compareToStartTime, compareToEndTime, comparison))
 
   let mockDelay = async () => {
     if data != []->JSON.Encode.array {

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
@@ -278,7 +278,7 @@ let make = (
       getPaymentsProcessed()->ignore
     }
     None
-  }, (startTimeVal, endTimeVal, compareToStartTime, compareToEndTime, comparison))
+  }, (compareToStartTime, compareToEndTime, comparison))
 
   let mockDelay = async () => {
     if paymentsProcessedData != []->JSON.Encode.array {

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsSuccessRate/PaymentsSuccessRate.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsSuccessRate/PaymentsSuccessRate.res
@@ -181,7 +181,7 @@ let make = (
       getPaymentsSuccessRate()->ignore
     }
     None
-  }, (startTimeVal, endTimeVal, compareToStartTime, compareToEndTime, comparison))
+  }, (compareToStartTime, compareToEndTime, comparison))
 
   let mockDelay = async () => {
     if paymentsSuccessRateData != []->JSON.Encode.array {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
when api is beign called two times with same payload wherever the module which has a dependency on comparision range
even thoutgh the comparision is diabled the comparision date ranges do updated when primary date range is changes 
<img width="483" alt="image" src="https://github.com/user-attachments/assets/5bd0a4f2-ff6f-4c40-a0bf-d6e53352391a">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the api should be called once the comparision is disabled or enabled 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
