### PR TITLE
fix: recovery Processor Reference ID empty value validation check

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -129,15 +129,14 @@ let make = (
     if profileId->String.length === 0 {
       Dict.set(errors, "Profile Id", `Please select your business profile`->JSON.Encode.string)
     }
+    let valueDict = values->getDictFromJsonObject
+    let revenue_recovery =
+      valueDict->getDictfromDict("feature_metadata")->getDictfromDict("revenue_recovery")
 
     if (
       currentStep->RevenueRecoveryOnboardingUtils.getSectionVariant ==
         (#addAPlatform, #configureRetries)
     ) {
-      let valueDict = values->getDictFromJsonObject
-      let revenue_recovery =
-        valueDict->getDictfromDict("feature_metadata")->getDictfromDict("revenue_recovery")
-
       let billing_connector_retry_threshold =
         revenue_recovery->getInt("billing_connector_retry_threshold", 0)
       let max_retry_count = revenue_recovery->getInt("max_retry_count", 0)
@@ -167,6 +166,22 @@ let make = (
           errors,
           "max_retry_count",
           `Max retry count count should be less than 15`->JSON.Encode.string,
+        )
+      }
+    }
+
+    if (
+      currentStep->RevenueRecoveryOnboardingUtils.getSectionVariant ==
+        (#addAPlatform, #connectProcessor)
+    ) {
+      let billing_account_reference =
+        revenue_recovery->getObj("billing_account_reference", Dict.make())
+
+      if billing_account_reference->getString(connectorID, "")->isEmptyString {
+        Dict.set(
+          errors,
+          "billing_account_reference",
+          `Please enter Processor Reference ID`->JSON.Encode.string,
         )
       }
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
recovery Processor Reference ID empty value validation check for billing connector onboarding flow 
<!-- Describe your changes in detail -->
![Screenshot 2025-05-05 at 3 09 24 PM](https://github.com/user-attachments/assets/5fb173fc-9452-4442-96b4-5b7d661c6866)

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
then the Processor Reference ID is empty the next button should be disabled 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
