### PR TITLE
chore: filter authentication processor

### DIFF
--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -459,12 +459,15 @@ module ClickToPaySection = {
     let connectorView = userHasAccess(~groupAccess=ConnectorsView) === Access
     let isClickToPayEnabled =
       formState.values->getDictFromJsonObject->getBool("is_click_to_pay_enabled", false)
-    let dropDownOptions = connectorListAtom->Array.map((item): SelectBox.dropdownOption => {
-      {
-        label: `${item.connector_name} - ${item.merchant_connector_id}`,
-        value: item.merchant_connector_id,
-      }
-    })
+    let dropDownOptions =
+      connectorListAtom
+      ->Array.filter(ele => ele.connector_type === "authentication_processor")
+      ->Array.map((item): SelectBox.dropdownOption => {
+        {
+          label: `${item.connector_label} - ${item.merchant_connector_id}`,
+          value: item.merchant_connector_id,
+        }
+      })
 
     <RenderIf condition={featureFlagDetails.clickToPay && connectorView}>
       <DesktopRow>

--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -461,7 +461,10 @@ module ClickToPaySection = {
       formState.values->getDictFromJsonObject->getBool("is_click_to_pay_enabled", false)
     let dropDownOptions =
       connectorListAtom
-      ->Array.filter(ele => ele.connector_type === "authentication_processor")
+      ->Array.filter(ele =>
+        ele.connector_type->ConnectorUtils.connectorTypeStringToTypeMapper ===
+          AuthenticationProcessor
+      )
       ->Array.map((item): SelectBox.dropdownOption => {
         {
           label: `${item.connector_label} - ${item.merchant_connector_id}`,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Need to show only authentication processors in the dropdown list

## How did you test it?

Via local UI in Click to Pay - previously every processor mcs_id was coming now only authentication processors coming. 

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
