### PR TITLE
fix: added validation for the api keys

### DIFF
--- a/src/screens/Developer/APIKeys/DeveloperUtils.res
+++ b/src/screens/Developer/APIKeys/DeveloperUtils.res
@@ -29,6 +29,14 @@ let validateAPIKeyForm = (
       }
     } else if key == "expiration" && value->String.toLowerCase == "never" {
       setShowCustomDate(false)
+    } else if key == "name" && value->String.length > 64 {
+      Dict.set(errors, "name", "Name can't be more than 64 characters"->JSON.Encode.string)
+    } else if key == "description" && value->String.length > 256 {
+      Dict.set(
+        errors,
+        "description",
+        "Description can't be more than 256 characters"->JSON.Encode.string,
+      )
     } else if (
       value->LogicUtils.isNonEmptyString &&
       (key === "webhook_url" || key === "return_url") &&

--- a/src/screens/Developer/APIKeys/KeyManagement.res
+++ b/src/screens/Developer/APIKeys/KeyManagement.res
@@ -108,7 +108,7 @@ module ApiEditModal = {
             initialValues={initialValues->JSON.Encode.object}
             subscription=ReactFinalForm.subscribeToPristine
             validate={values =>
-              validateAPIKeyForm(values, ["name", "expiration"], ~setShowCustomDate)}
+              validateAPIKeyForm(values, ["name", "expiration", "description"], ~setShowCustomDate)}
             onSubmit
             render={({handleSubmit}) => {
               <LabelVisibilityContext showLabel=false>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Throwing 500 error when adding long key and description for api key generation

<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/2136

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally


https://github.com/user-attachments/assets/82887556-9c10-4ffa-af03-1b3434a017c5


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
