### PR TITLE
chore: hiding org merchant dropdown for internal user

### DIFF
--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -83,8 +83,10 @@ let make = () => {
 
   let ompDropdowns =
     <div className="flex items-center gap-4 mx-4">
-      <MerchantSwitch />
-      <p className="text-gray-400 text-fs-14"> {"/"->React.string} </p>
+      <RenderIf condition={!isInternalUser}>
+        <MerchantSwitch />
+        <p className="text-gray-400 text-fs-14"> {"/"->React.string} </p>
+      </RenderIf>
       <ProfileSwitch />
     </div>
 
@@ -114,9 +116,9 @@ let make = () => {
                         headerActions={<div className="relative flex space-around gap-4 my-2 ">
                           <div className="flex gap-4">
                             <GlobalSearchBar />
-                            // <RenderIf condition={isInternalUser}>      // to be removed later
-                            //   <SwitchMerchantForInternal />
-                            // </RenderIf>
+                            <RenderIf condition={isInternalUser}>
+                              <SwitchMerchantForInternal />
+                            </RenderIf>
                             <div
                               className={`px-4 py-2 rounded whitespace-nowrap text-fs-13 ${modeStyles} font-semibold`}>
                               {modeText->React.string}

--- a/src/screens/Sidebar/Sidebar.res
+++ b/src/screens/Sidebar/Sidebar.res
@@ -457,8 +457,8 @@ let make = (
   let isMobileView = MatchMedia.useMobileChecker()
   let sideBarRef = React.useRef(Nullable.null)
   let {email} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
-  // let {userInfo: {roleId}} = React.useContext(UserInfoProvider.defaultContext)
-  // let isInternalUser = roleId->HyperSwitchUtils.checkIsInternalUser
+  let {userInfo: {roleId}} = React.useContext(UserInfoProvider.defaultContext)
+  let isInternalUser = roleId->HyperSwitchUtils.checkIsInternalUser
   let (openItem, setOpenItem) = React.useState(_ => "")
   let {isSidebarExpanded, setIsSidebarExpanded} = React.useContext(SidebarProvider.defaultContext)
 
@@ -546,9 +546,9 @@ let make = (
             />
           </div>
         </RenderIf>
-        // <RenderIf condition={!isInternalUser}>  // to be removed later
-        <SidebarSwitch isSidebarExpanded />
-        // </RenderIf>
+        <RenderIf condition={!isInternalUser}>
+          <SidebarSwitch isSidebarExpanded />
+        </RenderIf>
         <div
           className="h-full overflow-y-scroll transition-transform duration-1000 overflow-x-hidden sidebar-scrollbar"
           style={height: `calc(100vh - ${verticalOffset})`}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- org and merchant list api do not support internal user, therefore hiding these dropdown for internal user
![image](https://github.com/user-attachments/assets/25d6db8f-8996-4f5d-a006-742fc2e1a17d)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
