### PR TITLE
fix: new authentication analytics key and dimensions changes

### DIFF
--- a/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
+++ b/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
@@ -32,6 +32,7 @@ let make = () => {
 
   let loadInfo = async () => {
     try {
+      setScreenState(_ => PageLoaderWrapper.Loading)
       let infoUrl = getURL(~entityName=V1(ANALYTICS_AUTHENTICATION_V2), ~methodType=Get)
       let infoDetails = await fetchDetails(infoUrl)
       setDimensions(_ => infoDetails->getDictFromJsonObject->getArrayFromDict("dimensions", []))
@@ -46,6 +47,7 @@ let make = () => {
   let tabNames = HSAnalyticsUtils.getStringListFromArrayDict(dimensions)
 
   let getFilters = async () => {
+    setFilterDataJson(_ => None)
     try {
       let analyticsfilterUrl = getURL(
         ~entityName=V1(ANALYTICS_AUTHENTICATION_V2_FILTERS),
@@ -176,7 +178,9 @@ let make = () => {
   }, [])
 
   React.useEffect(() => {
-    if startTimeVal->isNonEmptyString && endTimeVal->isNonEmptyString {
+    if (
+      startTimeVal->isNonEmptyString && endTimeVal->isNonEmptyString && dimensions->Array.length > 0
+    ) {
       getFilters()->ignore
     }
     None
@@ -217,7 +221,7 @@ let make = () => {
         initialFixedFilters={initialFixedFilterFields(~events=dateDropDownTriggerMixpanelCallback)}
         defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
         tabNames
-        key="0"
+        key="1"
         updateUrlWith=updateExistingKeys
         filterFieldsPortalName={HSAnalyticsUtils.filterFieldsPortalName}
         showCustomFilter=false


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

In the NewAuthenticationAnalytics component where the setAllFilters function in the DynamicFilter component was not updating when remoteFilters changed

Problem: getFilters API Call When dimensions Is Empty and Same Key for Some and None case:

If dimensions was empty (e.g., due to an API giving response with not None in loadInfo), Rendering the Component with Key 0 in `NewAuthenticationAnalytics` and eventually after loading the dimensions with correct value, the key doesn't change as it is still in the Some case which is not mounting the `DynamicFilter` component again to set allFilters.

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
