### PR TITLE
fix: Overflowing merchant profile names in dropdowns

### DIFF
--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -22,22 +22,15 @@ module ListBaseComp = {
             ? "rotate-0"
             : "rotate-180"} transition duration-[250ms] opacity-70 ${secondaryTextColor}`
 
-    let subHeadingElem = if subHeading->String.length > 20 {
-      <HelperComponents.EllipsisText
-        displayValue=subHeading endValue=20 showCopy=false customTextStyle={`${secondaryTextColor}`}
-      />
-    } else {
-      {subHeading->React.string}
-    }
-
     <>
       {switch user {
       | #Merchant =>
         <div
           className={`text-sm cursor-pointer font-semibold ${secondaryTextColor} hover:bg-opacity-80`}>
-          <div className="text-left flex gap-2">
-            <p className={`fs-10 ${secondaryTextColor} overflow-scroll text-nowrap`}>
-              subHeadingElem
+          <div className="text-left flex gap-2 w-52">
+            <p
+              className={`fs-10 ${secondaryTextColor} overflow-scroll text-nowrap whitespace-pre `}>
+              {subHeading->React.string}
             </p>
             {showDropdownArrow
               ? <Icon className={`${arrowClassName} ml-1`} name="arrow-without-tail-new" size=15 />
@@ -48,9 +41,10 @@ module ListBaseComp = {
       | #Profile =>
         <div
           className="flex flex-row cursor-pointer items-center p-3 gap-2 min-w-44 justify-between h-8 bg-white border rounded-lg border-nd_gray-100 shadow-sm">
-          <div>
-            <p className="overflow-scroll text-nowrap text-sm font-medium text-nd_gray-500">
-              subHeadingElem
+          <div className="max-w-40">
+            <p
+              className="overflow-scroll text-nowrap text-sm font-medium text-nd_gray-500 whitespace-pre  ">
+              {subHeading->React.string}
             </p>
           </div>
           {showDropdownArrow


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

If the names of the profile and merchant were more than 20 then it was showing functional ellipses causing overflow on opening. Added overflow scroll to view large names and stop overflow.

After changes:

https://github.com/user-attachments/assets/dbe53ce5-f748-4b92-b276-c04723cd72c3


## Motivation and Context

UI 

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
