### PR TITLE
refactor: Value formatter moved to LogicUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## 2025.01.21.0
+
+### Features
+
+- Added responsiveness to api keys page ([#2061](https://github.com/juspay/hyperswitch-control-center/pull/2061)) ([`769daa7`](https://github.com/juspay/hyperswitch-control-center/commit/769daa796fc04297b01caf4e65c04d2f22fb965a))
+
+### Bug Fixes
+
+- Fixed multiple connector api calls ([#2060](https://github.com/juspay/hyperswitch-control-center/pull/2060)) ([`a77774a`](https://github.com/juspay/hyperswitch-control-center/commit/a77774a5fbfbda1fc2050a34d43173aa0e1e19e7))
+
+### Refactors
+
+- Changed linegraph and sankeygraph options ([#2089](https://github.com/juspay/hyperswitch-control-center/pull/2089)) ([`4cf2c50`](https://github.com/juspay/hyperswitch-control-center/commit/4cf2c50d5999015d4fb41947e4513f6a413bf14c))
+
+### Miscellaneous Tasks
+
+- Remove unused feature flags and codeblocks ([#1931](https://github.com/juspay/hyperswitch-control-center/pull/1931)) ([`d3d32a6`](https://github.com/juspay/hyperswitch-control-center/commit/d3d32a62684e67da7a5181046521852ba664a2ab))
+
+**Full Changelog:** [`2025.01.20.1...2025.01.21.0`](https://github.com/juspay/hyperswitch-control-center/compare/2025.01.20.1...2025.01.21.0)
+
+- - -
+
 ## 2025.01.20.1
 
 ### Features

--- a/src/components/Graphs/SankyGraph/SankeyGraphUtils.res
+++ b/src/components/Graphs/SankyGraph/SankeyGraphUtils.res
@@ -8,7 +8,7 @@ let valueFormatter = (
   @this
   (this: nodeFormatter) => {
     let weight = this.point.options.dataLabels.name
-    let sum = weight->Int.toFloat->NewAnalyticsUtils.valueFormatter(Volume)
+    let sum = weight->Int.toFloat->LogicUtils.valueFormatter(Volume)
     let label = `<span style="font-size: 20px; font-weight: bold;">${sum}</span><br/> <span style="font-size: 14px;">${this.point.id}</span>`
     label
   }
@@ -19,7 +19,7 @@ let tooltipFormatter = (
   (this: pointFormatter) => {
     let pointType = this.point.formatPrefix == "node" ? Node : Link
 
-    let format = value => value->Int.toFloat->NewAnalyticsUtils.valueFormatter(Volume)
+    let format = value => value->Int.toFloat->LogicUtils.valueFormatter(Volume)
 
     let arrowIcon = "&#8594;"
 
@@ -40,7 +40,7 @@ let tooltipFormatter = (
         let percentage = toValue->Int.toFloat /. fromValue->Int.toFloat *. 100.0
         (
           `${toValue->format} of ${fromValue->format}`,
-          `${percentage->NewAnalyticsUtils.valueFormatter(Rate)}`,
+          `${percentage->LogicUtils.valueFormatter(Rate)}`,
         )
       }
 

--- a/src/screens/NewAnalytics/NewAnalyticsFilters/NewAnalyticsFiltersUtils.res
+++ b/src/screens/NewAnalytics/NewAnalyticsFilters/NewAnalyticsFiltersUtils.res
@@ -1,12 +1,5 @@
 open NewAnalyticsTypes
 
-let getTypeValue = value => {
-  switch value {
-  | "all_currencies" => #all_currencies
-  | _ => #none
-  }
-}
-
 let defaultCurrency = {
   label: "All Currencies (Converted to USD*)",
   value: (#all_currencies: defaultFilters :> string),

--- a/src/screens/NewAnalytics/NewAnalyticsHelper.res
+++ b/src/screens/NewAnalytics/NewAnalyticsHelper.res
@@ -190,7 +190,7 @@ module StatisticsCard = {
       <div className="-mb-0.5 flex">
         {icon}
         <div className="font-semibold text-sm pt-0.5 pr-0.5">
-          {`${value->NewAnalyticsUtils.valueFormatter(Rate)}`->React.string}
+          {`${value->LogicUtils.valueFormatter(Rate)}`->React.string}
         </div>
       </div>
     </div>

--- a/src/screens/NewAnalytics/NewAnalyticsTypes.res
+++ b/src/screens/NewAnalytics/NewAnalyticsTypes.res
@@ -73,14 +73,6 @@ type chartEntity<'t, 'chartOption, 'data> = {
 
 type optionType = {label: string, value: string}
 
-type valueType =
-  | Amount
-  | Rate
-  | Volume
-  | Latency
-  | LatencyMs
-  | No_Type
-
 type metricType =
   | Smart_Retry
   | Default
@@ -88,7 +80,7 @@ type metricType =
 type singleStatConfig = {
   titleText: string,
   description: string,
-  valueType: valueType,
+  valueType: LogicUtilsTypes.valueType,
 }
 
 type filters = [#currency]

--- a/src/screens/NewAnalytics/NewAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/NewAnalyticsUtils.res
@@ -81,32 +81,6 @@ let requestBody = (
   ]->JSON.Encode.array
 }
 
-let formatCurrency = currency => {
-  switch currency->NewAnalyticsFiltersUtils.getTypeValue {
-  | #all_currencies => "USD*"
-  | _ => currency->String.toUpperCase
-  }
-}
-
-let valueFormatter = (value, statType: valueType, ~currency="") => {
-  open LogicUtils
-
-  let amountSuffix = currency->formatCurrency
-
-  let percentFormat = value => {
-    `${Float.toFixedWithPrecision(value, ~digits=2)}%`
-  }
-
-  switch statType {
-  | Amount => `${value->indianShortNum} ${amountSuffix}`
-  | Rate => value->Js.Float.isNaN ? "-" : value->percentFormat
-  | Volume => value->indianShortNum
-  | Latency => latencyShortNum(~labelValue=value)
-  | LatencyMs => latencyShortNum(~labelValue=value, ~includeMilliseconds=true)
-  | No_Type => value->Float.toString
-  }
-}
-
 let getMonthName = month => {
   switch month {
   | 0 => "Jan"
@@ -182,7 +156,9 @@ let getToolTipConparision = (~primaryValue, ~secondaryValue) => {
   | No_Change => ("#A0A0A0", "")
   }
 
-  `<span style="color:${textColor};margin-left:7px;" >${icon}${value->valueFormatter(Rate)}</span>`
+  `<span style="color:${textColor};margin-left:7px;" >${icon}${value->LogicUtils.valueFormatter(
+      Rate,
+    )}</span>`
 }
 
 open LogicUtils

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/FailureReasonsRefunds/FailureReasonsRefundsUtils.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/FailureReasonsRefunds/FailureReasonsRefundsUtils.res
@@ -1,4 +1,3 @@
-open NewAnalyticsTypes
 open FailureReasonsRefundsTypes
 open LogicUtils
 
@@ -72,7 +71,6 @@ let getHeading = colType => {
 }
 
 let getCell = (obj, colType): Table.cell => {
-  open NewAnalyticsUtils
   switch colType {
   | Refund_Error_Message => Text(obj.refund_error_message)
   | Refund_Error_Message_Count => Text(obj.refund_error_message_count->Int.toString)

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsOverviewSection/RefundsOverviewSectionUtils.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsOverviewSection/RefundsOverviewSectionUtils.res
@@ -40,7 +40,7 @@ let getValueFromObj = (data, index, responseKey) => {
 }
 
 let getKey = (id, ~currency="") => {
-  open NewAnalyticsFiltersUtils
+  open LogicUtils
   let key = switch id {
   | Total_Refund_Success_Rate => #total_refund_success_rate
   | Successful_Refund_Count => #successful_refund_count

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
@@ -54,6 +54,8 @@ module TableModule = {
 module RefundsProcessedHeader = {
   open NewAnalyticsUtils
   open LogicUtils
+  open LogicUtilsTypes
+
   @react.component
   let make = (
     ~data: JSON.t,

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessedUtils.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessedUtils.res
@@ -51,7 +51,7 @@ let refundsProcessedMapper = (
     text: "Refunds Processed",
   }
 
-  open NewAnalyticsTypes
+  open LogicUtilsTypes
   let metricType = switch xKey->getVariantValueFromString {
   | Refund_Processed_Amount => Amount
   | _ => Volume
@@ -157,7 +157,6 @@ let getKeyForModule = key => {
 }
 
 let getKey = (id, ~currency="") => {
-  open NewAnalyticsFiltersUtils
   let key = switch id {
   | Refund_Processed_Count => #refund_processed_count
 

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsReasons/RefundsReasonsUtils.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsReasons/RefundsReasonsUtils.res
@@ -1,4 +1,3 @@
-open NewAnalyticsTypes
 open RefundsReasonsTypes
 open LogicUtils
 
@@ -71,7 +70,7 @@ let getCell = (obj, colType): Table.cell => {
   | Refund_Reason_Count => Text(obj.refund_reason_count->Int.toString)
   | Total_Refund_Reason_Count => Text(obj.total_refund_reason_count->Int.toString)
   | Refund_Reason_Count_Ratio =>
-    Text(obj.refund_reason_count_ratio->NewAnalyticsUtils.valueFormatter(Rate))
+    Text(obj.refund_reason_count_ratio->LogicUtils.valueFormatter(Rate))
   | Connector => Text(obj.connector)
   }
 }

--- a/src/screens/NewAnalytics/PaymentAnalytics/FailedPaymentsDistribution/FailedPaymentsDistributionUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/FailedPaymentsDistribution/FailedPaymentsDistributionUtils.res
@@ -119,7 +119,6 @@ let getHeading = colType => {
 }
 
 let getCell = (obj, colType): Table.cell => {
-  open NewAnalyticsUtils
   switch colType {
   | Payments_Failure_Rate_Distribution =>
     Text(obj.payments_failure_rate_distribution->valueFormatter(Rate))

--- a/src/screens/NewAnalytics/PaymentAnalytics/FailureReasonsPayments/FailureReasonsPaymentsUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/FailureReasonsPayments/FailureReasonsPaymentsUtils.res
@@ -100,7 +100,6 @@ let getHeading = colType => {
 }
 
 let getCell = (obj, colType): Table.cell => {
-  open NewAnalyticsUtils
   switch colType {
   | Error_Reason => Text(obj.error_reason)
   | Failure_Reason_Count => Text(obj.failure_reason_count->Int.toString)

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsOverviewSection/NewPaymentsOverviewSectionUtils.res
@@ -43,7 +43,7 @@ let parseResponse = (response, key) => {
 
 open NewAnalyticsTypes
 let getKey = (id, ~isSmartRetryEnabled=Smart_Retry, ~currency="") => {
-  open NewAnalyticsFiltersUtils
+  open LogicUtils
   let key = switch id {
   | Total_Dispute => #total_dispute
   | Total_Refund_Processed_Amount =>

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessed.res
@@ -54,6 +54,8 @@ module TableModule = {
 module PaymentsProcessedHeader = {
   open NewAnalyticsUtils
   open LogicUtils
+  open LogicUtilsTypes
+
   @react.component
   let make = (
     ~data: JSON.t,

--- a/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/PaymentsProcessed/PaymentsProcessedUtils.res
@@ -49,7 +49,7 @@ let paymentsProcessedMapper = (
     text: "Payments Processed",
   }
 
-  open NewAnalyticsTypes
+  open LogicUtilsTypes
   let metricType = switch xKey->getVariantValueFromString {
   | Payment_Processed_Amount => Amount
   | _ => Volume
@@ -155,7 +155,6 @@ let defaulGranularity = {
 
 open NewAnalyticsTypes
 let getKey = (id, ~isSmartRetryEnabled=Smart_Retry, ~currency="") => {
-  open NewAnalyticsFiltersUtils
   let key = switch id {
   | Time_Bucket => #time_bucket
   | Payment_Processed_Count =>

--- a/src/screens/NewAnalytics/PaymentAnalytics/SuccessfulPaymentsDistribution/SuccessfulPaymentsDistributionUtils.res
+++ b/src/screens/NewAnalytics/PaymentAnalytics/SuccessfulPaymentsDistribution/SuccessfulPaymentsDistributionUtils.res
@@ -120,7 +120,6 @@ let getHeading = colType => {
 }
 
 let getCell = (obj, colType): Table.cell => {
-  open NewAnalyticsUtils
   switch colType {
   | Payments_Success_Rate_Distribution =>
     Text(obj.payments_success_rate_distribution->valueFormatter(Rate))

--- a/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessed.res
+++ b/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessed.res
@@ -54,6 +54,8 @@ module TableModule = {
 module SmartRetryPaymentsProcessedHeader = {
   open NewAnalyticsUtils
   open LogicUtils
+  open LogicUtilsTypes
+
   @react.component
   let make = (
     ~data: JSON.t,

--- a/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessedUtils.res
+++ b/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessedUtils.res
@@ -51,7 +51,7 @@ let smartRetryPaymentsProcessedMapper = (
     text: "Smart Retry Payments Processed",
   }
 
-  open NewAnalyticsTypes
+  open LogicUtilsTypes
   let metricType = switch xKey->getVariantValueFromString {
   | Payment_Processed_Amount => Amount
   | _ => Volume
@@ -156,7 +156,6 @@ let defaulGranularity = {
 }
 
 let getKey = (id, ~isSmartRetryEnabled=Smart_Retry, ~currency="") => {
-  open NewAnalyticsFiltersUtils
   let key = switch id {
   | Time_Bucket => #time_bucket
   | Payment_Processed_Count =>

--- a/src/utils/LogicUtils.res
+++ b/src/utils/LogicUtils.res
@@ -546,6 +546,37 @@ let convertNewLineSaperatedDataToArrayOfJson = text => {
   })
 }
 
+let getTypeValue = value => {
+  switch value {
+  | "all_currencies" => #all_currencies
+  | _ => #none
+  }
+}
+
+let formatCurrency = currency => {
+  switch currency->getTypeValue {
+  | #all_currencies => "USD*"
+  | _ => currency->String.toUpperCase
+  }
+}
+
+let valueFormatter = (value, statType: LogicUtilsTypes.valueType, ~currency="") => {
+  let amountSuffix = currency->formatCurrency
+
+  let percentFormat = value => {
+    `${Float.toFixedWithPrecision(value, ~digits=2)}%`
+  }
+
+  switch statType {
+  | Amount => `${value->indianShortNum} ${amountSuffix}`
+  | Rate => value->Js.Float.isNaN ? "-" : value->percentFormat
+  | Volume => value->indianShortNum
+  | Latency => latencyShortNum(~labelValue=value)
+  | LatencyMs => latencyShortNum(~labelValue=value, ~includeMilliseconds=true)
+  | No_Type => value->Float.toString
+  }
+}
+
 let getObjectArrayFromJson = json => {
   json->getArrayFromJson([])->Array.map(getDictFromJsonObject)
 }

--- a/src/utils/LogicUtilsTypes.res
+++ b/src/utils/LogicUtilsTypes.res
@@ -1,0 +1,7 @@
+type valueType =
+  | Amount
+  | Rate
+  | Volume
+  | Latency
+  | LatencyMs
+  | No_Type


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Moved value formatter to LogicUtils

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/2097
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

Refactoring PR make sure the NewAnalytics have amount in the format as earlier.

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
