### PR TITLE
fix: Fixed extend date button functionality

### DIFF
--- a/src/components/NoDataFound.res
+++ b/src/components/NoDataFound.res
@@ -1,37 +1,5 @@
 type renderType = InfoBox | Painting | NotFound | Locked | LoadError | ExtendDateUI
 
-module ExtendDateComponent = {
-  open LogicUtils
-  @react.component
-  let make = () => {
-    let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
-    let startTime = filterValueJson->getString("start_time", "")
-
-    let handleClick = _ => {
-      let startDateObj = startTime->DayJs.getDayJsForString
-      let extendedStartDate = startDateObj.subtract(90, "day").toDate()->Date.toISOString
-      let extendedEndDate = startDateObj.subtract(1, "day").toDate()->Date.toISOString
-
-      updateExistingKeys(Dict.fromArray([("start_time", {extendedStartDate})]))
-      updateExistingKeys(Dict.fromArray([("end_time", {extendedEndDate})]))
-    }
-    <div>
-      <ACLButton
-        buttonType=Primary onClick=handleClick text="Expand the search to the previous 90 days"
-      />
-      <div className="flex justify-center">
-        <p className="mt-6">
-          {"Or try the following:"->React.string}
-          <ul className="list-disc">
-            <li> {"Try a different search parameter"->React.string} </li>
-            <li> {"Adjust or remove filters and search once more"->React.string} </li>
-          </ul>
-        </p>
-      </div>
-    </div>
-  }
-}
-
 @react.component
 let make = (
   ~title=?,
@@ -41,6 +9,7 @@ let make = (
   ~customCssClass="my-6",
   ~customBorderClass="",
   ~customMessageCss="",
+  ~handleClick=?,
 ) => {
   let prefix = LogicUtils.useUrlPrefix()
   let isMobileView = MatchMedia.useMobileChecker()
@@ -136,8 +105,27 @@ let make = (
           </div>
         | ExtendDateUI =>
           <div className=containerClass>
-            <div className="px-3 text-2xl text-black font-bold mb-6"> {message->React.string} </div>
-            <ExtendDateComponent />
+            <div className="items-center text-2xl text-black font-bold mb-4">
+              {message->React.string}
+            </div>
+            {switch handleClick {
+            | Some(fn) =>
+              <div>
+                <ACLButton
+                  buttonType=Primary onClick=fn text="Expand the search to the previous 90 days"
+                />
+                <div className="flex justify-center">
+                  <p className="mt-6">
+                    {"Or try the following:"->React.string}
+                    <ul className="list-disc">
+                      <li> {"Try a different search parameter"->React.string} </li>
+                      <li> {"Adjust or remove filters and search once more"->React.string} </li>
+                    </ul>
+                  </p>
+                </div>
+              </div>
+            | None => React.null
+            }}
           </div>
         }}
       </div>

--- a/src/screens/Payouts/PayoutsList.res
+++ b/src/screens/Payouts/PayoutsList.res
@@ -19,9 +19,25 @@ let make = () => {
   let {userInfo: {transactionEntity}, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
   )
+  let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
+  let startTime = filterValueJson->getString("start_time", "")
+
+  let handleExtendDateButtonClick = _ => {
+    let startDateObj = startTime->DayJs.getDayJsForString
+    let prevStartdate = startDateObj.toDate()->Date.toISOString
+    let extendedStartDate = startDateObj.subtract(90, "day").toDate()->Date.toISOString
+
+    updateExistingKeys(Dict.fromArray([("start_time", {extendedStartDate})]))
+    updateExistingKeys(Dict.fromArray([("end_time", {prevStartdate})]))
+  }
 
   let customUI = {
-    <NoDataFound customCssClass="my-6" message="No results found" renderType=ExtendDateUI />
+    <NoDataFound
+      customCssClass="my-6"
+      message="No results found"
+      renderType=ExtendDateUI
+      handleClick=handleExtendDateButtonClick
+    />
   }
 
   let fetchPayouts = () => {

--- a/src/screens/Transaction/Disputes/Disputes.res
+++ b/src/screens/Transaction/Disputes/Disputes.res
@@ -7,7 +7,7 @@ let make = () => {
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
-  let {filterValueJson} = React.useContext(FilterContext.filterContext)
+  let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (disputesData, setDisputesData) = React.useState(_ => [])
   let (searchText, setSearchText) = React.useState(_ => "")
@@ -19,6 +19,16 @@ let make = () => {
   let {userInfo: {transactionEntity, orgId, merchantId}, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
   )
+  let startTime = filterValueJson->getString("start_time", "")
+
+  let handleExtendDateButtonClick = _ => {
+    let startDateObj = startTime->DayJs.getDayJsForString
+    let prevStartdate = startDateObj.toDate()->Date.toISOString
+    let extendedStartDate = startDateObj.subtract(90, "day").toDate()->Date.toISOString
+
+    updateExistingKeys(Dict.fromArray([("start_time", {extendedStartDate})]))
+    updateExistingKeys(Dict.fromArray([("end_time", {prevStartdate})]))
+  }
 
   let getDisputesList = async () => {
     try {
@@ -74,7 +84,12 @@ let make = () => {
   }, (filters, searchText))
 
   let customUI =
-    <NoDataFound customCssClass="my-6" message="No results found" renderType=ExtendDateUI />
+    <NoDataFound
+      customCssClass="my-6"
+      message="No results found"
+      renderType=ExtendDateUI
+      handleClick=handleExtendDateButtonClick
+    />
 
   let filtersUI =
     <RemoteTableFilters

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -29,6 +29,17 @@ let make = (~previewOnly=false) => {
   let pageDetail = pageDetailDict->Dict.get("Orders")->Option.getOr(defaultValue)
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
   let {generateReport, email} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
+  let startTime = filterValueJson->getString("start_time", "")
+
+  let handleExtendDateButtonClick = _ => {
+    let startDateObj = startTime->DayJs.getDayJsForString
+    let prevStartdate = startDateObj.toDate()->Date.toISOString
+    let extendedStartDate = startDateObj.subtract(90, "day").toDate()->Date.toISOString
+
+    updateExistingKeys(Dict.fromArray([("start_time", {extendedStartDate})]))
+    updateExistingKeys(Dict.fromArray([("end_time", {prevStartdate})]))
+  }
 
   let fetchOrders = () => {
     if !previewOnly {
@@ -110,7 +121,12 @@ let make = (~previewOnly=false) => {
   let customTitleStyle = previewOnly ? "py-0 !pt-0" : ""
 
   let customUI =
-    <NoDataFound customCssClass="my-6" message="No results found" renderType=ExtendDateUI />
+    <NoDataFound
+      customCssClass="my-6"
+      message="No results found"
+      renderType=ExtendDateUI
+      handleClick=handleExtendDateButtonClick
+    />
 
   let filtersUI = React.useMemo(() => {
     <RemoteTableFilters

--- a/src/screens/Transaction/Refunds/Refund.res
+++ b/src/screens/Transaction/Refunds/Refund.res
@@ -20,9 +20,25 @@ let make = () => {
   let {userInfo: {transactionEntity, merchantId, orgId}, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
   )
+  let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
+  let startTime = filterValueJson->getString("start_time", "")
+
+  let handleExtendDateButtonClick = _ => {
+    let startDateObj = startTime->DayJs.getDayJsForString
+    let prevStartdate = startDateObj.toDate()->Date.toISOString
+    let extendedStartDate = startDateObj.subtract(90, "day").toDate()->Date.toISOString
+
+    updateExistingKeys(Dict.fromArray([("start_time", {extendedStartDate})]))
+    updateExistingKeys(Dict.fromArray([("end_time", {prevStartdate})]))
+  }
 
   let customUI = {
-    <NoDataFound customCssClass="my-6" message="No results found" renderType=ExtendDateUI />
+    <NoDataFound
+      customCssClass="my-6"
+      message="No results found"
+      renderType=ExtendDateUI
+      handleClick=handleExtendDateButtonClick
+    />
   }
   let fetchRefunds = () => {
     switch filters {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Now when button is clicked , endtime becomes the previous start time without a day being subtracted.
Additionally refactored code to make it more generic.

https://github.com/user-attachments/assets/f2f20b3f-6c11-4857-aef8-19b8896f2c7a


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
