### PR TITLE
fix: configure pmts filter issues

### DIFF
--- a/src/components/Filter.res
+++ b/src/components/Filter.res
@@ -169,12 +169,6 @@ let make = (
   let searchParams = query->decodeURI
   let verticalGap = !isMobileView ? "gap-y-3" : ""
 
-  React.useEffect(_ => {
-    let updatedAllFilters = remoteFilters->Array.map(item => item.field)
-    setAllFilters(_ => updatedAllFilters)
-    None
-  }, [remoteFilters])
-
   let localFilterJson = RemoteFiltersUtils.getInitialValuesFromUrl(
     ~searchParams,
     ~initialFilters={Array.concat(localFilters, fixedFilters)},
@@ -397,6 +391,6 @@ let make = (
         </div>
       </>}
     </AddDataAttributes>}
-    <FormValuesSpy />
+    // <FormValuesSpy />
   </Form>
 }

--- a/src/components/Filter.res
+++ b/src/components/Filter.res
@@ -391,6 +391,6 @@ let make = (
         </div>
       </>}
     </AddDataAttributes>}
-    // <FormValuesSpy />
+    <FormValuesSpy />
   </Form>
 }

--- a/src/screens/ConfigurePMTs/paymentMethodList.res
+++ b/src/screens/ConfigurePMTs/paymentMethodList.res
@@ -14,7 +14,8 @@ let make = (~isPayoutFlow=false) => {
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ =>
     Dict.make()->JSON.Encode.object->getConnectedList
   )
-  let {updateExistingKeys, reset, filterValueJson} = FilterContext.filterContext->React.useContext
+  let {updateExistingKeys, reset, filterValueJson, filterValue} =
+    FilterContext.filterContext->React.useContext
   let (offset, setOffset) = React.useState(_ => 0)
   let allFilters: PaymentMethodConfigTypes.paymentMethodConfigFilters = React.useMemo(() => {
     filterValueJson->pmtConfigFilter
@@ -37,7 +38,7 @@ let make = (~isPayoutFlow=false) => {
   React.useEffect(() => {
     getConnectorListAndUpdateState()->ignore
     None
-  }, (isPayoutFlow, filterValueJson))
+  }, (isPayoutFlow, filterValue))
 
   let applyFilter = async () => {
     let res = connectorResponse->getFilterdConnectorList(allFilters)
@@ -83,22 +84,25 @@ let make = (~isPayoutFlow=false) => {
         defaultFilterKeys=[]
         updateUrlWith={updateExistingKeys}
         clearFilters={() => handleClearFilter()->ignore}
-      />
-      <LoadedTable
-        title="Payment Methods"
-        hideTitle=true
-        actualData={filteredConnectors->Array.map(Nullable.make)}
-        totalResults={filteredConnectors->Array.length}
-        resultsPerPage=20
-        showSerialNumber=true
-        offset
         setOffset
-        entity={PaymentMethodEntity.paymentMethodEntity(
-          ~setReferesh=getConnectorListAndUpdateState,
-        )}
-        currrentFetchCount={filteredConnectors->Array.length}
-        collapseTableRow=false
       />
+      <div className="mt-4">
+        <LoadedTable
+          title="Payment Methods"
+          hideTitle=true
+          actualData={filteredConnectors->Array.map(Nullable.make)}
+          totalResults={filteredConnectors->Array.length}
+          resultsPerPage=20
+          showSerialNumber=true
+          offset
+          setOffset
+          entity={PaymentMethodEntity.paymentMethodEntity(
+            ~setReferesh=getConnectorListAndUpdateState,
+          )}
+          currrentFetchCount={filteredConnectors->Array.length}
+          collapseTableRow=false
+        />
+      </div>
     </PageLoaderWrapper>
   </div>
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- In configure PMT if you select / deselect a filter (not apply a filter) PMT table refreshes for no reason.
- Select a filter, go to next page, click "Add filters" and you can select the same filter.
- Select a filter, go to some page (ex: 40), select another filter, even if there are results it doesn't redirect to first page OR redirects to last page
- Filters are overlapped with table headers

<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/1061

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

https://github.com/user-attachments/assets/58f36a48-2440-4cee-9832-91f7554af4a9

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
