### PR TITLE
fix: Payout routing default fallback connector label

### DIFF
--- a/src/screens/PayoutRouting/PayoutRoutingConfigure.res
+++ b/src/screens/PayoutRouting/PayoutRoutingConfigure.res
@@ -3,7 +3,6 @@ let make = (~routingType) => {
   open LogicUtils
   open RoutingTypes
   open RoutingUtils
-
   let url = RescriptReactRouter.useUrl()
   let (currentRouting, setCurrentRouting) = React.useState(() => NO_ROUTING)
   let (id, setId) = React.useState(() => None)
@@ -57,7 +56,11 @@ let make = (~routingType) => {
           baseUrlForRedirection
         />
       | DEFAULTFALLBACK =>
-        <DefaultRouting urlEntityName=V1(PAYOUT_DEFAULT_FALLBACK) baseUrlForRedirection />
+        <DefaultRouting
+          urlEntityName=V1(PAYOUT_DEFAULT_FALLBACK)
+          baseUrlForRedirection
+          connectorVariant=ConnectorTypes.PayoutProcessor
+        />
       | _ => React.null
       }}
     </History.BreadCrumbWrapper>

--- a/src/screens/PayoutRouting/PayoutRoutingConfigure.res
+++ b/src/screens/PayoutRouting/PayoutRoutingConfigure.res
@@ -3,6 +3,7 @@ let make = (~routingType) => {
   open LogicUtils
   open RoutingTypes
   open RoutingUtils
+
   let url = RescriptReactRouter.useUrl()
   let (currentRouting, setCurrentRouting) = React.useState(() => NO_ROUTING)
   let (id, setId) = React.useState(() => None)

--- a/src/screens/Routing/DefaultRouting/DefaultRouting.res
+++ b/src/screens/Routing/DefaultRouting/DefaultRouting.res
@@ -2,7 +2,7 @@ open APIUtils
 open MerchantAccountUtils
 
 @react.component
-let make = (~urlEntityName, ~baseUrlForRedirection) => {
+let make = (~urlEntityName, ~baseUrlForRedirection, ~connectorVariant) => {
   open LogicUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
@@ -18,7 +18,7 @@ let make = (~urlEntityName, ~baseUrlForRedirection) => {
   let modalObj = RoutingUtils.getModalObj(DEFAULTFALLBACK, "default")
   let typedConnectorValue = ConnectorInterface.useConnectorArrayMapper(
     ~interface=ConnectorInterface.connectorInterfaceV1,
-    ~retainInList=PaymentProcessor,
+    ~retainInList=connectorVariant,
   )
   let {globalUIConfig: {primaryColor}} = React.useContext(ThemeProvider.themeContext)
 

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -50,7 +50,11 @@ let make = (~routingType) => {
           baseUrlForRedirection
         />
       | DEFAULTFALLBACK =>
-        <DefaultRouting urlEntityName=V1(DEFAULT_FALLBACK) baseUrlForRedirection />
+        <DefaultRouting
+          urlEntityName=V1(DEFAULT_FALLBACK)
+          baseUrlForRedirection
+          connectorVariant=ConnectorTypes.PaymentProcessor
+        />
       | _ => <> </>
       }}
     </History.BreadCrumbWrapper>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Connector labels weren't visible for the payout routing default fallback. After changes:

<img width="750" alt="Screenshot 2025-03-25 at 12 38 22 PM" src="https://github.com/user-attachments/assets/d4261c35-4bce-43b3-b3af-32c9db5fb374" />


## Motivation and Context

Bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
