### PR TITLE
chore: org dropdown for tenant admin

### DIFF
--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -99,7 +99,7 @@ module ListBaseComp = {
               toolTipFor={<div className="cursor-pointer">
                 <OMPCopyTextCustomComp displayValue=" " copyValue=Some({subHeading}) />
               </div>}
-              toolTipPosition=ToolTip.TopRight
+              toolTipPosition=ToolTip.Right
             />
           </RenderIf>
           <RenderIf condition={showEditIcon}>

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -1,3 +1,41 @@
+module OMPCopyTextCustomComp = {
+  @react.component
+  let make = (
+    ~displayValue,
+    ~copyValue=None,
+    ~customTextCss="",
+    ~customParentClass="flex items-center",
+    ~customOnCopyClick=() => (),
+  ) => {
+    let showToast = ToastState.useShowToast()
+    let copyVal = switch copyValue {
+    | Some(val) => val
+    | None => displayValue
+    }
+    let onCopyClick = ev => {
+      ev->ReactEvent.Mouse.stopPropagation
+      Clipboard.writeText(copyVal)
+      customOnCopyClick()
+      showToast(~message="Copied to Clipboard!", ~toastType=ToastSuccess)
+    }
+
+    if displayValue->LogicUtils.isNonEmptyString {
+      <div className=customParentClass>
+        <div className=customTextCss> {displayValue->React.string} </div>
+        <img
+          alt="cursor"
+          src={`/assets/copyid.svg`}
+          className="cursor-pointer"
+          onClick={ev => {
+            onCopyClick(ev)
+          }}
+        />
+      </div>
+    } else {
+      "NA"->React.string
+    }
+  }
+}
 module ListBaseComp = {
   @react.component
   let make = (
@@ -28,8 +66,8 @@ module ListBaseComp = {
     let paddingSubheading = isDarkBg ? "pl-2" : ""
     let paddingHeading = isDarkBg ? "pl-2" : ""
 
-    let endValue = isDarkBg ? 23 : 15
-    let maxLength = isDarkBg ? 23 : 15
+    let endValue = isDarkBg ? 20 : 15
+    let maxLength = isDarkBg ? 20 : 15
 
     let subHeadingElement = if subHeading->String.length > maxLength {
       <HelperComponents.EllipsisText
@@ -54,6 +92,16 @@ module ListBaseComp = {
             className={`fs-10 ${textColor} ${width} ${paddingSubheading} overflow-scroll text-nowrap`}>
             {subHeadingElement}
           </p>
+          <RenderIf condition={!showDropdownArrow}>
+            <ToolTip
+              description={subHeading}
+              customStyle="!whitespace-nowrap"
+              toolTipFor={<div className="cursor-pointer">
+                <OMPCopyTextCustomComp displayValue=" " copyValue=Some({subHeading}) />
+              </div>}
+              toolTipPosition=ToolTip.TopRight
+            />
+          </RenderIf>
           <RenderIf condition={showEditIcon}>
             <Icon name="pencil-edit" size=15 onClick=onEditClick className="mx-2" />
           </RenderIf>
@@ -223,45 +271,6 @@ module OMPViews = {
     let displayName = selectedEntity->getNameForId
 
     <OMPViewsComp input options displayName />
-  }
-}
-
-module OMPCopyTextCustomComp = {
-  @react.component
-  let make = (
-    ~displayValue,
-    ~copyValue=None,
-    ~customTextCss="",
-    ~customParentClass="flex items-center",
-    ~customOnCopyClick=() => (),
-  ) => {
-    let showToast = ToastState.useShowToast()
-    let copyVal = switch copyValue {
-    | Some(val) => val
-    | None => displayValue
-    }
-    let onCopyClick = ev => {
-      ev->ReactEvent.Mouse.stopPropagation
-      Clipboard.writeText(copyVal)
-      customOnCopyClick()
-      showToast(~message="Copied to Clipboard!", ~toastType=ToastSuccess)
-    }
-
-    if displayValue->LogicUtils.isNonEmptyString {
-      <div className=customParentClass>
-        <div className=customTextCss> {displayValue->React.string} </div>
-        <img
-          alt="cursor"
-          src={`/assets/copyid.svg`}
-          className="cursor-pointer"
-          onClick={ev => {
-            onCopyClick(ev)
-          }}
-        />
-      </div>
-    } else {
-      "NA"->React.string
-    }
   }
 }
 

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -7,6 +7,7 @@ module ListBaseComp = {
     ~showEditIcon=false,
     ~onEditClick=_ => (),
     ~isDarkBg=false,
+    ~showDropdownArrow=true,
   ) => {
     let baseCompStyle = isDarkBg
       ? "text-white hover:bg-opacity-80 bg-sidebar-blue"
@@ -56,9 +57,11 @@ module ListBaseComp = {
           <RenderIf condition={showEditIcon}>
             <Icon name="pencil-edit" size=15 onClick=onEditClick className="mx-2" />
           </RenderIf>
-          <Icon
-            className={`${arrow ? arrowDownClass : arrowUpClass} ml-1`} name={iconName} size=15
-          />
+          <RenderIf condition={showDropdownArrow}>
+            <Icon
+              className={`${arrow ? arrowDownClass : arrowUpClass} ml-1`} name={iconName} size=15
+            />
+          </RenderIf>
         </div>
       </div>
     </div>

--- a/src/screens/OMPSwitch/OrgSwitch.res
+++ b/src/screens/OMPSwitch/OrgSwitch.res
@@ -272,49 +272,66 @@ let make = () => {
   let customScrollStyle = "bg-secondary max-h-72 overflow-scroll px-1 pt-1"
   let dropdownContainerStyle = "min-w-[15rem] rounded"
 
+  let showOrgDropdown = !(tenantUser && isTenantAdmin && orgList->Array.length >= 20)
+  let orgDropdown =
+    <SelectBox.BaseDropdown
+      allowMultiSelect=false
+      buttonText=""
+      input
+      deselectDisable=true
+      customButtonStyle="!rounded-md"
+      options={orgList->generateDropdownOptions}
+      marginTop="mt-14"
+      hideMultiSelectButtons=true
+      addButton=false
+      customStyle="bg-secondary md:bg-secondary hover:!bg-black/10 rounded !w-full"
+      customSelectStyle="md:bg-secondary hover:!bg-black/10 rounded"
+      searchable=false
+      baseComponent={<ListBaseComp
+        heading="Org"
+        subHeading={currentOMPName(orgList, orgId)}
+        arrow
+        showEditIcon={userHasAccess(~groupAccess=OrganizationManage) === Access}
+        onEditClick
+        isDarkBg=true
+      />}
+      baseComponentCustomStyle="border-blue-820 rounded bg-secondary rounded text-white"
+      bottomComponent={<RenderIf condition={tenantUser && isTenantAdmin}>
+        <OMPSwitchHelper.AddNewOMPButton
+          user=#Organization
+          setShowModal={setShowAddOrgModal}
+          customPadding
+          customStyle
+          customHRTagStyle
+        />
+      </RenderIf>}
+      optionClass="text-gray-200 text-fs-14"
+      selectClass="text-gray-200 text-fs-14"
+      customDropdownOuterClass="!border-none !w-full"
+      fullLength=true
+      toggleChevronState
+      customScrollStyle
+      dropdownContainerStyle
+      shouldDisplaySelectedOnTop=true
+    />
+
+  let orgBaseComp =
+    <ListBaseComp
+      heading="Org"
+      subHeading=orgId
+      arrow
+      showEditIcon={userHasAccess(~groupAccess=OrganizationManage) === Access}
+      onEditClick
+      isDarkBg=true
+      showDropdownArrow=false
+    />
+
+  let orgComp = showOrgDropdown ? orgDropdown : orgBaseComp
+
   <div className="w-full py-3.5 px-2 ">
     <div className="flex flex-col gap-4">
-      <SelectBox.BaseDropdown
-        allowMultiSelect=false
-        buttonText=""
-        input
-        deselectDisable=true
-        customButtonStyle="!rounded-md"
-        options={orgList->generateDropdownOptions}
-        marginTop="mt-14"
-        hideMultiSelectButtons=true
-        addButton=false
-        customStyle="bg-secondary md:bg-secondary hover:!bg-black/10 rounded !w-full"
-        customSelectStyle="md:bg-secondary hover:!bg-black/10 rounded"
-        searchable=false
-        baseComponent={<ListBaseComp
-          heading="Org"
-          subHeading={currentOMPName(orgList, orgId)}
-          arrow
-          showEditIcon={userHasAccess(~groupAccess=OrganizationManage) === Access}
-          onEditClick
-          isDarkBg=true
-        />}
-        baseComponentCustomStyle="border-blue-820 rounded bg-secondary rounded text-white"
-        bottomComponent={<RenderIf condition={tenantUser && isTenantAdmin}>
-          <OMPSwitchHelper.AddNewOMPButton
-            user=#Organization
-            setShowModal={setShowAddOrgModal}
-            customPadding
-            customStyle
-            customHRTagStyle
-          />
-        </RenderIf>}
-        optionClass="text-gray-200 text-fs-14"
-        selectClass="text-gray-200 text-fs-14"
-        customDropdownOuterClass="!border-none !w-full"
-        fullLength=true
-        toggleChevronState
-        customScrollStyle
-        dropdownContainerStyle
-        shouldDisplaySelectedOnTop=true
-      />
-      <RenderIf condition={tenantUser && isTenantAdmin && orgList->Array.length >= 20}>
+      {orgComp}
+      <RenderIf condition={!showOrgDropdown}>
         <SwitchOrg setShowModal={setShowSwitchingOrg} />
       </RenderIf>
     </div>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- this is specific change made to alter the view of org dropdown in case of tenant admin with more than 20 orgs because currently the api is only sending 20 org so there is discrepency that the. selected org might not be present in the org dropdown, hence removed the org dropdown as discussed particularly for  this case

org dropdown in case of tenant admin having more than 20 orgs
![image](https://github.com/user-attachments/assets/f193980d-21b0-48b8-b2c4-91fa23c02d82)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

check the org comp in home page for tenant admin

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
