### PR TITLE
fix: update profileID formatting in payment routing test

### DIFF
--- a/cypress/e2e/6-workflow/PaymentRouting.cy.js
+++ b/cypress/e2e/6-workflow/PaymentRouting.cy.js
@@ -60,7 +60,7 @@ describe("Volume based routing", () => {
       .invoke("text")
       .then((text) => {
         profileID = text;
-        let convertedStr = profileID.replace(" ", " (") + ")";
+        let convertedStr = profileID.replace("default", "default (") + ")";
         cy.get(`[data-button-text="${convertedStr}"]`).should(
           "contain",
           convertedStr,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

<!-- Describe your changes in detail -->
This change modifies the way the `profileID` string is processed. Previously, the code replaced a single space in the `profileID` string with `" ("` and appended `")"` to it. The updated logic specifically replaces the word `"default"` in the `profileID` string with `"default ("` and appends `")"`. This ensures that only the word `"default"` is wrapped in parentheses, rather than altering any spaces in the string.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Cypress Tests were failing because of this as there was no space (`" "`) in the fetched profileID fetched.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->
<img width="742" alt="image" src="https://github.com/user-attachments/assets/804dba17-d129-433b-bbef-69d96ffd6717" />

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
