### PR TITLE
fix: Amount Filter bug

### DIFF
--- a/src/screens/Connectors/ConnectorWalletDetails/Paze/PazeIntegration.res
+++ b/src/screens/Connectors/ConnectorWalletDetails/Paze/PazeIntegration.res
@@ -14,7 +14,7 @@ let make = (~connector, ~setShowWalletConfigurationModal, ~update, ~onCloseClick
       ->getDictfromDict("paze")
 
     form.change(
-      "connector_wallets_details.samsung_pay.merchant_credentials",
+      "connector_wallets_details.paze",
       initalFormValue->pazePayRequest->Identity.genericTypeToJson,
     )
   }

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
@@ -94,13 +94,17 @@ let make = (~options) => {
       form.change("end_amount", JSON.Encode.null)
       form.change("amount_option", mappedRange->Identity.genericTypeToJson)
       setSelectedOption(_ => {newValue->mapStringToRange})
+    } else {
+      setIsAmountRangeVisible(_ => true)
     }
   }
 
   let input: ReactFinalForm.fieldRenderPropsInput = {
     name: "amount",
     onBlur: _ => (),
-    onChange: ev => handleInputChange(ev->Identity.formReactEventToString),
+    onChange: ev => {
+      handleInputChange(ev->Identity.formReactEventToString)
+    },
     onFocus: _ => (),
     value: selectedOption->mapRangeTypetoString->JSON.Encode.string,
     checked: true,

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
@@ -12,7 +12,8 @@ let amountFilterOptions: array<FilterSelectBox.dropdownOption> = [
     value: label,
   }
 })
-let encodeFloatOrDefault = val => (val->getFloatFromJson(0.0) *. 100.0)->JSON.Encode.float
+let encodeFloatOrDefault = val =>
+  (val->getFloatFromJson(0.0) *. 100.0)->Float.toFixed->getFloatFromString(0.0)->JSON.Encode.float
 let validateAmount = dict => {
   let sAmntK = dict->getFloat((#start_amount: AmountFilterTypes.amountFilterChild :> string), -1.0)
   let eAmtK = dict->getFloat((#end_amount: AmountFilterTypes.amountFilterChild :> string), -1.0)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Floating-point precision in the amount filter by ensuring consistent scaling and encoding of values. 
Selection of same option again.

https://github.com/user-attachments/assets/93ccdb3e-256c-42ab-aebd-178feff165f4


## Motivation and Context

User experience.

## How did you test it?

Locally.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
