### PR TITLE
chore: conditional enforcement of cookies

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -50,6 +50,7 @@ new_analytics_refunds=false
 down_time=false
 dev_theme_feature=false
 tax_processor=true
+force_cookies=false
 x_feature_route=false
 tenant_user=false
 dev_click_to_pay=false

--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -718,13 +718,13 @@ let useHandleLogout = () => {
   let {setAuthStateToLogout} = React.useContext(AuthInfoProvider.authStatusContext)
   let clearRecoilValue = ClearRecoilValueHook.useClearRecoilValue()
   let fetchApi = AuthHooks.useApiFetcher()
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   () => {
     try {
       let logoutUrl = getURL(~entityName=USERS, ~methodType=Post, ~userType=#SIGNOUT)
       open Promise
       let _ =
-        fetchApi(logoutUrl, ~method_=Post, ~xFeatureRoute)
+        fetchApi(logoutUrl, ~method_=Post, ~xFeatureRoute, ~forceCookies)
         ->then(Fetch.Response.json)
         ->then(json => {
           json->resolve
@@ -887,11 +887,11 @@ let useGetMethod = (~showErrorToast=true) => {
         },
       },
     })
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   async url => {
     try {
-      let res = await fetchApi(url, ~method_=Get, ~xFeatureRoute)
+      let res = await fetchApi(url, ~method_=Get, ~xFeatureRoute, ~forceCookies)
       await responseHandler(
         ~url,
         ~res,
@@ -933,7 +933,7 @@ let useUpdateMethod = (~showErrorToast=true) => {
         },
       },
     })
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   async (
     url,
@@ -952,6 +952,7 @@ let useUpdateMethod = (~showErrorToast=true) => {
         ~headers,
         ~contentType,
         ~xFeatureRoute,
+        ~forceCookies,
       )
       await responseHandler(
         ~url,

--- a/src/components/AdvancedSearchComponent.res
+++ b/src/components/AdvancedSearchComponent.res
@@ -17,12 +17,12 @@ let make = (~children, ~setData=?, ~entity: EntityType.entityType<'colType, 't>,
   let initialValueJson = JSON.Encode.object(Dict.make())
   let showToast = ToastState.useShowToast()
   let (showModal, setShowModal) = React.useState(_ => false)
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   let onSubmit = (values, form: ReactFinalForm.formApi) => {
     open Promise
 
-    fetchApi(url, ~bodyStr=JSON.stringify(values), ~method_=Post, ~xFeatureRoute)
+    fetchApi(url, ~bodyStr=JSON.stringify(values), ~method_=Post, ~xFeatureRoute, ~forceCookies)
     ->then(res => res->Fetch.Response.json)
     ->then(json => {
       let jsonData = json->JSON.Decode.object->Option.flatMap(dict => dict->Dict.get("rows"))

--- a/src/components/AdvancedSearchModal.res
+++ b/src/components/AdvancedSearchModal.res
@@ -20,7 +20,8 @@ module AdvanceSearch = {
     let fetchApi = AuthHooks.useApiFetcher()
     let initialValueJson = JSON.Encode.object(Dict.make())
     let showToast = ToastState.useShowToast()
-    let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+    let {xFeatureRoute, forceCookies} =
+      HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
     let onSubmit = (values, _) => {
       let otherQueries = switch values->JSON.Decode.object {
@@ -42,7 +43,13 @@ module AdvanceSearch = {
       let finalUrl = otherQueries->isNonEmptyString ? `${url}?${otherQueries}` : url
 
       open Promise
-      fetchApi(finalUrl, ~bodyStr=JSON.stringify(initialValueJson), ~method_=Get, ~xFeatureRoute)
+      fetchApi(
+        finalUrl,
+        ~bodyStr=JSON.stringify(initialValueJson),
+        ~method_=Get,
+        ~xFeatureRoute,
+        ~forceCookies,
+      )
       ->then(res => res->Fetch.Response.json)
       ->then(json => {
         switch JSON.Classify.classify(json) {

--- a/src/components/DynamicChart.res
+++ b/src/components/DynamicChart.res
@@ -234,7 +234,7 @@ let makeEntity = (
 let useChartFetch = (~setStatusDict) => {
   let fetchApi = AuthHooks.useApiFetcher()
   let addLogsAroundFetch = AnalyticsLogUtilsHook.useAddLogsAroundFetch()
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   let fetchChartData = (updatedChartBody: array<fetchDataConfig>, setState) => {
     open Promise
@@ -247,6 +247,7 @@ let useChartFetch = (~setStatusDict) => {
         ~bodyStr=item.body,
         ~headers=[("QueryType", "Chart")]->Dict.fromArray,
         ~xFeatureRoute,
+        ~forceCookies,
       )
       ->addLogsAroundFetch(~logTitle="Chart Data Api", ~setStatusDict)
       ->then(json => {
@@ -262,6 +263,7 @@ let useChartFetch = (~setStatusDict) => {
             ~bodyStr=legendBody,
             ~headers=[("QueryType", "Chart")]->Dict.fromArray,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(~logTitle="Chart Data Api", ~setStatusDict)
           ->then(

--- a/src/components/DynamicSingleStat.res
+++ b/src/components/DynamicSingleStat.res
@@ -141,7 +141,7 @@ let make = (
   ~formaPayload: option<singleStatBodyEntity => string>=?,
 ) => {
   open LogicUtils
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   let {filterValueJson} = React.useContext(FilterContext.filterContext)
   let fetchApi = AuthHooks.useApiFetcher()
@@ -307,6 +307,7 @@ let make = (
           ~bodyStr=singleStatBody,
           ~headers=[("QueryType", "SingleStat")]->Dict.fromArray,
           ~xFeatureRoute,
+          ~forceCookies,
         )
         ->addLogsAroundFetch(~logTitle="SingleStat Data Api")
         ->then(json => resolve((`${urlConfig.prefix->Option.getOr("")}${uri}`, json)))
@@ -381,6 +382,7 @@ let make = (
           ~bodyStr=singleStatBodyMakerFn(singleStatBodyEntity),
           ~headers=[("QueryType", "SingleStatTimeseries")]->Dict.fromArray,
           ~xFeatureRoute,
+          ~forceCookies,
         )
         ->addLogsAroundFetch(~logTitle="SingleStatTimeseries Data Api")
         ->then(

--- a/src/components/DynamicTable.res
+++ b/src/components/DynamicTable.res
@@ -115,7 +115,7 @@ let make = (
     filterCheck,
     filterForRow,
   } = entity
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let tableName =
     prefixAddition->Option.getOr(false)
       ? title->(String.replaceRegExp(_, %re("/ /g"), "-"))->String.toLowerCase->Some
@@ -237,7 +237,14 @@ let make = (
     }
     let uri = uri ++ getNewUrl(defaultFilters)
     setTableDataLoading(_ => true)
-    fetchApi(uri, ~bodyStr=JSON.stringify(finalJson), ~headers, ~method_=method, ~xFeatureRoute)
+    fetchApi(
+      uri,
+      ~bodyStr=JSON.stringify(finalJson),
+      ~headers,
+      ~method_=method,
+      ~xFeatureRoute,
+      ~forceCookies,
+    )
     ->then(resp => {
       let status = resp->Fetch.Response.status
       if status >= 300 {

--- a/src/components/custom-icons/LottieFiles.res
+++ b/src/components/custom-icons/LottieFiles.res
@@ -25,7 +25,12 @@ let useLottieJson = lottieFileName => {
       }
     | None => {
         let fetchLottie =
-          fetchApi(`${prefix}/lottie-files/${lottieFileName}`, ~method_=Get, ~xFeatureRoute=false)
+          fetchApi(
+            `${prefix}/lottie-files/${lottieFileName}`,
+            ~method_=Get,
+            ~xFeatureRoute=false,
+            ~forceCookies=false,
+          )
           ->then(res => res->Fetch.Response.json)
           ->then(json => {
             setlottieJson(_ => json)

--- a/src/context/ChartContext.res
+++ b/src/context/ChartContext.res
@@ -91,7 +91,7 @@ let make = (~children, ~chartEntity: DynamicChart.entity, ~chartId="", ~defaultF
   let defaultFilters = [startTimeFilterKey, endTimeFilterKey]
 
   let {allFilterDimension} = chartEntity
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   let sortingParams = React.useMemo((): option<AnalyticsNewUtils.sortedBasedOn> => {
     switch chartEntity {
@@ -344,6 +344,7 @@ let make = (~children, ~chartEntity: DynamicChart.entity, ~chartId="", ~defaultF
               ~headers=[("QueryType", "Chart Time Series")]->Dict.fromArray,
               ~betaEndpointConfig=?betaEndPointConfig,
               ~xFeatureRoute,
+              ~forceCookies,
             )
             ->addLogsAroundFetch(~logTitle=`Chart fetch`)
             ->then(
@@ -403,6 +404,7 @@ let make = (~children, ~chartEntity: DynamicChart.entity, ~chartId="", ~defaultF
             ~headers=[("QueryType", "Chart Legend")]->Dict.fromArray,
             ~betaEndpointConfig=?betaEndPointConfig,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(~logTitle=`Chart legend Data`)
           ->then(text => {
@@ -471,6 +473,7 @@ let make = (~children, ~chartEntity: DynamicChart.entity, ~chartId="", ~defaultF
               ~headers=[("QueryType", "Chart Time Series")]->Dict.fromArray,
               ~betaEndpointConfig=?betaEndPointConfig,
               ~xFeatureRoute,
+              ~forceCookies,
             )
             ->addLogsAroundFetch(~logTitle=`Chart fetch bottomChart`)
             ->then(
@@ -527,6 +530,7 @@ let make = (~children, ~chartEntity: DynamicChart.entity, ~chartId="", ~defaultF
             ~headers=[("QueryType", "Chart Legend")]->Dict.fromArray,
             ~betaEndpointConfig=?betaEndPointConfig,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(~logTitle=`Chart legend Data`)
           ->then(text => {
@@ -584,7 +588,8 @@ module SDKAnalyticsChartContext = {
     ~segmentValue: option<array<string>>=?,
     ~differentTimeValues: option<array<AnalyticsUtils.timeRanges>>=?,
   ) => {
-    let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+    let {xFeatureRoute, forceCookies} =
+      HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let parentToken = AuthWrapperUtils.useTokenParent(Original)
     let addLogsAroundFetch = AnalyticsLogUtilsHook.useAddLogsAroundFetchNew()
     let betaEndPointConfig = React.useContext(BetaEndPointConfigProvider.betaEndPointConfig)
@@ -817,6 +822,7 @@ module SDKAnalyticsChartContext = {
                   ~headers=[("QueryType", "Chart Time Series")]->Dict.fromArray,
                   ~betaEndpointConfig=?betaEndPointConfig,
                   ~xFeatureRoute,
+                  ~forceCookies,
                 )
                 ->addLogsAroundFetch(~logTitle=`Chart fetch`)
                 ->then(text => {
@@ -857,6 +863,7 @@ module SDKAnalyticsChartContext = {
                         ~headers=[("QueryType", "Chart Time Series")]->Dict.fromArray,
                         ~betaEndpointConfig=?betaEndPointConfig,
                         ~xFeatureRoute,
+                        ~forceCookies,
                       )
                       ->addLogsAroundFetch(~logTitle=`Chart fetch`)
                       ->then(

--- a/src/context/SingleStatContext.res
+++ b/src/context/SingleStatContext.res
@@ -57,7 +57,7 @@ let make = (
   let addLogsAroundFetch = AnalyticsLogUtilsHook.useAddLogsAroundFetchNew()
   let betaEndPointConfig = React.useContext(BetaEndPointConfigProvider.betaEndPointConfig)
   let fetchApi = AuthHooks.useApiFetcher()
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let getTopLevelSingleStatFilter = React.useMemo(() => {
     getAllFilter
     ->Dict.toArray
@@ -260,6 +260,7 @@ let make = (
             ~headers=[("QueryType", "SingleStatHistoric")]->Dict.fromArray,
             ~betaEndpointConfig=?betaEndPointConfig,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(
             ~logTitle=`SingleStat histotic data for metrics ${metrics->metrixMapper}`,
@@ -311,6 +312,7 @@ let make = (
             ~headers=[("QueryType", "SingleStat")]->Dict.fromArray,
             ~betaEndpointConfig=?betaEndPointConfig,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(~logTitle=`SingleStat data for metrics ${metrics->metrixMapper}`)
           ->then(
@@ -361,6 +363,7 @@ let make = (
             ~headers=[("QueryType", "SingleStat Time Series")]->Dict.fromArray,
             ~betaEndpointConfig=?betaEndPointConfig,
             ~xFeatureRoute,
+            ~forceCookies,
           )
           ->addLogsAroundFetch(
             ~logTitle=`SingleStat Time Series data for metrics ${metrics->metrixMapper}`,

--- a/src/context/ThemeProvider.res
+++ b/src/context/ThemeProvider.res
@@ -257,7 +257,12 @@ let make = (~children) => {
         defaultStyle->Identity.genericTypeToJson
       } else {
         let url = `${GlobalVars.getHostUrl}/themes/${themesID}/theme.json`
-        let themeResponse = await fetchApi(`${url}`, ~method_=Get, ~xFeatureRoute=true)
+        let themeResponse = await fetchApi(
+          `${url}`,
+          ~method_=Get,
+          ~xFeatureRoute=true,
+          ~forceCookies=false,
+        )
         let themesData = await themeResponse->(res => res->Fetch.Response.json)
         themesData
       }

--- a/src/entryPoints/AuthModule/UserInfo/UserInfoProvider.res
+++ b/src/entryPoints/AuthModule/UserInfo/UserInfoProvider.res
@@ -9,7 +9,7 @@ let make = (~children) => {
   let (screenState, setScreenState) = React.useState(_ => Loading)
   let (userInfo, setUserInfo) = React.useState(_ => UserInfoUtils.defaultValueOfUserInfo)
   let fetchApi = AuthHooks.useApiFetcher()
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let userInfoRef = Some(React.useRef(userInfo))
 
   let updateUserInfoRef = updatedUserInfo => {
@@ -28,7 +28,7 @@ let make = (~children) => {
     open LogicUtils
     let url = `${Window.env.apiBaseUrl}/user`
     try {
-      let res = await fetchApi(`${url}`, ~method_=Get, ~xFeatureRoute)
+      let res = await fetchApi(`${url}`, ~method_=Get, ~xFeatureRoute, ~forceCookies)
       let response = await res->(res => res->Fetch.Response.json)
       let userInfo = response->getDictFromJsonObject->UserInfoUtils.itemMapper
       updateUserInfoRef(userInfo)

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -46,6 +46,7 @@ type featureFlag = {
   clickToPay: bool,
   devThemeFeature: bool,
   devReconv2Product: bool,
+  forceCookies: bool,
 }
 
 let featureFlagType = (featureFlags: JSON.t) => {
@@ -94,6 +95,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     tenantUser: dict->getBool("tenant_user", false),
     devThemeFeature: dict->getBool("dev_theme_feature", false),
     devReconv2Product: dict->getBool("dev_recon_v2_product", false),
+    forceCookies: dict->getBool("force_cookies", false),
   }
 }
 

--- a/src/hooks/AuthHooks.res
+++ b/src/hooks/AuthHooks.res
@@ -66,6 +66,7 @@ let useApiFetcher = () => {
       ~betaEndpointConfig=?,
       ~contentType=Headers("application/json"),
       ~xFeatureRoute,
+      ~forceCookies,
     ) => {
       let token = {
         switch authStatus {
@@ -98,7 +99,7 @@ let useApiFetcher = () => {
           Fetch.RequestInit.make(
             ~method_,
             ~body?,
-            ~credentials=SameOrigin,
+            ~credentials={forceCookies ? SameOrigin : Omit},
             ~headers=getHeaders(~headers, ~uri, ~contentType, ~token, ~xFeatureRoute),
           ),
         )

--- a/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ApplePay/ApplePaySimplifiedFlow.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ApplePay/ApplePaySimplifiedFlow.res
@@ -63,7 +63,12 @@ let make = (
   let downloadApplePayCert = () => {
     open Promise
     let downloadURL = Window.env.applePayCertificateUrl->Option.getOr("")
-    fetchApi(downloadURL, ~method_=Get, ~xFeatureRoute=featureFlagDetails.xFeatureRoute)
+    fetchApi(
+      downloadURL,
+      ~method_=Get,
+      ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+      ~forceCookies=featureFlagDetails.forceCookies,
+    )
     ->then(Fetch.Response.blob)
     ->then(content => {
       DownloadUtils.download(

--- a/src/screens/Hooks/OMPSwitchHooks.res
+++ b/src/screens/Hooks/OMPSwitchHooks.res
@@ -10,11 +10,11 @@ let useUserInfo = () => {
     UserInfoProvider.defaultContext,
   )
   let url = `${Window.env.apiBaseUrl}/user`
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   let getUserInfo = async () => {
     try {
-      let res = await fetchApi(`${url}`, ~method_=Get, ~xFeatureRoute)
+      let res = await fetchApi(`${url}`, ~method_=Get, ~xFeatureRoute, ~forceCookies)
       let response = await res->(res => res->Fetch.Response.json)
       let userInfo = response->getDictFromJsonObject->UserInfoUtils.itemMapper
       setUserInfoData(userInfo)

--- a/src/screens/MixpanelHook.res
+++ b/src/screens/MixpanelHook.res
@@ -71,6 +71,7 @@ let useSendEvent = () => {
         ~method_=Post,
         ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
         ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+        ~forceCookies=featureFlagDetails.forceCookies,
       )
     } catch {
     | _ => ()
@@ -135,6 +136,7 @@ let usePageView = () => {
           ~method_=Post,
           ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+          ~forceCookies=featureFlagDetails.forceCookies,
         )
       }
     } catch {
@@ -174,12 +176,14 @@ let useSetIdentity = () => {
           ~method_=Post,
           ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+          ~forceCookies=featureFlagDetails.forceCookies,
         )
         let _ = await fetchApi(
           `${getHostUrl}/mixpanel/engage`,
           ~method_=Post,
           ~bodyStr=`data=${peopleProperties->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+          ~forceCookies=featureFlagDetails.forceCookies,
         )
       }
     } catch {

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -164,7 +164,7 @@ module OMPViewsComp = {
     let customScrollStyle = "md:max-h-72 md:overflow-scroll md:px-1 md:pt-1"
     let dropdownContainerStyle = "md:rounded-lg md:border md:w-full md:shadow-md"
 
-    <div className="flex h-fit border border-grey-100 bg-white rounded-lg py-2 hover:bg-opacity-80">
+    <div className="flex h-fit border bg-white rounded-lg py-2 hover:bg-opacity-80">
       <SelectBox.BaseDropdown
         allowMultiSelect=false
         buttonText=""

--- a/src/screens/SDKPayment/WebSDK.res
+++ b/src/screens/SDKPayment/WebSDK.res
@@ -41,7 +41,7 @@ module CheckoutForm = {
     let elements = useWidgets()
     let (appearanceElem, setAppearanceElem) = React.useState(() => JSON.Encode.null)
     let (paymentElem, setPaymentElem) = React.useState(() => JSON.Encode.null)
-
+    let {forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let fetchApi = AuthHooks.useApiFetcher()
     React.useEffect(() => {
       let val = {
@@ -62,6 +62,7 @@ module CheckoutForm = {
           ~headers=[("Access-Control-Allow-Origin", "*")]->Dict.fromArray,
           ~method_=Post,
           ~xFeatureRoute=false,
+          ~forceCookies,
         )
         ->then(res => res->Fetch.Response.json)
         ->then(json => {

--- a/src/screens/Settings/ComplianceCertificates/Compliance.res
+++ b/src/screens/Settings/ComplianceCertificates/Compliance.res
@@ -23,7 +23,7 @@ let make = () => {
   let showToast = ToastState.useShowToast()
   let fetchApi = AuthHooks.useApiFetcher()
   let (buttonState, setButtonState) = React.useState(_ => Button.Normal)
-  let {xFeatureRoute} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let downloadPDF = _ => {
     setButtonState(_ => Button.Loading)
     let currentDate =
@@ -37,7 +37,7 @@ let make = () => {
     // For local testing this condition is added
     if downloadURL->LogicUtils.isNonEmptyString {
       open Promise
-      fetchApi(downloadURL, ~method_=Get, ~xFeatureRoute)
+      fetchApi(downloadURL, ~method_=Get, ~xFeatureRoute, ~forceCookies)
       ->then(resp => {
         Fetch.Response.blob(resp)
       })

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,6 +15,10 @@ let proxy = {
     pathRewrite: { "^/api": "" },
     changeOrigin: true,
   },
+  "/themes": {
+    target: "https://integ.hyperswitch.io/",
+    changeOrigin: true,
+  },
 };
 
 let configMiddleware = (req, res, next) => {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,7 +16,7 @@ let proxy = {
     changeOrigin: true,
   },
   "/themes": {
-    target: "https://integ.hyperswitch.io/",
+    target: "",
     changeOrigin: true,
   },
 };


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Introduced a `force_cookies` feature flag, defaulting to false. When enabled (true), it enforces cookie usage; when disabled (false), cookies are not enforced.

## Motivation and Context

Recent multitenancy updates in Sandbox encountered several bugs due to same-origin credential issues. Adding conditional cookie enforcement via the force_cookies flag addresses these issues and improve handling.

## How did you test it?

On being false, cookies weren't sent in the request.
Have to explicitly make it true for development and integ.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
