### PR TITLE
chore: removed production access for v2 products

### DIFF
--- a/src/IntelligentRoutingScreens/IntelligentRoutingAnalytics.res
+++ b/src/IntelligentRoutingScreens/IntelligentRoutingAnalytics.res
@@ -400,7 +400,8 @@ let make = () => {
           {"You are in demo environment and this is sample setup."->React.string}
         </p>
       </div>
-      <GetProductionAccess />
+
+      // <GetProductionAccess />
     </div>
     <div className="mt-10">
       <div className="flex items-center justify-between">

--- a/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
+++ b/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
@@ -470,7 +470,7 @@ module ReconOverviewContent = {
             {"You're viewing sample analytics to help you understand how the reports will look with real data"->React.string}
           </p>
         </div>
-        <ReconHelper.GetProductionAccess />
+        // <ReconHelper.GetProductionAccess />
       </div>
       <ReconciliationOverview />
       <Exceptions />

--- a/src/Recon/ReconScreens/ReconReports/ReconReports.res
+++ b/src/Recon/ReconScreens/ReconReports/ReconReports.res
@@ -130,7 +130,7 @@ let make = () => {
           {"You're viewing sample analytics to help you understand how the reports will look with real data"->React.string}
         </p>
       </div>
-      <ReconHelper.GetProductionAccess />
+      // <ReconHelper.GetProductionAccess />
     </div>
     <div className="flex flex-col space-y-2 justify-center relative gap-4 mt-16">
       <div>

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -356,18 +356,18 @@ let make = () => {
                     </div>
                   </div>
                 </div>
+                <RenderIf condition={showFeedbackModal && featureFlagDetails.feedback}>
+                  <HSwitchFeedBackModal
+                    modalHeading="We'd love to hear from you!"
+                    showModal={showFeedbackModal}
+                    setShowModal={setShowFeedbackModal}
+                  />
+                </RenderIf>
+                <RenderIf condition={!featureFlagDetails.isLiveMode}>
+                  <ProdIntentForm />
+                </RenderIf>
               </PageLoaderWrapper>
             </div>
-            <RenderIf condition={showFeedbackModal && featureFlagDetails.feedback}>
-              <HSwitchFeedBackModal
-                modalHeading="We'd love to hear from you!"
-                showModal={showFeedbackModal}
-                setShowModal={setShowFeedbackModal}
-              />
-            </RenderIf>
-            <RenderIf condition={!featureFlagDetails.isLiveMode}>
-              <ProdIntentForm />
-            </RenderIf>
           </div>
         </div>
       | #DEFAULT =>

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -61,13 +61,19 @@ let emptyComponent = CustomComponent({
   component: React.null,
 })
 
-let productionAccessComponent = (isProductionAccessEnabled, userHasAccess, hasAnyGroupAccess) =>
+let productionAccessComponent = (
+  isProductionAccessEnabled,
+  userHasAccess,
+  hasAnyGroupAccess,
+  version,
+) =>
   isProductionAccessEnabled &&
   // TODO: Remove `MerchantDetailsManage` permission in future
   hasAnyGroupAccess(
     userHasAccess(~groupAccess=MerchantDetailsManage),
     userHasAccess(~groupAccess=AccountManage),
-  ) === CommonAuthTypes.Access
+  ) === CommonAuthTypes.Access &&
+  version === UserInfoTypes.V1
     ? CustomComponent({
         component: <GetProductionAccess />,
       })
@@ -712,9 +718,11 @@ let useGetSidebarValuesForCurrentActive = (~isReconEnabled) => {
   let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {userHasAccess, hasAnyGroupAccess} = GroupACLHooks.useUserGroupACLHook()
   let {isLiveMode, devModularityV2} = featureFlagDetails
-
+  let {userInfo: {version}} = React.useContext(UserInfoProvider.defaultContext)
   let hsSidebars = useGetHsSidebarValues(~isReconEnabled)
-  let defaultSidebar = [productionAccessComponent(!isLiveMode, userHasAccess, hasAnyGroupAccess)]
+  let defaultSidebar = [
+    productionAccessComponent(!isLiveMode, userHasAccess, hasAnyGroupAccess, version),
+  ]
 
   if devModularityV2 {
     defaultSidebar->Array.pushMany([


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Removed get production access for v2 products 

For V2 merchant : 
<img width="283" alt="image" src="https://github.com/user-attachments/assets/6041b630-1f93-43ec-ad51-ac6956a52886" />

For V1 merchant : 
<img width="283" alt="image" src="https://github.com/user-attachments/assets/f9486037-a2ca-4595-9ca7-d4d3ca08b33c" />


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
for v2 merchants get production access should not come in sidebar as well as in product banner 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
