### PR TITLE
fix: recon ui issues in 13 inch screen

### DIFF
--- a/src/Recon/ReconScreens/ReconReports/ReconReportsList.res
+++ b/src/Recon/ReconScreens/ReconReports/ReconReportsList.res
@@ -86,8 +86,8 @@ let make = () => {
         setShowModal
         showModal
         closeOnOutsideClick=true
-        modalClass="w-1/3 h-screen float-right overflow-hidden !bg-white dark:!bg-jp-gray-lightgray_background"
-        childClass="m-2 h-full"
+        modalClass="flex flex-col w-1/3 h-screen float-right overflow-hidden !bg-white dark:!bg-jp-gray-lightgray_background"
+        childClass="my-6 mx-2 h-full flex flex-col justify-between"
         customModalHeading=modalHeading>
         <ShowAllReports isModal=true setShowModal selectedId />
       </Modal>

--- a/src/Recon/ReconScreens/ReconReports/ShowAllReports.res
+++ b/src/Recon/ReconScreens/ReconReports/ShowAllReports.res
@@ -105,7 +105,7 @@ let make = (~isModal, ~setShowModal, ~selectedId) => {
       customUI={<NoDataFound
         message="Payment does not exists in out record" renderType=NotFound
       />}>
-      <div className="flex flex-col h-[82vh] px-6">
+      <div className="flex flex-col px-6">
         <OrderInfo reportDetails=reconReport isModal />
       </div>
       <Button
@@ -121,7 +121,7 @@ let make = (~isModal, ~setShowModal, ~selectedId) => {
       customUI={<NoDataFound
         message="Payment does not exists in out record" renderType=NotFound
       />}>
-      <div className="flex flex-col h-[82vh] px-6">
+      <div className="flex flex-col px-6">
         <OrderInfo reportDetails=reconReport isModal />
         <div className="gap-6 border-t">
           <div className="flex flex-col gap-2 my-6">
@@ -145,7 +145,7 @@ let make = (~isModal, ~setShowModal, ~selectedId) => {
       customUI={<NoDataFound
         message="Payment does not exists in out record" renderType=NotFound
       />}>
-      <div className="flex flex-col h-[82vh] px-6">
+      <div className="flex flex-col px-6">
         <OrderInfo reportDetails=reconReport isModal />
         <div className="gap-6 border-t">
           <div className="flex flex-col gap-2 my-6">

--- a/src/components/InputFields.resi
+++ b/src/components/InputFields.resi
@@ -295,10 +295,9 @@ let iconFieldWithMessageDes: (
   (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element,
   ~description: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let passwordMatchField: (~leftIcon: React.element=?) => (
-  ~input: ReactFinalForm.fieldRenderPropsInput,
-  ~placeholder: string,
-) => React.element
+let passwordMatchField: (
+  ~leftIcon: React.element=?,
+) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: string) => React.element
 let checkboxInput: (
   ~isHorizontal: bool=?,
   ~options: array<SelectBox.dropdownOption>,
@@ -317,7 +316,8 @@ let checkboxInput: (
   ~checkboxDimension: string=?,
   ~wrapBasis: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let boolInput: (~isDisabled: bool, ~isCheckBox: bool=?, ~boolCustomClass: string=?) => (
-  ~input: ReactFinalForm.fieldRenderPropsInput,
-  ~placeholder: 'a,
-) => React.element
+let boolInput: (
+  ~isDisabled: bool,
+  ~isCheckBox: bool=?,
+  ~boolCustomClass: string=?,
+) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element

--- a/src/screens/Analytics/HSAnalyticsUtils.res
+++ b/src/screens/Analytics/HSAnalyticsUtils.res
@@ -138,7 +138,6 @@ let initialFixedFilterFields = (_json, ~events=?) => {
   | Some(fn) => fn
   | None => _ => ()
   }
- 
 
   let newArr = [
     (


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

`OK` and `More Details` button is not visible in the `all` recon reports tab for 13 inch screen laptop.

## Motivation and Context
https://github.com/juspay/hyperswitch-control-center/issues/2760
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<img width="762" alt="Screenshot 2025-04-03 at 2 39 14 PM" src="https://github.com/user-attachments/assets/ca4591ce-ff52-4ba8-b1cf-4b73bdfe4837" />
<img width="764" alt="Screenshot 2025-04-03 at 2 39 29 PM" src="https://github.com/user-attachments/assets/d5a10b44-92c2-4ea6-893b-78c0b10411e4" />
<img width="776" alt="Screenshot 2025-04-03 at 2 39 47 PM" src="https://github.com/user-attachments/assets/71253d15-be6f-46b8-87c4-696068b7ef20" />

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
