### PR TITLE
fix: fraud and risk connector list bug fix

### DIFF
--- a/src/screens/Connectors/FraudAndRisk/FRMSelect.res
+++ b/src/screens/Connectors/FraudAndRisk/FRMSelect.res
@@ -90,7 +90,7 @@ let make = () => {
   let (searchText, setSearchText) = React.useState(_ => "")
   let connectorList = ConnectorInterface.useConnectorArrayMapper(
     ~interface=ConnectorInterface.connectorInterfaceV1,
-    ~retainInList=PaymentVas,
+    ~retainInList=PaymentProcessor,
   )
 
   let customUI =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Even though there's a payment connectors beign configued the from page still shows defailt landing page 
<img width="1248" alt="Screenshot 2025-03-05 at 1 44 49 PM" src="https://github.com/user-attachments/assets/5742c5d8-d904-4233-b8a8-b6f73fb48007" />

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the frm should show frm connectors when there one or more payment connectors are beign configured 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
