### PR TITLE
chore: configure retry tooltip text

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsConfigureRetry.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsConfigureRetry.res
@@ -8,7 +8,18 @@ let make = (~handleAuthKeySubmit, ~initialValues, ~validateMandatoryField) => {
     <div className="mb-10 flex flex-col gap-8">
       <Form onSubmit={handleAuthKeySubmit} initialValues validate=validateMandatoryField>
         <div>
-          <div className="text-nd_gray-700 font-medium"> {"Start Retry After"->React.string} </div>
+          <div className="text-nd_gray-700 font-medium flex gap-2 w-fit align-center">
+            {"Start Retry After"->React.string}
+            <ToolTip
+              height="mt-0.5"
+              description="Sets the number of failed attempts that will be monitored before initiating retry scheduling"
+              toolTipFor={<div className="cursor-pointer">
+                <Icon name="info-vacent" size=13 />
+              </div>}
+              toolTipPosition=ToolTip.Top
+              newDesign=true
+            />
+          </div>
           <div className="-m-1 -mt-3">
             <FormRenderer.FieldRenderer
               labelClass="font-semibold !text-hyperswitch_black"
@@ -23,7 +34,18 @@ let make = (~handleAuthKeySubmit, ~initialValues, ~validateMandatoryField) => {
           </div>
         </div>
         <div className="mt-5">
-          <div className="text-nd_gray-700 font-medium"> {"Max Retry Attempts"->React.string} </div>
+          <div className="text-nd_gray-700 font-medium flex gap-2 w-fit">
+            {"Max Retry Attempts"->React.string}
+            <ToolTip
+              height="mt-0.5"
+              description="Defines the maximum number of retry attempts before the system stops trying."
+              toolTipFor={<div className="cursor-pointer">
+                <Icon name="info-vacent" size=13 />
+              </div>}
+              toolTipPosition=ToolTip.Top
+              newDesign=true
+            />
+          </div>
           <div className="-m-1 -mt-3">
             <FormRenderer.FieldRenderer
               labelClass="font-semibold !text-hyperswitch_black"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
added the tool tip for configure retry pages 
<img width="329" alt="Screenshot 2025-03-20 at 4 32 54 PM" src="https://github.com/user-attachments/assets/3f0705ad-d510-483d-9c2b-950411ca268d" />

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the tooltip should show for configure retry pages 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
