### PR TITLE
chore: remove profile level report - auth analytics

### DIFF
--- a/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
+++ b/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
@@ -15,10 +15,6 @@ let make = () => {
   )
   let startTimeVal = filterValueJson->getString("startTime", "")
   let endTimeVal = filterValueJson->getString("endTime", "")
-  let {userInfo: {transactionEntity}, checkUserEntity} = React.useContext(
-    UserInfoProvider.defaultContext,
-  )
-  let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
 
   let title = "Authentication Analytics"
   let (filterDataJson, setFilterDataJson) = React.useState(_ => None)
@@ -226,14 +222,6 @@ let make = () => {
       <div className="flex justify-end mr-4">
         <GenerateReport entityName={V1(AUTHENTICATION_REPORT)} />
       </div>
-      <Portal to="AuthenticationAnalyticsV2OMPView">
-        <OMPSwitchHelper.OMPViews
-          views={OMPSwitchUtils.transactionViewList(~checkUserEntity)}
-          selectedEntity={transactionEntity}
-          onChange={updateTransactionEntity}
-          entityMapper=UserInfoUtils.transactionEntityMapper
-        />
-      </Portal>
       <div
         className="-ml-1 sticky top-0 z-10 p-1 bg-hyperswitch_background/70 py-1 rounded-lg my-2">
         {topFilterUi}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removed Profile level Generate reports as Auth Analytics is only having merchant level analytics.

Will add this back when backend is ready with the profile level analytics.

## Motivation and Context

For making UI consistent

## How did you test it?

Locally via removing the dropdown only merchant report API was getting called.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
