### PR TITLE
fix: show edit and copy icon in MP dropdowns mobile

### DIFF
--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -244,6 +244,7 @@ module MerchantDropdownItem = {
     let (showSwitchingMerch, setShowSwitchingMerch) = React.useState(_ => false)
     let isUnderEdit =
       currentlyEditingId->Option.isSome && currentlyEditingId->Option.getOr(0) == index
+    let isMobileView = MatchMedia.useMobileChecker()
 
     let productTypeIconMapper = productType => {
       switch productType {
@@ -332,6 +333,7 @@ module MerchantDropdownItem = {
           handleEdit=handleIdUnderEdit
           isUnderEdit
           showEditIcon={isActive && userHasAccess(~groupAccess=MerchantDetailsManage) === Access}
+          showEditIconOnHover={!isMobileView}
           onSubmit
           labelTextCustomStyle={` truncate max-w-28 ${isActive
               ? `${secondaryTextColor}`
@@ -383,6 +385,8 @@ module ProfileDropdownItem = {
     let isUnderEdit =
       currentlyEditingId->Option.isSome && currentlyEditingId->Option.getOr(0) == index
     let (_, setProfileList) = Recoil.useRecoilState(HyperswitchAtom.profileListAtom)
+    let isMobileView = MatchMedia.useMobileChecker()
+
     let getProfileList = async () => {
       try {
         let response = switch version {
@@ -471,6 +475,7 @@ module ProfileDropdownItem = {
           showEditIcon={isActive &&
           userHasAccess(~groupAccess=MerchantDetailsManage) === Access &&
           version == V1}
+          showEditIconOnHover={!isMobileView}
           onSubmit
           labelTextCustomStyle={` truncate max-w-28 ${isActive ? " text-nd_gray-700" : ""}`}
           validateInput


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Edit and copy button in mobile is visible only when clicking on the merchant drop down item. As there is no hover in mobile. It should be visible by default instead of click.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Locally

![image](https://github.com/user-attachments/assets/58112693-d985-47af-a8a5-2d95f5ba3c49)

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
