### PR TITLE
test: payment operations date checking with 2 digits

### DIFF
--- a/cypress/e2e/3-operations/paymentOperations.cy.js
+++ b/cypress/e2e/3-operations/paymentOperations.cy.js
@@ -582,7 +582,7 @@ describe("Payment Operations", () => {
         const formatDate = (date) => {
           return date.toLocaleDateString("en-US", {
             month: "short",
-            day: "numeric",
+            day: "2-digit",
             year: "numeric",
           });
         };


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Payment Operations date range selection in cypress test is checking with the single digit date, so when the date is from 1st to 9th it will be 1, 2, ... 9 but in the website we have date range with 2 digits 01, 02, 03, ... 09 

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
