### PR TITLE
fix: empty page issue on omp dropdown item click

### DIFF
--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -306,7 +306,9 @@ module MerchantDropdownItem = {
     }
 
     let handleMerchantSwitch = id => {
-      switchMerch(id)->ignore
+      if !isActive {
+        switchMerch(id)->ignore
+      }
     }
 
     let onSubmit = async (newMerchantName: string) => {
@@ -405,6 +407,7 @@ module ProfileDropdownItem = {
       currentlyEditingId->Option.isSome && currentlyEditingId->Option.getOr(0) == index
     let (_, setProfileList) = Recoil.useRecoilState(HyperswitchAtom.profileListAtom)
     let isMobileView = MatchMedia.useMobileChecker()
+    let isActive = currentId == profileId
 
     let getProfileList = async () => {
       try {
@@ -457,7 +460,9 @@ module ProfileDropdownItem = {
       }
     }
     let handleProfileSwitch = id => {
-      profileSwitch(id)->ignore
+      if !isActive {
+        profileSwitch(id)->ignore
+      }
     }
 
     let onSubmit = async (newProfileName: string) => {
@@ -476,7 +481,6 @@ module ProfileDropdownItem = {
       }
     }
 
-    let isActive = currentId == profileId
     let leftIconCss = {isActive && !isUnderEdit ? "" : isUnderEdit ? "hidden" : "invisible"}
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
 

--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -102,8 +102,15 @@ module OrgTile = {
     | true => "border-blue-811 ring-blue-811/20 ring-offset-0 ring-2"
     | false => "ring-grey-outline"
     }
+
+    let handleClick = () => {
+      if !isActive {
+        orgSwitch(orgID)->ignore
+      }
+    }
+
     <div
-      onClick={_ => orgSwitch(orgID)->ignore}
+      onClick={_ => handleClick()}
       className={`w-10 h-10 rounded-lg  flex items-center justify-center relative cursor-pointer ${hoverLabel1} `}>
       <div
         className={`w-8 h-8 border  cursor-pointer flex items-center justify-center rounded-md shadow-md ${ringClass} ${isActive


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
empty page issue on omp dropdown item click

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- open dashboard 
- click on any omp item click 
- should not redirect to empty page 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
