### PR TITLE
fix: close icon on merchant select modal

### DIFF
--- a/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
+++ b/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
@@ -43,8 +43,12 @@ module SelectMerchantBody = {
     ~setActiveProductValue,
   ) => {
     open LogicUtils
+    let url = RescriptReactRouter.useUrl()
     let internalSwitch = OMPSwitchHooks.useInternalSwitch()
     let showToast = ToastState.useShowToast()
+    let merchantDetailsTypedValue =
+      HyperswitchAtom.merchantDetailsValueAtom->Recoil.useRecoilValueFromAtom
+
     let dropDownOptions =
       merchantList
       ->Array.filter(item => {
@@ -120,6 +124,22 @@ module SelectMerchantBody = {
           subHeading=""
           customSubHeadingStyle="w-full !max-w-none pr-10"
         />
+        <div
+          className="h-fit"
+          onClick={_ => {
+            let currentUrl = GlobalVars.extractModulePath(
+              ~path=url.path,
+              ~end=url.path->List.toArray->Array.length,
+            )
+            setShowModal(_ => false)
+            let productUrl = ProductUtils.getProductUrl(
+              ~productType=merchantDetailsTypedValue.product_type,
+              ~url=currentUrl,
+            )
+            RescriptReactRouter.replace(productUrl)
+          }}>
+          <Icon name="modal-close-icon" className="cursor-pointer" size=30 />
+        </div>
       </div>
       <hr />
       <Form key="new-merchant-creation" onSubmit initialValues validate={validateForm}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Add closes icon in merchant select modal , on click it will redirect back to current modules home page 
<img width="623" alt="image" src="https://github.com/user-attachments/assets/7aa036d0-55c6-4cb4-a9c7-caa77397fb22" />


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- create multiple merchant for another product apart from Orchestrator For rg: Vault
- Click on Vault from Sidebar , merchant dropdown will appear 
- Click on close icon , it should redirect back to current active product's home page eg: Orchestration home 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
