### PR TITLE
chore: updated pr label workflow

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -13,31 +13,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Get existing labels
+      - name: Remove S-waiting-on-review label and add closed label
         run: |
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          TOKEN=$GITHUB_TOKEN
 
-          # Add your repository name if it's not the default branch
-          REPO_NAME=$(basename $GITHUB_REPOSITORY)
+          # Remove S-waiting-on-review label if it exists
+          curl -X DELETE \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/S-waiting-on-review"
 
-          # Get existing labels on the PR
-          EXISTING_LABELS=$(curl -s -H "Authorization: Bearer ${{ secrets.AUTO_RELEASE_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER" \
-            | jq -r '.labels | map(.name) | join(" ")')
-
-          echo $EXISTING_LABELS
-
-           # Remove existing labels
-          for LABEL in $EXISTING_LABELS; do
-            curl -X DELETE \
-              -H 'Accept: application/vnd.github.v3+json' \
-              -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/${LABEL}"
-          done
-
-      - name: Add new label
-        run: |
+          # Add closed label
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           gh pr edit ${{ github.event.pull_request.number }} --add-label "closed"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- pr-label workflow currently removed all the labels and adds the `closed` 
- instead it should only remove `S-waiting-on-review` and add `closed` 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
