### PR TITLE
fix: refunds disable/enable in operations

### DIFF
--- a/src/screens/Transaction/Order/OrderRefundForm.res
+++ b/src/screens/Transaction/Order/OrderRefundForm.res
@@ -90,27 +90,28 @@ let make = (
       }
     })
     let amountValue = Dict.get(valuesDict, "amount")
-    let metadata = getDictFromJsonObject(values)->getDictfromDict("metadata")
 
-    let emailValue = metadata->LogicUtils.getString("email", "")
-    let cryptoAddress = metadata->Dict.get("address")
-    let metadataErrors = Dict.make()
-
-    if (
-      cryptoAddress->Option.isNone ||
-        cryptoAddress
-        ->Option.getOr(JSON.Encode.null)
-        ->LogicUtils.getStringFromJson("")
-        ->String.trim
-        ->LogicUtils.isEmptyString
-    ) {
-      Dict.set(metadataErrors, "address", `Required`->JSON.Encode.string)
-    }
-    if emailValue->CommonAuthUtils.isValidEmail {
-      Dict.set(metadataErrors, "email", `Please Enter Valid Email`->JSON.Encode.string)
-    }
-    if !(metadataErrors->isEmptyDict) {
-      Dict.set(errors, "metadata", metadataErrors->JSON.Encode.object)
+    if showRefundAddressEmail {
+      let metadata = getDictFromJsonObject(values)->getDictfromDict("metadata")
+      let emailValue = metadata->LogicUtils.getString("email", "")
+      let cryptoAddress = metadata->Dict.get("address")
+      let metadataErrors = Dict.make()
+      if (
+        cryptoAddress->Option.isNone ||
+          cryptoAddress
+          ->Option.getOr(JSON.Encode.null)
+          ->LogicUtils.getStringFromJson("")
+          ->String.trim
+          ->LogicUtils.isEmptyString
+      ) {
+        Dict.set(metadataErrors, "address", `Required`->JSON.Encode.string)
+      }
+      if emailValue->CommonAuthUtils.isValidEmail {
+        Dict.set(metadataErrors, "email", `Please Enter Valid Email`->JSON.Encode.string)
+      }
+      if !(metadataErrors->isEmptyDict) {
+        Dict.set(errors, "metadata", metadataErrors->JSON.Encode.object)
+      }
     }
 
     switch amountValue->Option.flatMap(obj => obj->JSON.Decode.float) {

--- a/src/screens/Transaction/Order/OrderRefundForm.res
+++ b/src/screens/Transaction/Order/OrderRefundForm.res
@@ -89,8 +89,6 @@ let make = (
         Dict.set(errors, key, "Required"->JSON.Encode.string)
       }
     })
-    let amountValue = Dict.get(valuesDict, "amount")
-
     if showRefundAddressEmail {
       let metadata = getDictFromJsonObject(values)->getDictfromDict("metadata")
       let emailValue = metadata->LogicUtils.getString("email", "")
@@ -113,7 +111,7 @@ let make = (
         Dict.set(errors, "metadata", metadataErrors->JSON.Encode.object)
       }
     }
-
+    let amountValue = Dict.get(valuesDict, "amount")
     switch amountValue->Option.flatMap(obj => obj->JSON.Decode.float) {
     | Some(floatVal) =>
       if floatVal > amoutAvailableToRefund {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Errors dict was getting populated even if address and email fields not present. 

## Motivation and Context

Bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
