### PR TITLE
fix: changed old analytics graph font style to InterDisplay

### DIFF
--- a/src/components/CustomCharts/HighchartTimeSeriesChart.res
+++ b/src/components/CustomCharts/HighchartTimeSeriesChart.res
@@ -454,6 +454,9 @@ module LineChart1D = {
             {
               "type": chartType,
               "margin": None,
+              "style": {
+                "fontFamily": "InterDisplay",
+              }->genericObjectOrRecordToJson,
               "zoomType": "x",
               "backgroundColor": Nullable.null,
               "height": Some(chartHeight),

--- a/src/components/CustomCharts/LineChartUtils.res
+++ b/src/components/CustomCharts/LineChartUtils.res
@@ -601,7 +601,7 @@ let getTooltipHTML = (metrics, data, onCursorName, index, length) => {
 
   let spacing = index !== length - 1 ? "<tr style='height: 10px;'></tr>" : ""
 
-  let highlight = onCursorName == name ? "font-weight:900;font-size:13px;" : "opacity:60%;"
+  let highlight = onCursorName == name ? "font-weight:500;font-size:13px;" : "opacity:60%;"
 
   `<tr>
       <td><span style='height:10px; width:10px;margin-top:5px;display:inline-block; background-color:${color};border-radius:3px;margin-right:3px;fontFamily:"Inter"'/></td>
@@ -645,7 +645,7 @@ let legendItemStyle = legendFontSizeClass => {
     "cursor": "pointer",
     "fontSize": legendFontSizeClass,
     "fontWeight": "500",
-    "fontFamily": "Inter",
+    "fontFamily": "InterDisplay",
     "fontStyle": "normal",
   }->genericObjectOrRecordToJson
 }

--- a/src/screens/Analytics/PerformanceMonitor/BarChartPerformance/BarChartPerformanceUtils.res
+++ b/src/screens/Analytics/PerformanceMonitor/BarChartPerformance/BarChartPerformanceUtils.res
@@ -3,6 +3,9 @@ let getBarOption = data =>
   {
     "chart": {
       "type": `column`,
+      "style": {
+        "fontFamily": "InterDisplay",
+      },
     },
     "xAxis": {
       "categories": data.categories,

--- a/src/screens/Analytics/PerformanceMonitor/GaugeChart/CustomGraphs/GaugeFailureRateUtils.res
+++ b/src/screens/Analytics/PerformanceMonitor/GaugeChart/CustomGraphs/GaugeFailureRateUtils.res
@@ -17,6 +17,9 @@ let falureGaugeOption = (data: gaugeData) =>
       "plotBorderWidth": 0,
       "plotShadow": false,
       "height": "75%",
+      "style": {
+        "fontFamily": "InterDisplay",
+      },
     },
     "pane": {
       "startAngle": -90,

--- a/src/screens/Analytics/PerformanceMonitor/GaugeChart/GaugeChartPerformanceUtils.res
+++ b/src/screens/Analytics/PerformanceMonitor/GaugeChart/GaugeChartPerformanceUtils.res
@@ -36,6 +36,9 @@ let gaugeOption = (data: gaugeData) =>
       "plotBorderWidth": 0,
       "plotShadow": false,
       "height": "75%",
+      "style": {
+        "fontFamily": "InterDisplay",
+      },
     },
     "pane": {
       "startAngle": -90,

--- a/src/screens/Analytics/PerformanceMonitor/PieChartPerformance/PieChartPerformanceUtils.res
+++ b/src/screens/Analytics/PerformanceMonitor/PieChartPerformance/PieChartPerformanceUtils.res
@@ -5,6 +5,9 @@ let getPieChartOptions = series => {
   {
     "chart": {
       "type": "pie",
+      "style": {
+        "fontFamily": "InterDisplay",
+      },
     },
     "tooltip": {
       "valueSuffix": ``,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
changed the old analytics graphs font style to Inter Display
<!-- Describe your changes in detail -->
<img width="851" alt="Screenshot 2025-05-01 at 11 07 23 PM" src="https://github.com/user-attachments/assets/fc89c643-3719-4dfd-96c3-62e8e9c377b4" />
<img width="842" alt="Screenshot 2025-05-01 at 11 08 01 PM" src="https://github.com/user-attachments/assets/0361cd6c-5f02-45d4-a9de-b377612533cc" />
<img width="868" alt="Screenshot 2025-05-01 at 11 12 28 PM" src="https://github.com/user-attachments/assets/dfdf3f13-0820-4992-b603-68cc128b0fbc" />
<img width="884" alt="Screenshot 2025-05-01 at 11 14 40 PM" src="https://github.com/user-attachments/assets/a1d40b0e-4761-490d-90e8-1fe008f36ab6" />

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the data displayed on the graph should have the same font 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
