### PR TITLE
chore: global search free text handling

### DIFF
--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
@@ -261,6 +261,8 @@ let make = () => {
             activeFilter
             onFilterClicked
             onSuggestionClicked
+            categorySuggestions
+            searchText
           />
           {switch viewType {
           | Results | Load | EmptyResult =>

--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
@@ -529,6 +529,8 @@ module ModalSearchBox = {
     ~activeFilter,
     ~onFilterClicked,
     ~onSuggestionClicked,
+    ~categorySuggestions,
+    ~searchText,
   ) => {
     let (errorMessage, setErrorMessage) = React.useState(_ => "")
 
@@ -681,10 +683,24 @@ module ModalSearchBox = {
       }
     }
 
+    let filterKey = activeFilter->String.split(filterSeparator)->getValueFromArray(0, "")
+
+    let filters = categorySuggestions->Array.filter(category => {
+      if activeFilter->isNonEmptyString {
+        let categoryType = category.categoryType->getcategoryFromVariant
+        if searchText->getEndChar == filterSeparator {
+          `${categoryType}:` == `${filterKey}:`
+        } else {
+          categoryType->String.includes(filterKey)
+        }
+      } else {
+        true
+      }
+    })
+
     let validateForm = _ => {
       let errors = Dict.make()
-      let lastChar = localSearchText->getEndChar
-      if lastChar == " " && localSearchText->validateQuery {
+      if localSearchText->validateQuery && filters->Array.length == 0 {
         setErrorMessage(_ =>
           "Only one free-text search is allowed and additional text will be ignored."
         )


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
rather then showing error text multiple free text it will show up during typing itself if the multiple free text is detected and the second free text is not a filter keyword 
![Screenshot 2025-01-07 at 7 33 34 PM](https://github.com/user-attachments/assets/dac5e909-d8cf-49a3-8e4c-f28462bddb23)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
when u enter a multiple frree text the waring will be displyed and this warning will show up only if the free text is not a filter 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
