### PR TITLE
fix: org indexes logic fix

### DIFF
--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -319,7 +319,6 @@ let analytics = (
   ~authenticationAnalyticsFlag,
   ~userHasResourceAccess,
 ) => {
-  Js.log(authenticationAnalyticsFlag)
   let links = [paymentAnalytcis, refundAnalytics]
   if authenticationAnalyticsFlag {
     links->Array.push(authenticationAnalytics)

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -68,12 +68,11 @@ module OrgTile = {
     let displayText = {
       let firstLetter = orgName->String.charAt(0)->String.toUpperCase
       if orgName == orgID {
-        let count =
-          orgList
-          ->Array.slice(~start=0, ~end=index + 1)
-          ->Array.filter(org => org.name == org.id)
-          ->Array.length
-        `O${count->Int.toString}`
+        let lastTwoChars =
+          (len => orgID->String.slice(~start=len - 2, ~end=len))(
+            orgID->String.length,
+          )->String.toUpperCase
+        lastTwoChars
       } else {
         firstLetter
       }
@@ -328,7 +327,7 @@ let make = () => {
     setUnderEdit(_ => selectedEditId)
   }
 
-  <div className={`${backgroundColor.sidebarNormal} p-2 border-r ${borderColor}`}>
+  <div className={`${backgroundColor.sidebarNormal} relative inset-0 p-2 border-r ${borderColor}`}>
     // the org tiles
     <div className="flex flex-col gap-5 py-3 px-2 items-center justify-center ">
       {orgList

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -327,7 +327,7 @@ let make = () => {
     setUnderEdit(_ => selectedEditId)
   }
 
-  <div className={`${backgroundColor.sidebarNormal} relative inset-0 p-2 border-r ${borderColor}`}>
+  <div className={`${backgroundColor.sidebarNormal} p-2 border-r ${borderColor}`}>
     // the org tiles
     <div className="flex flex-col gap-5 py-3 px-2 items-center justify-center ">
       {orgList

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -16,7 +16,7 @@ module OrgTile = {
     let updateDetails = useUpdateMethod()
     let fetchDetails = useGetMethod()
     let showToast = ToastState.useShowToast()
-    let (_, setOrgList) = Recoil.useRecoilState(HyperswitchAtom.orgListAtom)
+    let setOrgList = Recoil.useSetRecoilState(HyperswitchAtom.orgListAtom)
     let {userInfo: {orgId}} = React.useContext(UserInfoProvider.defaultContext)
     let {
       globalUIConfig: {
@@ -68,11 +68,9 @@ module OrgTile = {
     let displayText = {
       let firstLetter = orgName->String.charAt(0)->String.toUpperCase
       if orgName == orgID {
-        let lastTwoChars =
-          orgID
-          ->String.slice(~start=orgID->String.length - 2, ~end=orgID->String.length)
-          ->String.toUpperCase
-        lastTwoChars
+        orgID
+        ->String.slice(~start=orgID->String.length - 2, ~end=orgID->String.length)
+        ->String.toUpperCase
       } else {
         firstLetter
       }

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -16,7 +16,7 @@ module OrgTile = {
     let updateDetails = useUpdateMethod()
     let fetchDetails = useGetMethod()
     let showToast = ToastState.useShowToast()
-    let (orgList, setOrgList) = Recoil.useRecoilState(HyperswitchAtom.orgListAtom)
+    let (_, setOrgList) = Recoil.useRecoilState(HyperswitchAtom.orgListAtom)
     let {userInfo: {orgId}} = React.useContext(UserInfoProvider.defaultContext)
     let {
       globalUIConfig: {
@@ -69,9 +69,9 @@ module OrgTile = {
       let firstLetter = orgName->String.charAt(0)->String.toUpperCase
       if orgName == orgID {
         let lastTwoChars =
-          (len => orgID->String.slice(~start=len - 2, ~end=len))(
-            orgID->String.length,
-          )->String.toUpperCase
+          orgID
+          ->String.slice(~start=orgID->String.length - 2, ~end=orgID->String.length)
+          ->String.toUpperCase
         lastTwoChars
       } else {
         firstLetter


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Used the last two characters of `orgID` as the `orgTile` display when orgName is not provided.

<img width="313" alt="Screenshot 2025-01-31 at 6 03 37 PM" src="https://github.com/user-attachments/assets/2b945d81-d3d1-4ee4-b3da-22464dea51bd" />


## Motivation and Context

Previously, the list of organizations appeared inconsistent and shuffled when orgName was missing. This change ensures a more structured and recognizable indexing approach.

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
