### PR TITLE
fix: Button issues fix in payment settings and auth select

### DIFF
--- a/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
+++ b/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
@@ -56,12 +56,15 @@ let make = (~setSelectedAuthId) => {
         text="Continue with Password"
         buttonType={Primary}
         buttonSize={Large}
+        customButtonStyle="w-full"
         onClick={_ => handleTerminateSSO(method.id)->ignore}
       />
     | (OPEN_ID_CONNECT, #Okta) | (OPEN_ID_CONNECT, #Google) | (OPEN_ID_CONNECT, #Github) =>
       <Button
         text={`Login with ${(authMethodName :> string)}`}
         buttonType={PrimaryOutline}
+        buttonSize={Large}
+        customButtonStyle="w-full"
         onClick={_ => handleTerminateSSO(method.id)->ignore}
       />
     | (_, _) => React.null

--- a/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
+++ b/src/entryPoints/AuthModule/PreLoginModule/AuthSelect.res
@@ -56,7 +56,7 @@ let make = (~setSelectedAuthId) => {
         text="Continue with Password"
         buttonType={Primary}
         buttonSize={Large}
-        customButtonStyle="w-full"
+        customButtonStyle="!w-full"
         onClick={_ => handleTerminateSSO(method.id)->ignore}
       />
     | (OPEN_ID_CONNECT, #Okta) | (OPEN_ID_CONNECT, #Google) | (OPEN_ID_CONNECT, #Github) =>
@@ -64,7 +64,7 @@ let make = (~setSelectedAuthId) => {
         text={`Login with ${(authMethodName :> string)}`}
         buttonType={PrimaryOutline}
         buttonSize={Large}
-        customButtonStyle="w-full"
+        customButtonStyle="!w-full"
         onClick={_ => handleTerminateSSO(method.id)->ignore}
       />
     | (_, _) => React.null

--- a/src/screens/Developer/PaymentSettings/PaymentSettings.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettings.res
@@ -261,10 +261,9 @@ module WebHookSection = {
             <DesktopRow>
               <div className="flex justify-end w-full gap-2">
                 <SubmitButton
-                  customSumbitButtonStyle="justify-start"
                   text="Update"
                   buttonType=Button.Primary
-                  buttonSize=Button.Small
+                  buttonSize=Button.Medium
                   disabledParamter={!allowEdit}
                 />
                 <Button
@@ -692,10 +691,7 @@ let make = (~webhookOnly=false, ~showFormOnly=false, ~profileId="") => {
                 <DesktopRow>
                   <div className="flex justify-end w-full gap-2">
                     <SubmitButton
-                      customSumbitButtonStyle="justify-start"
-                      text="Update"
-                      buttonType=Button.Primary
-                      buttonSize=Button.Small
+                      text="Update" buttonType=Button.Primary buttonSize=Button.Medium
                     />
                     <Button
                       buttonType=Button.Secondary

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -35,8 +35,8 @@ module ActionButtons = {
       <ACLButton
         text={"Setup"}
         authorization={userHasAccess(~groupAccess=WorkflowsManage)}
-        customButtonStyle="mx-auto"
-        buttonType=Primary
+        customButtonStyle="mx-auto w-full"
+        buttonType={Secondary}
         buttonSize=Small
         onClick={_ => {
           RescriptReactRouter.push(
@@ -51,7 +51,8 @@ module ActionButtons = {
       <ACLButton
         text={"Manage"}
         authorization={userHasAccess(~groupAccess=WorkflowsManage)}
-        buttonType=Primary
+        buttonType={Secondary}
+        customButtonStyle="mx-auto w-full"
         buttonSize=Small
         onClick={_ => {
           RescriptReactRouter.push(


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

changed payment settings update button and auth select to full width button

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

When we invite a user, the user gets email to join the community. Then the button Continue with Password should be full width button.

When we navigate to payment settings the update button should be with center aligned.

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
