### PR TITLE
fix: logo aspect ratio

### DIFF
--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -152,7 +152,7 @@ let make = () => {
                       headerLeftActions={switch Window.env.urlThemeConfig.logoUrl {
                       | Some(url) =>
                         <div className="flex md:gap-4 gap-2 items-center">
-                          <img className="w-40 h-16" alt="image" src={`${url}`} />
+                          <img className="h-8 w-auto object-contain" alt="image" src={`${url}`} />
                           <ProfileSwitch />
                           <div
                             className={`flex flex-row items-center px-2 py-3 gap-2 whitespace-nowrap cursor-default justify-between h-8 bg-white border rounded-lg  text-sm text-nd_gray-500 border-nd_gray-300`}>
@@ -168,7 +168,7 @@ let make = () => {
                           </div>
                         </div>
                       | None =>
-                        <div className="flex md:gap-4 gap-2 items-center ">
+                        <div className="flex md:gap-4 gap-2 items-center">
                           <ProfileSwitch />
                           <div
                             className={`flex flex-row items-center px-2 py-3 gap-2 whitespace-nowrap cursor-default justify-between h-8 bg-white border rounded-lg  text-sm text-nd_gray-500 border-nd_gray-300`}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Logo was getting stretched out. Fixed scaling


<img width="1279" alt="Screenshot 2025-03-24 at 11 37 11 AM" src="https://github.com/user-attachments/assets/ab4feb59-c8df-4054-b660-d3d07c267693" />


## Motivation and Context

UI

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
