### PR TITLE
chore: limit unusually large width of dropdown

### DIFF
--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -181,7 +181,7 @@ let make = () => {
   let customStyle = "text-blue-500 bg-white dark:bg-black hover:bg-jp-gray-100 text-nowrap w-full"
   let addItemBtnStyle = "border border-t-0 w-full"
   let customScrollStyle = "max-h-72 overflow-scroll px-1 pt-1 border border-b-0"
-  let dropdownContainerStyle = "rounded-md border border-1 w-[15rem]"
+  let dropdownContainerStyle = "rounded-md border border-1 w-[14rem] max-w-[20rem]"
 
   let subHeading = {currentOMPName(merchantList, merchantId)}
 

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -28,8 +28,9 @@ module ListBaseComp = {
     let paddingHeading = isDarkBg ? "pl-2" : ""
 
     let endValue = isDarkBg ? 23 : 15
+    let maxLength = isDarkBg ? 23 : 15
 
-    let subHeadingElement = if subHeading->String.length > 15 {
+    let subHeadingElement = if subHeading->String.length > maxLength {
       <HelperComponents.EllipsisText
         displayValue=subHeading
         endValue

--- a/src/screens/OMPSwitch/ProfileSwitch.res
+++ b/src/screens/OMPSwitch/ProfileSwitch.res
@@ -152,7 +152,7 @@ let make = () => {
   let customStyle = "text-blue-500 bg-white dark:bg-black hover:bg-jp-gray-100 text-nowrap w-full"
   let addItemBtnStyle = "border border-t-0 w-full"
   let customScrollStyle = "max-h-72 overflow-scroll px-1 pt-1 border border-b-0"
-  let dropdownContainerStyle = "rounded-md border border-1 w-[15rem]"
+  let dropdownContainerStyle = "rounded-md border border-1 w-[14rem] max-w-[20rem]"
   let profileSwitch = async value => {
     try {
       setShowSwitchingProfile(_ => true)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- limit the width of profile and merchant dropdowns
- org base comp word limit incresed to show ellipsis

current
![image](https://github.com/user-attachments/assets/1f754337-ad4b-4646-891b-0ce3e3899f6a)
new
![image](https://github.com/user-attachments/assets/8d40f6ac-4b28-401a-9c1d-9a0891136975)


current
![image](https://github.com/user-attachments/assets/37eae24e-4999-46c9-8278-ef04d2ca03e6)
new
![image](https://github.com/user-attachments/assets/eb501adc-13a9-4d84-97a6-0458dd8d37b2)


current
![image](https://github.com/user-attachments/assets/97b90ee2-82db-4e77-9cd5-a855bab71a0c)
new
![image](https://github.com/user-attachments/assets/425d9c8f-0a16-4e70-8d61-8facaf9c30ee)


## Motivation and Context

improving ui

## How did you test it?

check the ui changes as in desc

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
