### PR TITLE
chore: made chargebee webhooks details field as required

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -33,7 +33,8 @@ let make = (
     ConnectorInterface.connectorInterfaceV2,
     initialValues->LogicUtils.getDictFromJsonObject,
   )
-  let connectorTypeFromName = connector->getConnectorNameTypeFromString
+  let connectorTypeFromName =
+    connector->getConnectorNameTypeFromString(~connectorType=ConnectorTypes.BillingProcessor)
 
   let updatedInitialVal = React.useMemo(() => {
     let initialValuesToDict = initialValues->getDictFromJsonObject

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -1248,6 +1248,8 @@ let getDisableConnectorPayload = (connectorType, previousConnectorState) => {
 let getWebHookRequiredFields = (connector: connectorTypes, fieldName: string) => {
   switch (connector, fieldName) {
   | (Processors(ADYEN), "merchant_secret") => true
+  | (BillingProcessor(CHARGEBEE), "merchant_secret") => true
+  | (BillingProcessor(CHARGEBEE), "additional_secret") => true
   | _ => false
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
made the chargebee webhooks details as required field 
<img width="513" alt="Screenshot 2025-03-21 at 1 19 39 PM" src="https://github.com/user-attachments/assets/fe27c336-489d-4bd9-9a42-277645431982" />

<img width="515" alt="Screenshot 2025-03-21 at 1 25 11 PM" src="https://github.com/user-attachments/assets/faec25b8-4c1b-46d5-a51a-850fedfbda9e" />

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the billing connector chargebee page should show the webhooks details page as required and the next 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
