### PR TITLE
fix: payout details page display

### DIFF
--- a/src/screens/Payouts/PayoutsEntity.res
+++ b/src/screens/Payouts/PayoutsEntity.res
@@ -301,12 +301,12 @@ let getHeading = colType => {
   }
 }
 
-let getCell = (payoutData, colType): Table.cell => {
+let getCell = (payoutData, colType, merchantId, orgId): Table.cell => {
   switch colType {
   | PayoutId =>
     CustomCell(
       <HSwitchOrderUtils.CopyLinkTableCell
-        url={`/payouts/${payoutData.payout_id}/${payoutData.profile_id}`}
+        url={`/payouts/${payoutData.payout_id}/${payoutData.profile_id}/${merchantId}/${orgId}`}
         displayValue={payoutData.payout_id}
         copyValue={Some(payoutData.payout_id)}
       />,
@@ -429,18 +429,19 @@ let getPayouts: JSON.t => array<payouts> = json => {
   getArrayDataFromJson(json, itemToObjMapper)
 }
 
-let payoutEntity = EntityType.makeEntity(
-  ~uri="",
-  ~getObjects=getPayouts,
-  ~defaultColumns,
-  ~allColumns,
-  ~getHeading,
-  ~getCell,
-  ~dataKey="",
-  ~getShowLink={
-    payoutData =>
-      GlobalVars.appendDashboardPath(
-        ~url=`/payouts/${payoutData.payout_id}/${payoutData.profile_id}`,
-      )
-  },
-)
+let payoutEntity = (merchantId, orgId) =>
+  EntityType.makeEntity(
+    ~uri="",
+    ~getObjects=getPayouts,
+    ~defaultColumns,
+    ~allColumns,
+    ~getHeading,
+    ~getCell=(payout, payoutColsType) => getCell(payout, payoutColsType, merchantId, orgId),
+    ~dataKey="",
+    ~getShowLink={
+      payoutData =>
+        GlobalVars.appendDashboardPath(
+          ~url=`/payouts/${payoutData.payout_id}/${payoutData.profile_id}/${merchantId}/${orgId}`,
+        )
+    },
+  )

--- a/src/screens/Payouts/PayoutsList.res
+++ b/src/screens/Payouts/PayoutsList.res
@@ -16,7 +16,7 @@ let make = () => {
   let pageDetail = pageDetailDict->Dict.get("Payouts")->Option.getOr(defaultValue)
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
-  let {userInfo: {transactionEntity}, checkUserEntity} = React.useContext(
+  let {userInfo: {transactionEntity, orgId, merchantId}, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
   )
   let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
@@ -115,7 +115,7 @@ let make = () => {
           hideTitle=true
           title="Payouts"
           actualData=payoutData
-          entity={PayoutsEntity.payoutEntity}
+          entity={PayoutsEntity.payoutEntity(merchantId, orgId)}
           resultsPerPage=20
           showSerialNumber=true
           totalResults={totalCount}

--- a/src/screens/Payouts/ShowPayout.res
+++ b/src/screens/Payouts/ShowPayout.res
@@ -102,6 +102,7 @@ module PayoutInfo = {
       ~bgColor="bg-white dark:bg-jp-gray-lightgray_background",
       ~children=?,
     ) => {
+      let {userInfo: {orgId, merchantId}} = React.useContext(UserInfoProvider.defaultContext)
       <OrderUtils.Section
         customCssClass={`border border-jp-gray-940 border-opacity-75 dark:border-jp-gray-960 ${bgColor} rounded-md p-5`}>
         <FormRenderer.DesktopRow>
@@ -114,7 +115,7 @@ module PayoutInfo = {
                 <div className={`flex ${widthClass} items-center`}>
                   <OrderUtils.DisplayKeyValueParams
                     heading={getHeading(colType)}
-                    value={getCell(data, colType)}
+                    value={getCell(data, colType, merchantId, orgId)}
                     customMoneyStyle="!font-normal !text-sm"
                     labelMargin="!py-0 mt-2"
                     overiddingHeadingStyles="text-black text-sm font-medium"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Payout details page wasn't being displayed.


https://github.com/user-attachments/assets/eeeb62e7-91c0-4a4d-afbd-6c74eac6fa49



## Motivation and Context

Bug fix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
