### PR TITLE
fix: granularity time conversion fix for smart retry and refunds

### DIFF
--- a/src/screens/NewAnalytics/NewAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/NewAnalyticsUtils.res
@@ -533,18 +533,14 @@ let fillMissingDataPoints = (
   ~timeKey="time_bucket",
   ~defaultValue: JSON.t,
   ~granularity: string,
-  ~isoStringToCustomTimeZone: option<string => TimeZoneHook.dateTimeString>=?,
+  ~isoStringToCustomTimeZone: string => TimeZoneHook.dateTimeString,
   ~granularityEnabled,
 ) => {
   let dataDict = Dict.make()
 
   data->Array.forEach(item => {
-    let time = switch (
-      isoStringToCustomTimeZone,
-      granularityEnabled,
-      granularity != (#G_ONEDAY: granularity :> string),
-    ) {
-    | (Some(timeConvert), true, true) => {
+    let time = switch (granularityEnabled, granularity != (#G_ONEDAY: granularity :> string)) {
+    | (true, true) => {
         let value =
           item
           ->getDictFromJsonObject
@@ -552,7 +548,7 @@ let fillMissingDataPoints = (
 
         let time = value->getString("start_time", "")
 
-        let {year, month, date, hour, minute} = timeConvert(time)
+        let {year, month, date, hour, minute} = isoStringToCustomTimeZone(time)
 
         if (
           granularity == (#G_THIRTYMIN: granularity :> string) ||

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsProcessed/RefundsProcessed.res
@@ -151,6 +151,7 @@ let make = (
   open NewAnalyticsUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
+  let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let {filterValueJson} = React.useContext(FilterContext.filterContext)
   let (refundsProcessedData, setRefundsProcessedData) = React.useState(_ => JSON.Encode.array([]))
@@ -241,6 +242,7 @@ let make = (
                 "time_bucket": startTimeVal,
               }->Identity.genericTypeToJson,
               ~granularity=granularity.value,
+              ~isoStringToCustomTimeZone,
               ~granularityEnabled=featureFlag.granularity,
             )
           })
@@ -261,6 +263,7 @@ let make = (
               "payment_processed_amount": 0,
               "time_bucket": startTimeVal,
             }->Identity.genericTypeToJson,
+            ~isoStringToCustomTimeZone,
             ~granularity=granularity.value,
             ~granularityEnabled=featureFlag.granularity,
           )

--- a/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsSuccessRate/RefundsSuccessRate.res
+++ b/src/screens/NewAnalytics/NewRefundsAnalytics/RefundsSuccessRate/RefundsSuccessRate.res
@@ -53,6 +53,7 @@ let make = (
   open NewAnalyticsUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
+  let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
 
   let (paymentsSuccessRateData, setPaymentsSuccessRateData) = React.useState(_ =>
@@ -134,6 +135,7 @@ let make = (
                 "payment_processed_amount": 0,
                 "time_bucket": startTimeVal,
               }->Identity.genericTypeToJson,
+              ~isoStringToCustomTimeZone,
               ~granularity=granularity.value,
               ~granularityEnabled=featureFlag.granularity,
             )
@@ -154,6 +156,7 @@ let make = (
               "payment_success_rate": 0,
               "time_bucket": startTimeVal,
             }->Identity.genericTypeToJson,
+            ~isoStringToCustomTimeZone,
             ~granularity=granularity.value,
             ~granularityEnabled=featureFlag.granularity,
           )

--- a/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessed.res
+++ b/src/screens/NewAnalytics/SmartRetryAnalytics/SmartRetryPaymentsProcessed/SmartRetryPaymentsProcessed.res
@@ -149,6 +149,7 @@ let make = (
   open NewAnalyticsUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
+  let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let {filterValueJson} = React.useContext(FilterContext.filterContext)
   let (smartRetryPaymentsProcessedData, setSmartRetryPaymentsProcessedData) = React.useState(_ =>
@@ -253,6 +254,7 @@ let make = (
                 "payment_processed_amount": 0,
                 "time_bucket": startTimeVal,
               }->Identity.genericTypeToJson,
+              ~isoStringToCustomTimeZone,
               ~granularity=granularity.value,
               ~granularityEnabled=featureFlag.granularity,
             )
@@ -274,6 +276,7 @@ let make = (
               "payment_processed_amount": 0,
               "time_bucket": startTimeVal,
             }->Identity.genericTypeToJson,
+            ~isoStringToCustomTimeZone,
             ~granularity=granularity.value,
             ~granularityEnabled=featureFlag.granularity,
           )


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
time conversion fix for smart retry and refunds when granularity set to time range 
<img width="1011" alt="Screenshot 2025-02-14 at 3 08 30 PM" src="https://github.com/user-attachments/assets/afbb2fff-9193-4fd9-aa26-fdebcb1e00c5" />
<img width="1004" alt="Screenshot 2025-02-14 at 3 08 48 PM" src="https://github.com/user-attachments/assets/90d9f26a-6865-4c0e-bf6a-46cbf92a95f3" />
<img width="1010" alt="Screenshot 2025-02-14 at 3 09 02 PM" src="https://github.com/user-attachments/assets/1dbdac79-a725-452b-aeee-459bd3ab0dc2" />
<img width="1000" alt="Screenshot 2025-02-14 at 3 09 15 PM" src="https://github.com/user-attachments/assets/cb191862-5e22-4753-b6aa-596aa2d9f1a2" />

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
time showed in operations tab and ingights should match for payments and refunds 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
