### PR TITLE
fix: sdk go to payment button redirection fix

### DIFF
--- a/src/screens/SDKPayment/SDKPage.res
+++ b/src/screens/SDKPayment/SDKPage.res
@@ -96,6 +96,7 @@ let make = () => {
   let paymentConnectorList =
     connectorList->RoutingUtils.filterConnectorList(~retainInList=PaymentConnector)
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+  let {userInfo: {profileId, merchantId, orgId}} = React.useContext(UserInfoProvider.defaultContext)
 
   React.useEffect(() => {
     let paymentIntentOptional = filtersFromUrl->Dict.get("payment_intent_client_secret")
@@ -133,7 +134,9 @@ let make = () => {
   let onProceed = async (~paymentId) => {
     switch paymentId {
     | Some(val) =>
-      RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url=`/payments/${val}`))
+      RescriptReactRouter.replace(
+        GlobalVars.appendDashboardPath(~url=`/payments/${val}/${profileId}/${merchantId}/${orgId}`),
+      )
     | None => ()
     }
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
`go to payment` button after successful payment through sdk dashboard including the profile, merchant and org id to the redirection link 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
after a successful payment done though sdk in dashboard the `go to payment` button should redirect to that payments details page 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
