### PR TITLE
fix: All types of connectors showing in operations connector filter

### DIFF
--- a/src/components/FilterSelectBox.res
+++ b/src/components/FilterSelectBox.res
@@ -406,8 +406,14 @@ type allSelectType = Icon | Text
 
 type opt = {name_: string}
 
-let makeOptions = (options: array<string>): array<dropdownOption> => {
-  options->Array.map(str => {label: str, value: str})
+let makeOptions = (options: array<string>, ~isTitle=false): array<dropdownOption> => {
+  options->Array.map(str => {
+    let option: dropdownOption = {
+      label: isTitle ? str->LogicUtils.snakeToTitle : str,
+      value: str,
+    }
+    option
+  })
 }
 
 module BaseSelect = {

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -1694,6 +1694,17 @@ let defaultSelectAllCards = (
   }
 }
 
+let connectorTypeToListMapper = connector => {
+  switch connector {
+  | Processor => connectorList
+  | ThreeDsAuthenticator => threedsAuthenticatorList
+  | PayoutProcessor => payoutConnectorList
+  | TaxProcessor => taxProcessorList
+  | PMAuthenticationProcessor => pmAuthenticationConnectorList
+  | _ => []
+  }
+}
+
 let getConnectorPaymentMethodDetails = async (
   ~initialValues,
   ~setPaymentMethods,

--- a/src/screens/Payouts/PayoutsList.res
+++ b/src/screens/Payouts/PayoutsList.res
@@ -106,6 +106,7 @@ let make = () => {
               placeholder="Search for payout ID" setSearchVal=setSearchText searchVal=searchText
             />}
             entityName=V1(PAYOUTS_FILTERS)
+            connectorTypes=[PayoutProcessor]
           />
         </div>
         <PortalCapture key={`PayoutsCustomizeColumn`} name={`PayoutsCustomizeColumn`} />

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -217,6 +217,7 @@ let initialFilters = (json, filtervalues, _, _, _) => {
 
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForDisputeFilters(filterDict, filtervalues)
+    | #connector => values->FilterSelectBox.makeOptions(~isTitle=true)
     | _ => values->FilterSelectBox.makeOptions
     }
 

--- a/src/screens/Transaction/Refunds/RefundUtils.res
+++ b/src/screens/Transaction/Refunds/RefundUtils.res
@@ -222,6 +222,7 @@ let initialFilters = (json, filtervalues, _, _, _) => {
 
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForRefundFilters(filterDict, filtervalues)
+    | #connector => values->FilterSelectBox.makeOptions(~isTitle=true)
     | _ => values->FilterSelectBox.makeOptions
     }
     let customInput = switch key->getFilterTypeFromString {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

https://github.com/user-attachments/assets/f7119b4c-c275-4d75-99e4-90e4e248df96


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Operations tab should have only payment and threeds processors in the connector filter list
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
