### PR TITLE
feat: granularity options for refunds tab analytics

### DIFF
--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
@@ -65,10 +65,12 @@ module RefundsProcessedHeader = {
     ~setSelectedMetric,
     ~granularity,
     ~setGranularity,
+    ~granularityOptions,
   ) => {
     let {filterValueJson} = React.useContext(FilterContext.filterContext)
     let comparison = filterValueJson->getString("comparison", "")->DateRangeUtils.comparisonMapprer
     let currency = filterValueJson->getString((#currency: filters :> string), "")
+    let featureFlag = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
     let primaryValue = getMetaDataValue(
       ~data,
@@ -108,7 +110,7 @@ module RefundsProcessedHeader = {
     | _ => Volume
     }
 
-    <div className="w-full px-7 py-8 grid grid-cols-1">
+    <div className="w-full px-7 py-8 grid grid-cols-3">
       <div className="flex gap-2 items-center">
         <div className="text-fs-28 font-semibold">
           {primaryValue->valueFormatter(metricType, ~currency)->React.string}
@@ -119,12 +121,16 @@ module RefundsProcessedHeader = {
           />
         </RenderIf>
       </div>
-      // will enable it in future
-      <RenderIf condition={false}>
-        <div className="flex justify-center">
-          <Tabs option={granularity} setOption={setGranularity} options={tabs} />
-        </div>
-      </RenderIf>
+      <div className="flex justify-center">
+        <RenderIf condition={featureFlag.granularity}>
+          <Tabs
+            option={granularity}
+            setOption={setGranularity}
+            options={granularityOptions}
+            showSingleTab=false
+          />
+        </RenderIf>
+      </div>
       <div className="flex gap-2 justify-end">
         <CustomDropDown
           buttonText={selectedMetric} options={dropDownOptions} setOption={setSelectedMetric}
@@ -161,6 +167,7 @@ let make = (
   let comparison = filterValueJson->getString("comparison", "")->DateRangeUtils.comparisonMapprer
   let currency = filterValueJson->getString((#currency: filters :> string), "")
 
+  let granularityOptions = getGranularityOptions(~startTime=startTimeVal, ~endTime=endTimeVal)
   let (granularity, setGranularity) = React.useState(_ =>
     getDefaultGranularity(~startTime=startTimeVal, ~endTime=endTimeVal)
   )
@@ -266,7 +273,15 @@ let make = (
       getRefundsProcessed()->ignore
     }
     None
-  }, (startTimeVal, endTimeVal, compareToStartTime, compareToEndTime, comparison, currency))
+  }, (
+    startTimeVal,
+    endTimeVal,
+    compareToStartTime,
+    compareToEndTime,
+    comparison,
+    currency,
+    granularity,
+  ))
 
   let params = {
     data: refundsProcessedData,
@@ -292,6 +307,7 @@ let make = (
           setSelectedMetric
           granularity
           setGranularity
+          granularityOptions
         />
         <div className="mb-5">
           {switch viewType {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
added granularity options for refunds tab analytics
![Screenshot 2025-01-21 at 5 40 40 PM](https://github.com/user-attachments/assets/d37de601-124e-45cb-8b14-553a479aa220)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
on diff granularity options selected the number of points on graph should change and on diff time range the granuality options should also change [tabs displayed]
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
