### PR TITLE
chore: style issues for scrolling sdk

### DIFF
--- a/src/screens/SDKPayment/PreviewSection/SDKPayment.res
+++ b/src/screens/SDKPayment/PreviewSection/SDKPayment.res
@@ -171,8 +171,10 @@ let make = () => {
     | INCOMPLETE =>
       <RenderIf condition={clientSecretStatus == Success}>
         <div
-          className={`flex items-center justify-center ${backgroundBasedOnTheme} w-full h-3/4 border-2`}>
-          <WebSDK />
+          className={`flex items-center justify-center ${backgroundBasedOnTheme} w-full h-5/6 border-2`}>
+          <div className="w-full h-full overflow-y-auto p-4">
+            <WebSDK />
+          </div>
         </div>
       </RenderIf>
     | status =>

--- a/src/screens/SDKPayment/PreviewSection/WebSDK.res
+++ b/src/screens/SDKPayment/PreviewSection/WebSDK.res
@@ -63,7 +63,7 @@ let make = () => {
     locale: themeConfig->getString("locale", "en-GB"),
   }
 
-  <div className="w-4/5">
+  <div>
     {switch (isScriptLoaded, isHyperReady) {
     | (true, true) =>
       <Elements options=elementOptions stripe={hyperPromise()}>

--- a/src/screens/SDKPayment/SDKHelper/TestCredentials.res
+++ b/src/screens/SDKPayment/SDKHelper/TestCredentials.res
@@ -21,16 +21,15 @@ let make = () => {
   let testCardNumber = "4242 4242 4242 4242"
   let cardNumberCopy = "4242424242424242"
   let testCredsLink = "https://docs.hyperswitch.io/hyperswitch-cloud/connectors/test-a-payment-with-connector"
-  let applePayDocsLink = "https://hyperswitch.io/docs/paymentMethods/testCredentials"
 
   <div className="p-6 bg-jp-gray-test_credentials_bg w-full h-fit">
-    <div className="mb-4">
+    <div>
       <div className="flex items-center gap-4 mb-2">
         <p className="text-sm font-semibold">
           {"For Testing Stripe & Dummy Connectors"->React.string}
         </p>
       </div>
-      <div className="border-b border-[#c5d7f1] pb-4 mb-4">
+      <div>
         <TestCredsField label="Card Number :" value=testCardNumber copyData=cardNumberCopy />
         <TestCredsField label="Expiry:" value="Any future date" />
         <TestCredsField label="CVC:" value="Any 3 Digits" />
@@ -43,22 +42,6 @@ let make = () => {
           <img alt="open-new-tab" src="/icons/open-new-tab.svg" />
         </a>
       </div>
-    </div>
-    <div className="flex items-center gap-4 mb-4">
-      <p className="text-sm font-semibold"> {"For Testing Apple Pay"->React.string} </p>
-      <img alt="apple-pay" src="/Gateway/APPLE_PAY.svg" className="w-10 h-10" />
-    </div>
-    <div className="text-sm text-gray-700 opacity-70 leading-5">
-      <span>
-        {"Apple Pay cannot be tested from the dashboard as it is registered with merchant domain name and not app.hyperswitch. Please test using merchant SDK – refer the "->React.string}
-      </span>
-      <a
-        className="text-blue-400 underline underline-offset-4 decoration-blue-400"
-        href=applePayDocsLink
-        target="_blank"
-        rel="noopener noreferrer">
-        {"documentation"->React.string}
-      </a>
     </div>
   </div>
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix

## Description

Style issue the page was not scollable for multiple saved cards

## How did you test it?

<img width="1477" alt="Screenshot 2025-05-15 at 2 05 40 PM" src="https://github.com/user-attachments/assets/9755a40f-70f4-444e-89e3-1d2591c206aa" />


## Where to test it?

- [x] INTEG
- [x] SANDBOX

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
