### PR TITLE
fix: rule based routing month issue in description

### DIFF
--- a/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
@@ -1,18 +1,3 @@
-let getCurrentDetailedUTCTime = () => {
-  Js.Date.fromFloat(Date.now())->Js.Date.toUTCString
-}
-
-let getCurrentShortUTCTime = () => {
-  let currentDate = Date.now()->Js.Date.fromFloat
-  let month = currentDate->Js.Date.getUTCMonth +. 1.0
-  let day = currentDate->Js.Date.getUTCDate
-  let currMonth = month < 10.0 ? `0${month->Float.toString}` : month->Float.toString
-  let currDay = day < 10.0 ? `0${day->Float.toString}` : day->Float.toString
-  let currYear = currentDate->Js.Date.getUTCFullYear->Float.toString
-
-  `${currYear}-${currMonth}-${currDay}`
-}
-
 let operatorTypeToStringMapper = (operator: RoutingTypes.operator) => {
   switch operator {
   | CONTAINS => "CONTAINS"
@@ -57,12 +42,12 @@ let getRoutingTypeName = (routingType: RoutingTypes.routingType) => {
 let getRoutingNameString = (~routingType) => {
   open LogicUtils
   let routingText = routingType->getRoutingTypeName
-  `${routingText->capitalizeString} Based Routing-${getCurrentShortUTCTime()}`
+  `${routingText->capitalizeString} Based Routing-${RoutingUtils.getCurrentUTCTime()}`
 }
 
 let getRoutingDescriptionString = (~routingType) => {
   let routingText = routingType->getRoutingTypeName
-  `This is a ${routingText} based routing created at ${getCurrentDetailedUTCTime()}`
+  `This is a ${routingText} based routing created at ${RoutingUtils.currentTimeInUTC}`
 }
 
 let getWasmKeyType = (wasm, value) => {

--- a/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
@@ -4,8 +4,10 @@ let getCurrentDetailedUTCTime = () => {
 
 let getCurrentShortUTCTime = () => {
   let currentDate = Date.now()->Js.Date.fromFloat
-  let currMonth = currentDate->Js.Date.getUTCMonth->Float.toString
-  let currDay = currentDate->Js.Date.getUTCDate->Float.toString
+  let month = currentDate->Js.Date.getUTCMonth +. 1.0
+  let day = currentDate->Js.Date.getUTCDate
+  let currMonth = month < 10.0 ? `0${month->Float.toString}` : month->Float.toString
+  let currDay = day < 10.0 ? `0${day->Float.toString}` : day->Float.toString
   let currYear = currentDate->Js.Date.getUTCFullYear->Float.toString
 
   `${currYear}-${currMonth}-${currDay}`

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -10,8 +10,8 @@ let getCurrentUTCTime = () => {
   let currentDate = Date.now()->Js.Date.fromFloat
   let month = currentDate->Js.Date.getUTCMonth +. 1.0
   let day = currentDate->Js.Date.getUTCDate
-  let currMonth = month < 10.0 ? `0${month->Float.toString}` : month->Float.toString
-  let currDay = day < 10.0 ? `0${day->Float.toString}` : day->Float.toString
+  let currMonth = month->Float.toString->String.padStart(2, "0")
+  let currDay = day->Float.toString->String.padStart(2, "0")
   let currYear = currentDate->Js.Date.getUTCFullYear->Float.toString
 
   `${currYear}-${currMonth}-${currDay}`


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
In rule-based routing, the pre-populated month was incorrect.
After : 
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/439e0ad7-2952-415b-af43-04e595e8ec7a" />


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- Sign-in to a orchestration account 
- under Workflows , navigate to routing 
- Under routing choose Advanced routing , the pre-populated description should have the current month
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
