### PR TITLE
fix: Logs in payments details

### DIFF
--- a/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
+++ b/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
@@ -154,6 +154,12 @@ let make = (~id, ~urls, ~logType: LogTypes.pageType) => {
     a
   })
 
+  React.useEffect(_ => {
+    setActiveTab(_ => ["Log Details"])
+    setCollapseTab(prev => !prev)
+    None
+  }, [logDetails])
+
   let activeTab = React.useMemo(() => {
     Some(activeTab)
   }, [activeTab])
@@ -163,11 +169,6 @@ let make = (~id, ~urls, ~logType: LogTypes.pageType) => {
       setActiveTab(_ => str->String.split(","))
     }
   }, [setActiveTab])
-
-  React.useEffect(_ => {
-    setCollapseTab(prev => !prev)
-    None
-  }, [logDetails])
 
   let getDetails = async () => {
     let logs = []


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed tab switching issue in log viewer. When navigating between different log entries, the active tab is now correctly reset to "Log Details" to ensure proper content display.

## Motivation and Context

Bugfix

## How did you test it?

Locally

https://github.com/user-attachments/assets/a277c05d-7da3-463d-b817-f232153ed772

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
