### PR TITLE
fix: payme connector additional secret not getting populated

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/ConnectorAccountDetailsHelper.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorAccountDetailsHelper.res
@@ -135,8 +135,8 @@ module RenderConnectorInputFields = {
       let isDisabled =
         disabled ||
         (field == "additional_secret" &&
-        merchantSecretValue->LogicUtils.isEmptyString &&
-        additionalSecretValue->LogicUtils.isEmptyString)
+        merchantSecretValue->isEmptyString &&
+        additionalSecretValue->isEmptyString)
 
       let formName = isLabelNested ? `${name}.${field}` : name
       <RenderIf condition={label->isNonEmptyString} key={i->Int.toString}>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

https://github.com/user-attachments/assets/d966268f-11d7-49e5-9b24-fe30db2d5e43


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
