### PR TITLE
fix: recovery events logging fix for onboarding

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
@@ -15,7 +15,7 @@ let make = (
   open PageLoaderWrapper
   open RevenueRecoveryOnboardingUtils
   open ConnectProcessorsHelper
-
+  let mixpanelEvent = MixpanelHook.useSendEvent()
   let getURL = useGetURL()
   let showToast = ToastState.useShowToast()
   let fetchConnectorListResponse = ConnectorListHook.useFetchConnectorList(
@@ -118,7 +118,7 @@ let make = (
       setConnectorID(_ => connectorInfoDict.id)
       fetchConnectorListResponse()->ignore
       setScreenState(_ => Success)
-      onNextClick(currentStep, setNextStep)
+      onNextClick(currentStep, setNextStep, ~mixpanelEvent)
     } catch {
     | Exn.Error(e) => {
         let err = Exn.message(e)->Option.getOr("Something went wrong")
@@ -280,7 +280,7 @@ let make = (
           <Button
             text="Next"
             buttonType=Primary
-            onClick={_ => onNextClick(currentStep, setNextStep)->ignore}
+            onClick={_ => onNextClick(currentStep, setNextStep, ~mixpanelEvent)->ignore}
             customButtonStyle="w-full mt-8"
           />
         </div>

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -64,12 +64,11 @@ let make = (
 
   let handleAuthKeySubmit = async (values, _) => {
     setInitialValues(_ => values)
-    onNextClick(currentStep, setNextStep)
+    onNextClick(currentStep, setNextStep, ~mixpanelEvent)
     Nullable.null
   }
 
   let onSubmit = async (values, _form: ReactFinalForm.formApi) => {
-    mixpanelEvent(~eventName=currentStep->getMixpanelEventName)
     let dict = values->getDictFromJsonObject
     let values = dict->JSON.Encode.object
 
@@ -80,7 +79,7 @@ let make = (
       setInitialValues(_ => response)
       fetchConnectorListResponse()->ignore
       setScreenState(_ => Success)
-      onNextClick(currentStep, setNextStep)
+      onNextClick(currentStep, setNextStep, ~mixpanelEvent)
     } catch {
     | Exn.Error(e) => {
         let err = Exn.message(e)->Option.getOr("Something went wrong")
@@ -211,7 +210,9 @@ let make = (
         />
       | (#addAPlatform, #setupWebhookPlatform) =>
         <BillingProcessorsWebhooks
-          initialValues merchantId onNextClick={_ => onNextClick(currentStep, setNextStep)->ignore}
+          initialValues
+          merchantId
+          onNextClick={_ => onNextClick(currentStep, setNextStep, ~mixpanelEvent)->ignore}
         />
       | (#reviewDetails, _) => <BillingProcessorsReviewDetails />
       | _ => React.null

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingLanding.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingLanding.res
@@ -30,7 +30,7 @@ let make = (~createMerchant) => {
             mixpanelEvent(~eventName="recovery_get_started_new_merchant")
             setCreateNewMerchant(ProductTypes.Recovery)
           } else {
-            mixpanelEvent(~eventName="recovery_integrate_connectors_")
+            mixpanelEvent(~eventName="recovery_integrate_connectors")
             RescriptReactRouter.replace(
               GlobalVars.appendDashboardPath(~url=`/v2/recovery/onboarding`),
             )


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
recovery onboarding triggering mixpanel event on every step which before some steps had not logging events 
<!-- Describe your changes in detail -->
<img width="312" alt="Screenshot 2025-04-15 at 6 59 16 PM" src="https://github.com/user-attachments/assets/2d0a9432-e285-4663-af33-76e4b2193fdf" />

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the every next button click on recovery onboarding should trigger a mixpanel logging event 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
