### PR TITLE
fix: font color primary

### DIFF
--- a/src/context/ThemeProvider.res
+++ b/src/context/ThemeProvider.res
@@ -246,10 +246,6 @@ let make = (~children) => {
                   "primary_color",
                   defaultSettings.buttons.primary.backgroundColor,
                 ),
-                "textColor": dict->getString(
-                  "primary_color",
-                  defaultSettings.buttons.primary.textColor,
-                ),
                 "hoverBackgroundColor": dict->getString(
                   "primary_hover_color",
                   defaultSettings.buttons.primary.hoverBackgroundColor,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

textcolor to not get picked from primary but to be picked from default.

## Motivation and Context

UI

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
