### PR TITLE
fix: webhooks request response data interchange fix

### DIFF
--- a/src/screens/Analytics/Logs/LogUtils/ApiDetailsComponent.res
+++ b/src/screens/Analytics/Logs/LogUtils/ApiDetailsComponent.res
@@ -35,7 +35,7 @@ let make = (
     })
     ->getJsonFromArrayOfJson
     ->JSON.stringify
-  | WEBHOOKS => dataDict->getString("outgoing_webhook_event_type", "")
+  | WEBHOOKS => dataDict->getString("content", "")
   }
 
   let responseObject = switch logType {
@@ -45,7 +45,7 @@ let make = (
       let isErrorLog = dataDict->getString("log_type", "") === "ERROR"
       isErrorLog ? dataDict->getString("value", "") : ""
     }
-  | WEBHOOKS => dataDict->getString("content", "")
+  | WEBHOOKS => dataDict->getString("outgoing_webhook_event_type", "")
   }
 
   let statusCode = switch logType {

--- a/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
+++ b/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
@@ -68,9 +68,7 @@ module TabDetails = {
         | Event
         | Request =>
           <div className="px-5 py-3">
-            <RenderIf
-              condition={logDetails.request->isNonEmptyString &&
-                selectedOption.optionType !== WEBHOOKS}>
+            <RenderIf condition={logDetails.request->isNonEmptyString}>
               <div className="flex justify-end">
                 <HelperComponents.CopyTextCustomComp
                   displayValue=Some("")
@@ -80,9 +78,7 @@ module TabDetails = {
               </div>
               <PrettyPrintJson jsonToDisplay=logDetails.request />
             </RenderIf>
-            <RenderIf
-              condition={logDetails.request->isEmptyString &&
-                selectedOption.optionType !== WEBHOOKS}>
+            <RenderIf condition={logDetails.request->isEmptyString}>
               <NoDataFound
                 customCssClass={"my-6"} message="No Data Available" renderType=Painting
               />
@@ -91,7 +87,9 @@ module TabDetails = {
         | Metadata
         | Response =>
           <div className="px-5 py-3">
-            <RenderIf condition={logDetails.response->isNonEmptyString}>
+            <RenderIf
+              condition={logDetails.response->isNonEmptyString &&
+                selectedOption.optionType !== WEBHOOKS}>
               <div className="flex justify-end">
                 <HelperComponents.CopyTextCustomComp
                   displayValue=Some("")
@@ -101,7 +99,9 @@ module TabDetails = {
               </div>
               <PrettyPrintJson jsonToDisplay={logDetails.response} />
             </RenderIf>
-            <RenderIf condition={logDetails.response->isEmptyString}>
+            <RenderIf
+              condition={logDetails.response->isEmptyString ||
+                selectedOption.optionType === WEBHOOKS}>
               <NoDataFound
                 customCssClass={"my-6"} message="No Data Available" renderType=Painting
               />

--- a/src/screens/Analytics/Logs/LogUtils/LogTypes.res
+++ b/src/screens/Analytics/Logs/LogUtils/LogTypes.res
@@ -122,8 +122,8 @@ let setDefaultValue = (initialData, setLogDetails, setSelectedOption) => {
       })
     }
   | WEBHOOKS => {
-      let request = initialData->getString("outgoing_webhook_event_type", "")
-      let response = initialData->getString("content", "")
+      let request = initialData->getString("content", "")
+      let response = initialData->getString("outgoing_webhook_event_type", "")
       setLogDetails(_ => {
         response,
         request,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- request and response data was shown interchanged in audit trail of payments details 
- fixed log details state to contain correct data under request and request
- initially request and response were stored but while displaying response was being shown with request header 

![image](https://github.com/user-attachments/assets/3809e002-da82-4b1e-a065-8110647f6b8d)
![image](https://github.com/user-attachments/assets/dd5d2e29-b82c-4048-9bd9-06fd7a490de2)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- checked that request and response are displayed correctly under webhooks in audit trail

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
