### PR TITLE
chore: added time selection for payments and reports

### DIFF
--- a/src/components/TimeInput.res
+++ b/src/components/TimeInput.res
@@ -39,6 +39,8 @@ let make = (
   | Some(str) => str
   | None => ""
   }
+  let (zone, _setZone) = React.useContext(UserTimeZoneProvider.userTimeContext)
+
   let arr = value->String.split(":")
   let hourVal = arr->Array.get(0)->Option.flatMap(val => val->Belt.Int.fromString)->Option.getOr(0)
   let minuteVal =
@@ -81,5 +83,6 @@ let make = (
     } else {
       React.null
     }}
+    <div className="font-semibold ml-1"> {(zone :> string)->React.string} </div>
   </div>
 }

--- a/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
+++ b/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
@@ -10,11 +10,11 @@ module LogDetailsSection = {
       }
     }
 
-    let sidebarScrollbarCss = `
+    let auditLogScrollbar = `
   @supports (-webkit-appearance: none){
     pre {
         scrollbar-width: auto;
-        scrollbar-color: #8a8c8f;
+        scrollbar-color: #CACFD8;
       }
       
       pre::-webkit-scrollbar {
@@ -25,7 +25,7 @@ module LogDetailsSection = {
       }
       
       pre::-webkit-scrollbar-thumb {
-        background-color: #8a8c8f;
+        background-color: #CACFD8;
         border-radius: 3px;
       }
       
@@ -48,7 +48,7 @@ module LogDetailsSection = {
           <span className="w-2/5"> {key->snakeToTitle->React.string} </span>
           <span
             className="w-3/5 overflow-scroll cursor-pointer relative hover:bg-gray-50 p-1 rounded">
-            <style> {React.string(sidebarScrollbarCss)} </style>
+            <style> {React.string(auditLogScrollbar)} </style>
             <ReactSyntaxHighlighter.SyntaxHighlighter
               wrapLines={true}
               wrapLongLines=true

--- a/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
+++ b/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
@@ -10,6 +10,31 @@ module LogDetailsSection = {
       }
     }
 
+    let sidebarScrollbarCss = `
+  @supports (-webkit-appearance: none){
+    pre {
+        scrollbar-width: auto;
+        scrollbar-color: #8a8c8f;
+      }
+      
+      pre::-webkit-scrollbar {
+        display: block;
+        overflow: scroll;
+        height: 4px;
+        width: 5px;
+      }
+      
+      pre::-webkit-scrollbar-thumb {
+        background-color: #8a8c8f;
+        border-radius: 3px;
+      }
+      
+      pre::-webkit-scrollbar-track {
+        display: none;
+      }
+}
+  `
+
     <div className="pb-3 px-5 py-3">
       {logDetails.data
       ->Dict.toArray
@@ -23,6 +48,7 @@ module LogDetailsSection = {
           <span className="w-2/5"> {key->snakeToTitle->React.string} </span>
           <span
             className="w-3/5 overflow-scroll cursor-pointer relative hover:bg-gray-50 p-1 rounded">
+            <style> {React.string(sidebarScrollbarCss)} </style>
             <ReactSyntaxHighlighter.SyntaxHighlighter
               wrapLines={true}
               wrapLongLines=true
@@ -37,7 +63,7 @@ module LogDetailsSection = {
               customStyle={{
                 backgroundColor: "transparent",
                 fontSize: "0.875rem",
-                padding: "0px",
+                padding: "0px 0px 6px 0px",
               }}>
               {value->JSON.stringify}
             </ReactSyntaxHighlighter.SyntaxHighlighter>

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -407,7 +407,7 @@ let initialFixedFilter = () => [
           ~startKey=startTimeFilterKey,
           ~endKey=endTimeFilterKey,
           ~format="YYYY-MM-DDTHH:mm:ss[Z]",
-          ~showTime=false,
+          ~showTime=true,
           ~disablePastDates={false},
           ~disableFutureDates={true},
           ~predefinedDays=[


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

1. Dates not carried over for Generate Reports in Payments section
2. Time selection as a filter for Generate reports, Payments view
3. Added scroll bar for overflow values in the dashboard response

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally


https://github.com/user-attachments/assets/0252e1ca-dc57-48ee-b167-c35f0ab1849d


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
