### PR TITLE
fix: threeds app url validation

### DIFF
--- a/src/screens/Settings/HSwitchSettingTypes.res
+++ b/src/screens/Settings/HSwitchSettingTypes.res
@@ -103,8 +103,9 @@ type validationFields =
   | Website
   | WebhookUrl
   | ReturnUrl
-  | AuthetnticationConnectors(array<JSON.t>)
+  | AuthenticationConnectors(array<JSON.t>)
   | ThreeDsRequestorUrl
+  | ThreeDsRequestorAppUrl
   | UnknownValidateFields(string)
   | MaxAutoRetries
 

--- a/src/screens/Settings/MerchantAccountUtils.res
+++ b/src/screens/Settings/MerchantAccountUtils.res
@@ -400,10 +400,11 @@ let validationFieldsMapper = key => {
   | Website => "website"
   | WebhookUrl => "webhook_url"
   | ReturnUrl => "return_url"
-  | AuthetnticationConnectors(_) => "authentication_connectors"
+  | AuthenticationConnectors(_) => "authentication_connectors"
   | ThreeDsRequestorUrl => "three_ds_requestor_url"
   | UnknownValidateFields(key) => key
   | MaxAutoRetries => "max_auto_retries_enabled"
+  | ThreeDsRequestorAppUrl => "three_ds_requestor_app_url"
   }
 }
 
@@ -455,7 +456,7 @@ let checkValueChange = (~initialDict, ~valuesDict) => {
 
 let validateEmptyArray = (key, errors, arrayValue) => {
   switch key {
-  | AuthetnticationConnectors(_) =>
+  | AuthenticationConnectors(_) =>
     if arrayValue->Array.length === 0 {
       Dict.set(
         errors,
@@ -492,6 +493,23 @@ let validateCustom = (key, errors, value, isLiveMode) => {
 
       if !regexUrl {
         Dict.set(errors, key->validationFieldsMapper, "Please Enter Valid URL"->JSON.Encode.string)
+      }
+    }
+  | ThreeDsRequestorAppUrl =>
+    if value->LogicUtils.isEmptyString {
+      Dict.set(errors, key->validationFieldsMapper, "URL cannot be empty"->JSON.Encode.string)
+    } else {
+      let httpUrlValid = isLiveMode
+        ? RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost")
+        : RegExp.test(%re("/^(http|https):\/\//i"), value)
+
+      let deepLinkValid = RegExp.test(%re("/^[a-zA-Z][a-zA-Z0-9]*:\/\//i"), value)
+      if !(httpUrlValid || deepLinkValid) {
+        Dict.set(
+          errors,
+          key->validationFieldsMapper,
+          "Please enter a valid URL or Mobile Deeplink"->JSON.Encode.string,
+        )
       }
     }
   | _ => ()
@@ -532,10 +550,11 @@ let validateMerchantAccountForm = (
 
   let threedsArray = getArrayFromDict(valuesDict, "authentication_connectors", [])->getNonEmptyArray
   let threedsUrl = getString(valuesDict, "three_ds_requestor_url", "")->getNonEmptyString
+  let threedsAppUrl = getString(valuesDict, "three_ds_requestor_app_url", "")->getNonEmptyString
   switch threedsArray {
   | Some(valArr) => {
       let url = getString(valuesDict, "three_ds_requestor_url", "")
-      AuthetnticationConnectors(valArr)->validateEmptyArray(errors, valArr)
+      AuthenticationConnectors(valArr)->validateEmptyArray(errors, valArr)
       ThreeDsRequestorUrl->validateCustom(errors, url, isLiveMode)
     }
   | _ => ()
@@ -543,8 +562,16 @@ let validateMerchantAccountForm = (
   switch threedsUrl {
   | Some(str) => {
       let arr = getArrayFromDict(valuesDict, "authentication_connectors", [])
-      AuthetnticationConnectors(arr)->validateEmptyArray(errors, arr)
+      AuthenticationConnectors(arr)->validateEmptyArray(errors, arr)
       ThreeDsRequestorUrl->validateCustom(errors, str, isLiveMode)
+    }
+  | _ => ()
+  }
+  switch threedsAppUrl {
+  | Some(str) => {
+      let arr = getArrayFromDict(valuesDict, "authentication_connectors", [])
+      AuthenticationConnectors(arr)->validateEmptyArray(errors, arr)
+      ThreeDsRequestorAppUrl->validateCustom(errors, str, isLiveMode)
     }
   | _ => ()
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Validation check for three_ds_requestor_app_url field for
1. mobile deeplinks (e.g. merchantapp://auth/success?transactionId=1234567890) 
2. http/https links


https://github.com/user-attachments/assets/e9745ece-5069-4284-920e-b37d5852df5e




## Motivation and Context

Currently, empty strings and invalid request URLs are being populated in three_ds_requestor_app_url field. This PR resolves that.

## How did you test it?

attached video

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
