### PR TITLE
fix: column graph tooltip formatter listing

### DIFF
--- a/src/IntelligentRoutingScreens/IntelligentRoutingHelper.res
+++ b/src/IntelligentRoutingScreens/IntelligentRoutingHelper.res
@@ -73,7 +73,6 @@ let columnGraphOptions: ColumnGraphTypes.columnGraphPayload = {
   tooltipFormatter: ColumnGraphUtils.columnGraphTooltipFormatter(
     ~title="Revenue Uplift",
     ~metricType=AmountWithSuffix,
-    ~reverse=true,
   ),
   yAxisFormatter: ColumnGraphUtils.columnGraphYAxisFormatter(
     ~statType=AmountWithSuffix,

--- a/src/components/Graphs/ColumnGraph/ColumnGraphUtils.res
+++ b/src/components/Graphs/ColumnGraph/ColumnGraphUtils.res
@@ -93,24 +93,12 @@ let getColumnGraphOptions = (columnGraphOptions: columnGraphPayload) => {
   }
 }
 
-let columnGraphTooltipFormatter = (
-  ~title,
-  ~metricType: LogicUtilsTypes.valueType,
-  ~reverse=false,
-) => {
-  open LogicUtils
-
+let columnGraphTooltipFormatter = (~title, ~metricType: LogicUtilsTypes.valueType) => {
   (
     @this
     (this: pointFormatter) => {
       let title = `<div style="font-size: 16px; font-weight: bold;">${title}</div>`
-
-      let primaryIndex = reverse ? 1 : 0
-      let secondaryIndex = reverse ? 0 : 1
-
-      let defaultValue = {color: "", x: "", y: 0.0, point: {index: 0}, key: ""}
-      let primartPoint = this.points->getValueFromArray(primaryIndex, defaultValue)
-      let secondaryPoint = this.points->getValueFromArray(secondaryIndex, defaultValue)
+      let _defaultValue = {color: "", x: "", y: 0.0, point: {index: 0}, key: ""}
 
       let getRowsHtml = (~iconColor, ~date, ~value, ~comparisionComponent="") => {
         let formattedValue = LogicUtils.valueFormatter(value, metricType, ~currency="$")
@@ -123,14 +111,12 @@ let columnGraphTooltipFormatter = (
       }
 
       let tableItems =
-        [
-          getRowsHtml(~iconColor=primartPoint.color, ~date=primartPoint.key, ~value=primartPoint.y),
-          getRowsHtml(
-            ~iconColor=secondaryPoint.color,
-            ~date=secondaryPoint.key,
-            ~value=secondaryPoint.y,
-          ),
-        ]->Array.joinWith("")
+        this.points
+        ->Array.mapWithIndex((point, _index) => {
+          let {color, key, y} = point
+          getRowsHtml(~iconColor=color, ~date=key, ~value=y)
+        })
+        ->Array.joinWith("")
 
       let content = `
           <div style=" 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Column graphs listing the tooltip values 


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Locally

Before:
After recon v2 configuration the column graph tooltip was displaying two values 


<img width="283" alt="Screenshot 2025-03-12 at 9 33 07 PM" src="https://github.com/user-attachments/assets/eef5a0cd-d3f1-44d2-9962-28b590a5e046" />

After: It will be based on the points list

![image](https://github.com/user-attachments/assets/b02bdefa-7531-4a5e-b432-eefa724075b0)
![image](https://github.com/user-attachments/assets/0df48f6f-7ee1-4660-ab4e-580f80b97ef9)

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
