### PR TITLE
chore: number type input for connector metadata

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorHelper.res
+++ b/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorHelper.res
@@ -9,6 +9,17 @@ let textInput = (~field: CommonConnectorTypes.inputField, ~formName) => {
   )
 }
 
+let numberInput = (~field: CommonConnectorTypes.inputField, ~formName) => {
+  let {placeholder, label, required} = field
+  FormRenderer.makeFieldInfo(
+    ~label,
+    ~name={formName},
+    ~placeholder,
+    ~customInput=InputFields.numericTextInput(),
+    ~isRequired=required,
+  )
+}
+
 let selectInput = (
   ~field: CommonConnectorTypes.inputField,
   ~formName,

--- a/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorTypes.res
+++ b/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorTypes.res
@@ -1,4 +1,4 @@
-type inputType = Text | Toggle | Radio | Select | MultiSelect
+type inputType = Text | Number | Toggle | Radio | Select | MultiSelect
 
 type inputField = {
   name: string,

--- a/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorUtils.res
+++ b/src/screens/Connectors/PaymentProcessor/Common/CommonConnectorUtils.res
@@ -6,6 +6,7 @@ let inputTypeMapperr = ipType => {
   | "Select" => Select
   | "MultiSelect" => MultiSelect
   | "Radio" => Radio
+  | "Number" => Number
   | _ => Text
   }
 }

--- a/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ConnectorMetaDataUtils.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ConnectorMetaDataUtils.res
@@ -14,6 +14,7 @@ let connectorMetaDataValueInput = (~connectorMetaDataFields: CommonConnectorType
     switch (\"type", name) {
     | (Select, "merchant_config_currency") => currencyField(~name=formName)
     | (Text, _) => textInput(~field={connectorMetaDataFields}, ~formName)
+    | (Number, _) => numberInput(~field={connectorMetaDataFields}, ~formName)
     | (Select, _) =>
       selectInput(~field={connectorMetaDataFields}, ~formName, ~fixedDropDownDirection=TopLeft)
     | (Toggle, _) => toggleInput(~field={connectorMetaDataFields}, ~formName)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Number type input addition for connector metadata fields 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Cannot test as it is a chore chage 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
