### PR TITLE
fix: analytics filters init set function modification

### DIFF
--- a/src/container/NewAnalyticsContainer.res
+++ b/src/container/NewAnalyticsContainer.res
@@ -58,6 +58,7 @@ let make = () => {
     ~compareToStartTimeKey,
     ~compareToEndTimeKey,
     ~origin="analytics",
+    ~isInsightsPage=true,
     ~enableCompareTo=Some(true),
     ~range=6,
     ~comparisonKey,

--- a/src/screens/HSwitchRemoteFilter.res
+++ b/src/screens/HSwitchRemoteFilter.res
@@ -37,6 +37,7 @@ let useSetInitialFilters = (
   ~compareToEndTimeKey="",
   ~enableCompareTo=None,
   ~comparisonKey="",
+  ~isInsightsPage=false,
   ~range=7,
   ~origin,
   (),
@@ -68,15 +69,20 @@ let useSetInitialFilters = (
                   (compareToStartTimeKey, compareToStartTime),
                   (compareToEndTimeKey, compareToEndTime),
                   (comparisonKey, (DateRangeUtils.DisableComparison :> string)),
-                  ((#currency: filters :> string), (#all_currencies: defaultFilters :> string)),
                 ]
               }
             | None => [
                 (startTimeFilterKey, defaultDate.start_time),
                 (endTimeFilterKey, defaultDate.end_time),
-                ((#currency: filters :> string), (#all_currencies: defaultFilters :> string)),
               ]
             }
+
+      if isInsightsPage {
+        timeRange->Array.push((
+          (#currency: filters :> string),
+          (#all_currencies: defaultFilters :> string),
+        ))
+      }
 
       timeRange->Array.forEach(item => {
         let (key, defaultValue) = item


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
analytics currency filter modification 
<img width="941" alt="Screenshot 2025-01-29 at 12 35 34 PM" src="https://github.com/user-attachments/assets/08c3d19c-8300-4e61-b93a-d9ca508d9364" />
<img width="940" alt="Screenshot 2025-01-29 at 12 35 45 PM" src="https://github.com/user-attachments/assets/f669f79b-0a09-4ea0-897c-05ca5df87b91" />

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the currency applied in insights page shoudn't effect the old paymants and refunds analytics pages
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
