### PR TITLE
chore: customer list limit increased from 10 to 50

### DIFF
--- a/src/screens/Customers/Customers.res
+++ b/src/screens/Customers/Customers.res
@@ -10,8 +10,8 @@ let make = () => {
   let defaultValue: LoadedTable.pageDetails = {offset: 0, resultsPerPage: 20}
   let pageDetail = pageDetailDict->Dict.get("customers")->Option.getOr(defaultValue)
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
-  let total = 50 // TODO: take this value from API response [currenctly set to 5 pages]
-  let limit = 50 // each api calls will retrun 50 results
+  let total = 100 // TODO: take this value from API response [currenctly set to 5 pages]
+  let limit = 20 // each api calls will retrun 50 results
 
   let getCustomersList = async () => {
     setScreenState(_ => PageLoaderWrapper.Loading)
@@ -61,7 +61,7 @@ let make = () => {
       hideTitle=true
       actualData=customersData
       entity={customersEntity}
-      resultsPerPage=10
+      resultsPerPage=20
       showSerialNumber=true
       totalResults=total
       offset
@@ -70,6 +70,7 @@ let make = () => {
       defaultColumns={defaultColumns}
       customColumnMapper={TableAtoms.customersMapDefaultCols}
       showSerialNumberInCustomizeColumns=false
+      showResultsPerPageSelector=false
       sortingBasedOnDisabled=false
       showAutoScroll=true
     />

--- a/src/screens/Customers/Customers.res
+++ b/src/screens/Customers/Customers.res
@@ -11,6 +11,7 @@ let make = () => {
   let pageDetail = pageDetailDict->Dict.get("customers")->Option.getOr(defaultValue)
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
   let total = 50 // TODO: take this value from API response [currenctly set to 5 pages]
+  let limit = 50 // each api calls will retrun 50 results
 
   let getCustomersList = async () => {
     setScreenState(_ => PageLoaderWrapper.Loading)
@@ -18,7 +19,7 @@ let make = () => {
       let customersUrl = getURL(
         ~entityName=CUSTOMERS,
         ~methodType=Get,
-        ~queryParamerters=Some(`offset=${offset->Int.toString}`),
+        ~queryParamerters=Some(`limit=${limit->Int.toString}&offset=${offset->Int.toString}`),
       )
 
       let response = await fetchDetails(customersUrl)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
api calls will fertch 50 items per api calls 
![Screenshot 2025-01-23 at 2 35 34 PM](https://github.com/user-attachments/assets/f8673f6c-2f60-428b-870f-27469fcf1792)

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
each calls should retrun a 50 items and when u select show 50 results per page it should display all 50 rows 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
