### PR TITLE
feat: duplicate and edit configuration for rule based routing

### DIFF
--- a/src/components/MakeRuleFieldComponent.res
+++ b/src/components/MakeRuleFieldComponent.res
@@ -40,7 +40,7 @@ module TextView = {
 
 module CompressedView = {
   @react.component
-  let make = (~id, ~isFirst) => {
+  let make = (~id, ~isFirst, ~keyType) => {
     open LogicUtils
     let {globalUIConfig: {font: {textColor}}} = React.useContext(ThemeProvider.themeContext)
     let conditionInput = ReactFinalForm.useField(id).input
@@ -64,10 +64,11 @@ module CompressedView = {
           dict->getString("comparison", ""),
           dict->getDictfromDict("value")->getJsonObjectFromDict("value")->displayForValue,
           dict->getDictfromDict("metadata")->getOptionString("key"),
+          dict->getDictfromDict("value")->getDictfromDict("value")->getOptionString("key"),
         )
       })
     switch condition {
-    | Some((logical, field, operator, value, key)) =>
+    | Some((logical, field, operator, value, key, metadataKeyType)) =>
       <div className="flex flex-wrap items-center gap-4">
         {if !isFirst {
           <TextView
@@ -81,6 +82,12 @@ module CompressedView = {
         | Some(val) => <TextView str=val />
         | None => React.null
         }}
+        <RenderIf condition={keyType->AdvancedRoutingUtils.variantTypeMapper == Metadata_value}>
+          {switch metadataKeyType {
+          | Some(val) => <TextView str=val />
+          | None => React.null
+          }}
+        </RenderIf>
         <TextView str=operator fontColor="text-red-500" fontWeight="font-semibold" />
         <TextView str={value} />
       </div>

--- a/src/screens/Routing/AdvancedRouting/AdvancedRouting.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRouting.res
@@ -786,10 +786,28 @@ let make = (
                     {switch pageState {
                     | Preview =>
                       <div className="flex flex-col md:flex-row gap-4 my-5">
+                        <Button
+                          text={"Duplicate and Edit Configuration"}
+                          buttonType={Secondary}
+                          onClick={_ => {
+                            setPageState(_ => Create)
+                            let manipualtedJSONValue =
+                              initialValues->DuplicateAndEditUtils.manipulateInitialValuesForDuplicate
+                            let schemaValue = manipualtedJSONValue->getDictFromJsonObject
+                            let rulesValue =
+                              schemaValue->getObj("algorithm", Dict.make())->getDictfromDict("data")
+                            setInitialValues(_ =>
+                              initialValues->DuplicateAndEditUtils.manipulateInitialValuesForDuplicate
+                            )
+                            setInitialRule(_ => Some(ruleInfoTypeMapper(rulesValue)))
+                          }}
+                          customButtonStyle="w-1/5"
+                          buttonState=Normal
+                        />
                         <RenderIf condition={!isActive}>
                           <Button
                             text={"Activate Configuration"}
-                            buttonType={Primary}
+                            buttonType={Secondary}
                             onClick={_ => {
                               handleActivateConfiguration(routingRuleId)->ignore
                             }}
@@ -800,7 +818,7 @@ let make = (
                         <RenderIf condition={isActive}>
                           <Button
                             text={"Deactivate Configuration"}
-                            buttonType={Primary}
+                            buttonType={Secondary}
                             onClick={_ => {
                               handleDeactivateConfiguration()->ignore
                             }}

--- a/src/screens/Routing/AdvancedRouting/AdvancedRoutingUIUtils.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRoutingUIUtils.res
@@ -112,22 +112,10 @@ module OperatorInp = {
 
 module ValueInp = {
   @react.component
-  let make = (
-    ~fieldsArray: array<ReactFinalForm.fieldRenderProps>,
-    ~variantValues,
-    ~keyType,
-    ~id,
-    ~valuePath,
-  ) => {
+  let make = (~fieldsArray: array<ReactFinalForm.fieldRenderProps>, ~variantValues, ~keyType) => {
     let valueField = (fieldsArray[1]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)).input
     let opField = (fieldsArray[2]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)).input
     let typeField = (fieldsArray[3]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)).input
-    let form = ReactFinalForm.useForm()
-
-    React.useEffect(() => {
-      form.change(`${id}.${valuePath}`, valueField.value)
-      None
-    }, [valueField.value])
 
     React.useEffect(() => {
       typeField.onChange(
@@ -232,10 +220,10 @@ module MetadataInp = {
 let renderOperatorInp = keyType => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
   <OperatorInp fieldsArray keyType />
 }
-let renderValueInp = (keyType: string, variantValues, id, valuePath) => (
+let renderValueInp = (keyType: string, variantValues) => (
   fieldsArray: array<ReactFinalForm.fieldRenderProps>,
 ) => {
-  <ValueInp fieldsArray variantValues keyType id valuePath />
+  <ValueInp fieldsArray variantValues keyType />
 }
 
 let renderMetaInput = keyType => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
@@ -263,7 +251,7 @@ let valueInput = (id, variantValues, keyType) => {
   }
   makeMultiInputFieldInfoOld(
     ~label="",
-    ~comboCustomInput=renderValueInp(keyType, variantValues, id, valuePath),
+    ~comboCustomInput=renderValueInp(keyType, variantValues),
     ~inputFields=[
       makeInputFieldInfo(~name=`${id}.lhs`),
       makeInputFieldInfo(~name=`${id}.${valuePath}`),
@@ -389,7 +377,7 @@ module RuleFieldBase = {
         | _ => Window.getAllKeys()
         }
       }
-    }, [])
+    }, [field.value])
 
     <RenderIf condition={methodKeys->Array.length > 0}>
       {if isExpanded {
@@ -425,7 +413,7 @@ module RuleFieldBase = {
           </RenderIf>
         </div>
       } else {
-        <MakeRuleFieldComponent.CompressedView isFirst id />
+        <MakeRuleFieldComponent.CompressedView isFirst id keyType />
       }}
     </RenderIf>
   }

--- a/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
@@ -294,9 +294,15 @@ let getOperatorFromComparisonType = (comparison, variantType) => {
 
 let isStatementMandatoryFieldsPresent = (statement: RoutingTypes.statement) => {
   open LogicUtils
+
   let statementValue = switch statement.value.value->JSON.Classify.classify {
   | Array(ele) => ele->Array.length > 0
   | String(str) => str->isNonEmptyString
+  | Object(objectValue) => {
+      let key = objectValue->getString("key", "")
+      let value = objectValue->getString("value", "")
+      key->isNonEmptyString && value->isNonEmptyString
+    }
   | _ => false
   }
 

--- a/src/screens/Routing/AdvancedRouting/DuplicateAndEditUtils.res
+++ b/src/screens/Routing/AdvancedRouting/DuplicateAndEditUtils.res
@@ -1,0 +1,107 @@
+let getIsDistributed = distributedType => distributedType === "volume_split"
+
+let getConditionValye = (conditionArray, manipulatedStatementsArray, statementIndex) => {
+  open LogicUtils
+
+  let manipuatedConditionArray = conditionArray->Array.mapWithIndex((
+    eachContent,
+    conditionIndex,
+  ) => {
+    let conditionDIct = eachContent->getDictFromJsonObject
+    let getValueType = conditionDIct->getDictfromDict("value")->getString("type", "")
+
+    let manipulatedConditionDict = conditionDIct->Dict.copy
+
+    manipulatedConditionDict->Dict.set(
+      "comparison",
+      conditionDIct
+      ->getString("comparison", "")
+      ->AdvancedRoutingUtils.getOperatorFromComparisonType(getValueType)
+      ->JSON.Encode.string,
+    )
+
+    if statementIndex > 0 {
+      manipulatedConditionDict->Dict.set("logical", "OR"->JSON.Encode.string)
+    }
+    if conditionIndex > 0 {
+      manipulatedConditionDict->Dict.set("logical", "AND"->JSON.Encode.string)
+    }
+
+    manipulatedStatementsArray->Array.push(manipulatedConditionDict->JSON.Encode.object)
+    manipulatedConditionDict->JSON.Encode.object
+  })
+
+  manipuatedConditionArray->JSON.Encode.array
+}
+
+let getStatementsArray = statementsArray => {
+  open LogicUtils
+
+  let manipulatedStatementsArrayCustom = []
+
+  let _ = statementsArray->Array.mapWithIndex((eachStatement, statementIndex) => {
+    let statementDict = eachStatement->getDictFromJsonObject
+
+    let conditionValue =
+      statementDict
+      ->getArrayFromDict("condition", [])
+      ->getConditionValye(manipulatedStatementsArrayCustom, statementIndex)
+
+    conditionValue
+  })
+
+  manipulatedStatementsArrayCustom->JSON.Encode.array
+}
+
+let getRulesValue = rulesArray => {
+  open LogicUtils
+  let manipulatedRulesArray = rulesArray->Array.map(eachRule => {
+    let eachRuleDict = eachRule->getDictFromJsonObject
+    let rulesDict = eachRuleDict->Dict.copy
+
+    rulesDict->Dict.set(
+      "statements",
+      eachRuleDict->getArrayFromDict("statements", [])->getStatementsArray,
+    )
+
+    let isDistibuted =
+      rulesDict
+      ->getObj("connectorSelection", Dict.make())
+      ->getString("type", "priority")
+      ->getIsDistributed
+
+    rulesDict->Dict.set("isDistribute", isDistibuted->JSON.Encode.bool)
+
+    rulesDict->JSON.Encode.object
+  })
+
+  manipulatedRulesArray->JSON.Encode.array
+}
+
+let dataMapper = dataDict => {
+  open LogicUtils
+  let manipuledDataDict = dataDict->Dict.copy
+  manipuledDataDict->Dict.set("rules", dataDict->getArrayFromDict("rules", [])->getRulesValue)
+
+  manipuledDataDict->JSON.Encode.object
+}
+
+let getAlgo = algoDict => {
+  open LogicUtils
+
+  let manipulatedAlgoDIct = algoDict->Dict.copy
+  manipulatedAlgoDIct->Dict.set("data", algoDict->getObj("data", Dict.make())->dataMapper)
+
+  manipulatedAlgoDIct->JSON.Encode.object
+}
+
+let manipulateInitialValuesForDuplicate = json => {
+  open LogicUtils
+
+  let previewDict = json->getDictFromJsonObject
+  let finalJson = previewDict->Dict.copy
+
+  finalJson->Dict.set("algorithm", previewDict->getObj("algorithm", Dict.make())->getAlgo)
+
+  finalJson->JSON.Encode.object
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added duplicate and edit configuration for rule based routing 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- Create a rule based routing 
- Click on routing rule to preview from list 
- Click on "Duplicate and edit configuration" button
- The old should be copied as it is and all the fields should be populated 
- Should be able to edit and change the value 
- You can save / save and activate . This will not override the old rule but it will create a completely new rule 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
