### PR TITLE
fix: refunds amount overview fix

### DIFF
--- a/src/screens/Analytics/RefundsAnalytics/RefundsAnalyticsEntity.res
+++ b/src/screens/Analytics/RefundsAnalytics/RefundsAnalyticsEntity.res
@@ -116,7 +116,7 @@ let singleStateItemToObjMapper = json => {
     refund_success_rate: dict->getFloat("refund_success_rate", 0.0),
     refund_count: dict->getInt("refund_count", 0),
     refund_success_count: dict->getInt("refund_success_count", 0),
-    refund_processed_amount: dict->getFloat("refund_processed_amount", 0.0),
+    refund_processed_amount: dict->getFloat("refund_processed_amount_in_usd", 0.0),
   })
   ->Option.getOr({
     singleStateInitialValue
@@ -139,7 +139,28 @@ let singleStateSeriesItemToObjMapper = json => {
 }
 
 let itemToObjMapper = json => {
-  json->getQueryData->Array.map(json => singleStateItemToObjMapper(json))
+  let refund_count = ref(0)
+  let refund_processed_amount = ref(0.0)
+  let refund_success_count = ref(0)
+  let refund_success_rate = ref(0.0)
+
+  let dataObj = json->getQueryData->Array.map(json => singleStateItemToObjMapper(json))
+
+  dataObj->Array.forEach(item => {
+    refund_count := refund_count.contents + item.refund_count
+    refund_processed_amount := refund_processed_amount.contents +. item.refund_processed_amount
+    refund_success_count := refund_success_count.contents + item.refund_success_count
+    refund_success_rate := refund_success_rate.contents +. item.refund_success_rate
+  })
+
+  [
+    {
+      refund_success_rate: refund_success_rate.contents,
+      refund_count: refund_count.contents,
+      refund_success_count: refund_success_count.contents,
+      refund_processed_amount: refund_processed_amount.contents,
+    },
+  ]
 }
 
 let timeSeriesObjMapper = json =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
cause of BE default group by currency the old analytics overview section was breaking cause of two reponse object , fixed this issue in this pr 
<img width="619" alt="Screenshot 2024-12-02 at 10 24 33 PM" src="https://github.com/user-attachments/assets/d778fc5b-1bb2-4a91-acf3-5ef159fc954c">

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the values should be populated for all the metrics in the refunds analytics page 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
