### PR TITLE
fix: list invitation error on logout from recon

### DIFF
--- a/src/context/AuthInfoProvider.res
+++ b/src/context/AuthInfoProvider.res
@@ -47,7 +47,7 @@ let make = (~children) => {
     | LoggedOut => {
         setAuth(_ => LoggedOut)
         CommonAuthUtils.clearLocalStorage()
-        AuthUtils.redirectToLogin()
+        // AuthUtils.redirectToLogin()
       }
     | CheckingAuthStatus => setAuth(_ => CheckingAuthStatus)
     }

--- a/src/entryPoints/AuthModule/AuthWrapper.res
+++ b/src/entryPoints/AuthModule/AuthWrapper.res
@@ -133,6 +133,7 @@ let make = (~children) => {
   React.useEffect(() => {
     if authStatus === LoggedOut {
       getAuthMethods()->ignore
+      AuthUtils.redirectToLogin()
     }
     None
   }, [authStatus])

--- a/src/screens/APIUtils/APIUtils.res
+++ b/src/screens/APIUtils/APIUtils.res
@@ -734,7 +734,6 @@ let useHandleLogout = () => {
         })
       setAuthStateToLogout()
       clearRecoilValue()
-      AuthUtils.redirectToLogin()
       LocalStorage.clear()
     } catch {
     | _ => LocalStorage.clear()
@@ -800,6 +799,7 @@ let responseHandler = async (
         | 401 =>
           if !sessionExpired.contents {
             showToast(~toastType=ToastWarning, ~message="Session Expired", ~autoClose=false)
+            Js.log("Inside 401")
             handleLogout()->ignore
             AuthUtils.redirectToLogin()
             sessionExpired := true


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
After the logout event was triggered from Recon, the dashboard was redirecting to the home page, which then called the "list invitations" API. This resulted in an error because the local storage was cleared during the logout process.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- Login to account having recon 
- when the recon iframe throws error dashboard was logging out with error 'failed to fetch list invitations'
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [X] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build`
- [X] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
