### PR TITLE
fix: recon tabs and production access click changes

### DIFF
--- a/src/Recon/ReconApp/ReconSidebarValues.res
+++ b/src/Recon/ReconApp/ReconSidebarValues.res
@@ -13,7 +13,7 @@ let reconOnBoarding = {
 let reconReports = {
   Link({
     name: "Reconciliation Report",
-    link: `/v2/recon/reports?tab=all`,
+    link: `/v2/recon/reports`,
     access: Access,
     icon: "nd-reports",
     selectedIcon: "nd-reports-fill",

--- a/src/Recon/ReconScreens/ReconOnboarding/ReconOnboarding.res
+++ b/src/Recon/ReconScreens/ReconOnboarding/ReconOnboarding.res
@@ -5,7 +5,7 @@ let make = (~showOnBoarding) => {
   {
     switch showOnBoarding {
     | true => <ReconOnboardingLanding />
-    | false => <ReconOverview />
+    | false => <ReconOverviewContent />
     }
   }
 }

--- a/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
+++ b/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
@@ -433,7 +433,27 @@ module Exceptions = {
 module ReconOverviewContent = {
   @react.component
   let make = () => {
+    open APIUtils
     let mixpanelEvent = MixpanelHook.useSendEvent()
+    let getURL = useGetURL()
+    let updateDetails = useUpdateMethod()
+    let fetchMerchantAccountDetails = MerchantDetailsHook.useFetchMerchantDetails()
+    let showToast = ToastState.useShowToast()
+
+    let onClickForReconRequest = async () => {
+      try {
+        let url = getURL(~entityName=V1(RECON), ~reconType=#REQUEST, ~methodType=Get)
+        let _ = await updateDetails(url, JSON.Encode.null, Post)
+        let _ = await fetchMerchantAccountDetails()
+        showToast(
+          ~message=`Thank you for your interest in our reconciliation module. We are currently reviewing your request for access. We will follow up with you soon regarding next steps.`,
+          ~toastType=ToastSuccess,
+        )
+      } catch {
+      | _ => showToast(~message=`Something went wrong. Please try again.`, ~toastType=ToastError)
+      }
+    }
+
     <div>
       <div
         className="absolute z-10 top-76-px left-0 w-full py-3 px-10 bg-orange-50 flex justify-between items-center">
@@ -449,20 +469,13 @@ module ReconOverviewContent = {
           buttonSize=Medium
           buttonState=Normal
           onClick={_ => {
-            mixpanelEvent(~eventName="recon_send_an_email")
-            ()
+            mixpanelEvent(~eventName="recon_send_an_email_v2")
+            onClickForReconRequest()->ignore
           }}
         />
       </div>
       <ReconciliationOverview />
       <Exceptions />
     </div>
-  }
-}
-
-module ReconOverview = {
-  @react.component
-  let make = () => {
-    <ReconOverviewContent />
   }
 }

--- a/src/Recon/ReconScreens/ReconReports/ReconReports.res
+++ b/src/Recon/ReconScreens/ReconReports/ReconReports.res
@@ -34,8 +34,14 @@ let make = () => {
 
   React.useEffect(() => {
     switch url.search->ReconReportUtils.getTabFromUrl {
-    | Exceptions => setTabIndex(_ => 1)
-    | All => setTabIndex(_ => 0)
+    | Exceptions => {
+        mixpanelEvent(~eventName="recon_exceptions_reports")
+        setTabIndex(_ => 1)
+      }
+    | All => {
+        mixpanelEvent(~eventName="recon_all_reports")
+        setTabIndex(_ => 0)
+      }
     }
     setScreenState(_ => PageLoaderWrapper.Success)
     getReportsList()->ignore
@@ -87,9 +93,7 @@ let make = () => {
         renderContent: () =>
           <ReconReportsList configuredReports filteredReportsData setFilteredReports />,
         onTabSelection: () => {
-          RescriptReactRouter.replace(
-            GlobalVars.appendDashboardPath(~url="/v2/recon/reports?tab=all"),
-          )
+          RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/v2/recon/reports"))
         },
       },
       {
@@ -119,13 +123,6 @@ let make = () => {
   let toggleReconChevronState = () => {
     setReconArrow(prev => !prev)
   }
-
-  let tabValue = UrlUtils.useGetFilterDictFromUrl("")->LogicUtils.getString("tab", "")
-
-  React.useEffect(() => {
-    mixpanelEvent(~eventName=tabValue)
-    None
-  }, [tabValue])
 
   let customScrollStyle = "max-h-72 overflow-scroll px-1 pt-1 border border-b-0"
   let dropdownContainerStyle = "rounded-md border border-1 !w-full"

--- a/src/entryPoints/AuthModule/AuthWrapper.res
+++ b/src/entryPoints/AuthModule/AuthWrapper.res
@@ -146,6 +146,7 @@ let make = (~children) => {
       <Button
         text={`Continue with ${(authMethodName :> string)}`}
         buttonType={PrimaryOutline}
+        customButtonStyle="!w-full"
         onClick={_ => handleLoginWithSso(method.id)}
       />
     | (_, _) => React.null


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Selection in the sidebar for reconciliation reports and mix panel events refactoring.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
