### PR TITLE
fix: handle recon-iframe logout in dashboard

### DIFF
--- a/src/container/MerchantAccountContainer.res
+++ b/src/container/MerchantAccountContainer.res
@@ -83,12 +83,14 @@ let make = (~setAppScreenState) => {
           authorization={userHasResourceAccess(~resourceAccess=ReconConfig)}>
           <ReconModule urlList={url.path->urlPath} />
         </AccessControl>
-      | list{"file-processor"} =>
-        <AccessControl
-          isEnabled={featureFlagDetails.recon && !checkUserEntity([#Profile])}
-          authorization={userHasResourceAccess(~resourceAccess=ReconFiles)}>
-          <ReconModule urlList={url.path->urlPath} />
-        </AccessControl>
+
+      // Commented as not needed now
+      // | list{"file-processor"} =>
+      //   <AccessControl
+      //     isEnabled={featureFlagDetails.recon && !checkUserEntity([#Profile])}
+      //     authorization={userHasResourceAccess(~resourceAccess=ReconFiles)}>
+      //     <ReconModule urlList={url.path->urlPath} />
+      //   </AccessControl>
       | list{"sdk"} =>
         <AccessControl
           isEnabled={!featureFlagDetails.isLiveMode}

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -155,9 +155,11 @@ let make = () => {
                         | list{"recon-analytics"}
                         | list{"reports"}
                         | list{"config-settings"}
-                        | list{"file-processor"}
                         | list{"sdk"} =>
                           <MerchantAccountContainer setAppScreenState=setScreenState />
+                        // Commented as not needed now
+                        // list{"file-processor"}
+
                         | list{"connectors", ..._}
                         | list{"payoutconnectors", ..._}
                         | list{"3ds-authenticators", ..._}

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -600,14 +600,15 @@ let reconConfigurator = {
     searchOptions: [("Recon configurator", "")],
   })
 }
-let reconFileProcessor = {
-  SubLevelLink({
-    name: "File Processor",
-    link: `/file-processor`,
-    access: Access,
-    searchOptions: [("Recon file processor", "")],
-  })
-}
+// Commented as not needed now
+// let reconFileProcessor = {
+//   SubLevelLink({
+//     name: "File Processor",
+//     link: `/file-processor`,
+//     access: Access,
+//     searchOptions: [("Recon file processor", "")],
+//   })
+// }
 
 let reconAndSettlement = (recon, isReconEnabled, checkUserEntity, userHasResourceAccess) => {
   switch (recon, isReconEnabled, checkUserEntity([#Merchant, #Organization])) {
@@ -630,9 +631,10 @@ let reconAndSettlement = (recon, isReconEnabled, checkUserEntity, userHasResourc
       if userHasResourceAccess(~resourceAccess=ReconConfig) == CommonAuthTypes.Access {
         links->Array.push(reconConfigurator)
       }
-      if userHasResourceAccess(~resourceAccess=ReconFiles) == CommonAuthTypes.Access {
-        links->Array.push(reconFileProcessor)
-      }
+      // Commented as not needed now
+      // if userHasResourceAccess(~resourceAccess=ReconFiles) == CommonAuthTypes.Access {
+      //   links->Array.push(reconFileProcessor)
+      // }
       Section({
         name: "Recon And Settlement",
         icon: "recon",

--- a/src/screens/Recon/ReconModule.res
+++ b/src/screens/Recon/ReconModule.res
@@ -47,12 +47,16 @@ let make = (~urlList) => {
 
       let eventType =
         dictFromEvent
-        ->getDictfromDict("data")
+        ->getString("data", "")
+        ->safeParse
+        ->getDictFromJsonObject
         ->getString("event", "")
 
       let status =
         dictFromEvent
-        ->getDictfromDict("data")
+        ->getString("data", "")
+        ->safeParse
+        ->getDictFromJsonObject
         ->getString("AuthenticationStatus", "")
         ->ReconUtils.getAuthStatusFromMessage
 

--- a/src/screens/Recon/ReconModule.res
+++ b/src/screens/Recon/ReconModule.res
@@ -51,6 +51,7 @@ let make = (~urlList) => {
         ->safeParse
         ->getDictFromJsonObject
         ->getString("event", "")
+        ->ReconUtils.getEventTypeFromString
 
       let status =
         dictFromEvent
@@ -60,7 +61,7 @@ let make = (~urlList) => {
         ->getString("AuthenticationStatus", "")
         ->ReconUtils.getAuthStatusFromMessage
 
-      if eventType == "AuthenticationStatus" && status == IframeLoggedOut {
+      if eventType == AuthenticationStatus && status == IframeLoggedOut {
         handleLogout()->ignore
       }
     }

--- a/src/screens/Recon/ReconTypes.res
+++ b/src/screens/Recon/ReconTypes.res
@@ -1,0 +1,1 @@
+type authStatus = IframeLoggedIn | IframeLoggedOut

--- a/src/screens/Recon/ReconTypes.res
+++ b/src/screens/Recon/ReconTypes.res
@@ -1,1 +1,3 @@
 type authStatus = IframeLoggedIn | IframeLoggedOut
+
+type eventType = AuthenticationStatus

--- a/src/screens/Recon/ReconUtils.res
+++ b/src/screens/Recon/ReconUtils.res
@@ -1,0 +1,6 @@
+open ReconTypes
+let getAuthStatusFromMessage = authStatus =>
+  switch authStatus {
+  | "LoggedOut" => IframeLoggedOut
+  | _ => IframeLoggedIn
+  }

--- a/src/screens/Recon/ReconUtils.res
+++ b/src/screens/Recon/ReconUtils.res
@@ -4,3 +4,10 @@ let getAuthStatusFromMessage = authStatus =>
   | "LoggedOut" => IframeLoggedOut
   | _ => IframeLoggedIn
   }
+
+let getEventTypeFromString = eventTypeString =>
+  switch eventTypeString {
+  | "AuthenticationStatus"
+  | _ =>
+    AuthenticationStatus
+  }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
- URL changes for recon 
- Changes for handling iframe logout


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- Enable recon for a merchant 
- The iframe should be loaded
- when the iframe session is expired the dashboard should be logged out
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
