### PR TITLE
fix: rename webhooks request heading to event data

### DIFF
--- a/src/screens/Analytics/Logs/LogUtils/LogTypes.res
+++ b/src/screens/Analytics/Logs/LogUtils/LogTypes.res
@@ -47,6 +47,13 @@ let getTabKeyName = (key: eventLogs, option: logType) => {
     | Response => "Metadata"
     | _ => ""
     }
+  | WEBHOOKS =>
+    switch key {
+    | Logdetails => "Log Details"
+    | Request => "Event Data"
+    | Response => "Response"
+    | _ => ""
+    }
   | _ =>
     switch key {
     | Logdetails => "Log Details"
@@ -60,7 +67,9 @@ let getTabKeyName = (key: eventLogs, option: logType) => {
 let getLogTypefromString = log => {
   switch log {
   | "Log Details" => Logdetails
-  | "Request" => Request
+  | "Event Data"
+  | "Request" =>
+    Request
   | "Response" => Response
   | "Event" => Event
   | "Metadata" => Metadata


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- rename webhooks heading in audit trail from Request to Event Data
![image](https://github.com/user-attachments/assets/5458eebd-27e0-42a1-a195-e5bc845f4c8b)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

locally, check screenshot

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
