### PR TITLE
fix: Refactoring append themes css logic

### DIFF
--- a/public/hyperswitch/module.js
+++ b/public/hyperswitch/module.js
@@ -274,13 +274,13 @@ function appendStyle(themesConfig) {
   ${generateVariablesForSection(settings.spacing, "spacing")}
 
 }`;
-  if (document.getElementById("custom-themes-style")) {
-    style = document.getElementById("custom-themes-style");
+  let style = document.getElementById("custom-themes-style");
+  if (style) {
+    style.textContent = cssVariables;
   } else {
     style = document.createElement("style");
+    style.id = "custom-themes-style";
+    style.textContent = cssVariables;
+    document.head.appendChild(style);
   }
-  let text = document.createTextNode(cssVariables);
-  style.setAttribute("id", "custom-themes-style");
-  style.appendChild(text);
-  document.head.appendChild(style);
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Initially the themes css was getting appended to the dom multiple times. The changes allow to just replace with the last updated values.

## Motivation and Context



## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
