### PR TITLE
fix: invitation error message

### DIFF
--- a/src/screens/UserManagement/UserRevamp/InviteMember.res
+++ b/src/screens/UserManagement/UserRevamp/InviteMember.res
@@ -114,18 +114,16 @@ let make = (~isInviteUserFlow=true, ~setNewRoleSelected=_ => ()) => {
       )
     ) {
       (
-        "We've faced some problem while sending emails or creating users. Please check and try again.",
+        "Error sending emails or creating users. Please check if the user already exists and try again.",
         ToastState.ToastError,
       )
     } else if (
-      decodedResponse->Array.some(ele =>
-        ele->getDictFromJsonObject->getOptionString("error")->Option.isSome
-      )
+      decodedResponse->Array.some(ele => {
+        let error = ele->getDictFromJsonObject->getOptionString("error")
+        error->Option.isSome && error->Option.getExn->String.includes("account already exists")
+      })
     ) {
-      (
-        "We faced difficulties sending some invitations. Please check and try again.",
-        ToastState.ToastWarning,
-      )
+      ("Some users already exist. Please check the details and try again.", ToastState.ToastWarning)
     } else {
       (
         email


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Correct error message display on inviting existing users.

- If all user emails entered exists.
<img width="1366" alt="Screenshot 2025-01-16 at 4 41 51 PM" src="https://github.com/user-attachments/assets/9d25d294-48c9-413f-997b-4ec96fd5e5c1" />

- If some user emails entered exists and rest were invited.
<img width="1366" alt="Screenshot 2025-01-16 at 4 42 10 PM" src="https://github.com/user-attachments/assets/0c19d7a2-a8ec-4064-8f8c-d6057077d11c" />

## Motivation and Context

User experience

## How did you test it?

Locally.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

