### PR TITLE
fix: connector metadata default

### DIFF
--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -1628,7 +1628,7 @@ let constructConnectorRequestBody = (wasmRequest: wasmRequest, payload: JSON.t) 
     (
       "metadata",
       dict->getDictfromDict("metadata")->isEmptyDict
-        ? JSON.Encode.null
+        ? Dict.make()->JSON.Encode.object
         : dict->getDictfromDict("metadata")->JSON.Encode.object,
     ),
   ])


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

If metadata is not there , by default we will send empty dict instead of null.


## Motivation and Context

bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
