### PR TITLE
fix: maintaining org sidebar list order

### DIFF
--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -23,11 +23,18 @@ module OrgTile = {
         sidebarColor: {backgroundColor, primaryTextColor, secondaryTextColor, borderColor},
       },
     } = React.useContext(ThemeProvider.themeContext)
+
+    let sortByOrgName = (org1, org2) => {
+      compareLogic(org2, org1)
+    }
+
     let getOrgList = async () => {
       try {
         let url = getURL(~entityName=USERS, ~userType=#LIST_ORG, ~methodType=Get)
         let response = await fetchDetails(url)
-        setOrgList(_ => response->getArrayDataFromJson(OMPSwitchUtils.orgItemToObjMapper))
+        let orgData = response->getArrayDataFromJson(OMPSwitchUtils.orgItemToObjMapper)
+        orgData->Array.sort(sortByOrgName)
+        setOrgList(_ => orgData)
       } catch {
       | _ => {
           setOrgList(_ => OMPSwitchUtils.ompDefaultValue(orgId, ""))
@@ -287,6 +294,10 @@ let make = () => {
   let isTenantAdmin = roleId->HyperSwitchUtils.checkIsTenantAdmin
   let showToast = ToastState.useShowToast()
 
+  let sortByOrgName = (org1, org2) => {
+    compareLogic(org2, org1)
+  }
+
   let {
     globalUIConfig: {sidebarColor: {backgroundColor, hoverColor, secondaryTextColor, borderColor}},
   } = React.useContext(ThemeProvider.themeContext)
@@ -294,7 +305,9 @@ let make = () => {
     try {
       let url = getURL(~entityName=USERS, ~userType=#LIST_ORG, ~methodType=Get)
       let response = await fetchDetails(url)
-      setOrgList(_ => response->getArrayDataFromJson(orgItemToObjMapper))
+      let orgData = response->getArrayDataFromJson(orgItemToObjMapper)
+      orgData->Array.sort(sortByOrgName)
+      setOrgList(_ => orgData)
     } catch {
     | _ => {
         setOrgList(_ => ompDefaultValue(orgId, ""))
@@ -329,15 +342,6 @@ let make = () => {
     // the org tiles
     <div className="flex flex-col gap-5 py-3 px-2 items-center justify-center ">
       {orgList
-      ->Array.toSorted((org1, org2) => {
-        if org1.id === orgId {
-          -1.
-        } else if org2.id === orgId {
-          1.
-        } else {
-          0.
-        }
-      })
       ->Array.mapWithIndex((org, i) => {
         <OrgTile
           key={Int.toString(i)}

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -24,8 +24,8 @@ module OrgTile = {
       },
     } = React.useContext(ThemeProvider.themeContext)
 
-    let sortByOrgName = (org1, org2) => {
-      compareLogic(org2, org1)
+    let sortByOrgName = (org1: OMPSwitchTypes.ompListTypes, org2: OMPSwitchTypes.ompListTypes) => {
+      compareLogic(org2.name->String.toLowerCase, org1.name->String.toLowerCase)
     }
 
     let getOrgList = async () => {
@@ -42,6 +42,7 @@ module OrgTile = {
         }
       }
     }
+
     let onSubmit = async (newOrgName: string) => {
       try {
         let values = {"organization_name": newOrgName}->Identity.genericTypeToJson
@@ -294,8 +295,8 @@ let make = () => {
   let isTenantAdmin = roleId->HyperSwitchUtils.checkIsTenantAdmin
   let showToast = ToastState.useShowToast()
 
-  let sortByOrgName = (org1, org2) => {
-    compareLogic(org2, org1)
+  let sortByOrgName = (org1: OMPSwitchTypes.ompListTypes, org2: OMPSwitchTypes.ompListTypes) => {
+    compareLogic(org2.name->String.toLowerCase, org1.name->String.toLowerCase)
   }
 
   let {

--- a/src/screens/UserManagement/UserRevamp/ListUsers.res
+++ b/src/screens/UserManagement/UserRevamp/ListUsers.res
@@ -19,8 +19,11 @@ let make = () => {
     setUserModuleEntity,
   ) = React.useState(_ => #Default)
 
-  let sortByEmail = (email1, email2) => {
-    compareLogic(email2, email1)
+  let sortByEmail = (
+    user1: ListUserTableEntity.userTableTypes,
+    user2: ListUserTableEntity.userTableTypes,
+  ) => {
+    compareLogic(user2.email->String.toLowerCase, user1.email->String.toLowerCase)
   }
 
   let getUserData = async (userModuleEntity: UserManagementTypes.userModuleTypes) => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

While switching the organization, the organization list order is maintained without shifting active organization to the top of the organization list.

<!-- Describe your changes in detail -->

## Motivation and Context

Requirement

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Locally

https://github.com/user-attachments/assets/f999de4b-c3d8-4ba2-8339-41cf82b6822a


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
