### PR TITLE
fix: Analytics sample fixes

### DIFF
--- a/src/components/InputFields.res
+++ b/src/components/InputFields.res
@@ -544,6 +544,7 @@ let filterCompareDateRangeField = (
   ~compareWithStartTime: string,
   ~compareWithEndTime: string,
   ~disable=false,
+  ~textStyle=?,
 ): comboCustomInputRecord => {
   let fn = (_fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
     <DateRangeCompareFields
@@ -567,6 +568,7 @@ let filterCompareDateRangeField = (
       compareWithStartTime
       compareWithEndTime
       disable
+      ?textStyle
     />
   }
 

--- a/src/components/InputFields.resi
+++ b/src/components/InputFields.resi
@@ -266,6 +266,7 @@ let filterCompareDateRangeField: (
   ~compareWithStartTime: string,
   ~compareWithEndTime: string,
   ~disable: bool=?,
+  ~textStyle: string=?,
 ) => comboCustomInputRecord
 let dateRangeField: (
   ~startKey: string,
@@ -298,9 +299,10 @@ let iconFieldWithMessageDes: (
   (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element,
   ~description: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let passwordMatchField: (
-  ~leftIcon: React.element=?,
-) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: string) => React.element
+let passwordMatchField: (~leftIcon: React.element=?) => (
+  ~input: ReactFinalForm.fieldRenderPropsInput,
+  ~placeholder: string,
+) => React.element
 let checkboxInput: (
   ~isHorizontal: bool=?,
   ~options: array<SelectBox.dropdownOption>,
@@ -319,11 +321,11 @@ let checkboxInput: (
   ~checkboxDimension: string=?,
   ~wrapBasis: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let boolInput: (
-  ~isDisabled: bool,
-  ~isCheckBox: bool=?,
-  ~boolCustomClass: string=?,
-) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let colorPickerInput: (
-  ~defaultValue: Js.String.t=?,
-) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
+let boolInput: (~isDisabled: bool, ~isCheckBox: bool=?, ~boolCustomClass: string=?) => (
+  ~input: ReactFinalForm.fieldRenderPropsInput,
+  ~placeholder: 'a,
+) => React.element
+let colorPickerInput: (~defaultValue: string=?) => (
+  ~input: ReactFinalForm.fieldRenderPropsInput,
+  ~placeholder: 'a,
+) => React.element

--- a/src/components/InputFields.resi
+++ b/src/components/InputFields.resi
@@ -299,10 +299,9 @@ let iconFieldWithMessageDes: (
   (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element,
   ~description: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let passwordMatchField: (~leftIcon: React.element=?) => (
-  ~input: ReactFinalForm.fieldRenderPropsInput,
-  ~placeholder: string,
-) => React.element
+let passwordMatchField: (
+  ~leftIcon: React.element=?,
+) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: string) => React.element
 let checkboxInput: (
   ~isHorizontal: bool=?,
   ~options: array<SelectBox.dropdownOption>,
@@ -321,11 +320,11 @@ let checkboxInput: (
   ~checkboxDimension: string=?,
   ~wrapBasis: string=?,
 ) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
-let boolInput: (~isDisabled: bool, ~isCheckBox: bool=?, ~boolCustomClass: string=?) => (
-  ~input: ReactFinalForm.fieldRenderPropsInput,
-  ~placeholder: 'a,
-) => React.element
-let colorPickerInput: (~defaultValue: string=?) => (
-  ~input: ReactFinalForm.fieldRenderPropsInput,
-  ~placeholder: 'a,
-) => React.element
+let boolInput: (
+  ~isDisabled: bool,
+  ~isCheckBox: bool=?,
+  ~boolCustomClass: string=?,
+) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element
+let colorPickerInput: (
+  ~defaultValue: string=?,
+) => (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder: 'a) => React.element

--- a/src/components/SelectBox.res
+++ b/src/components/SelectBox.res
@@ -1726,15 +1726,17 @@ module BaseDropdown = {
     }, [showDropDown])
 
     let onClick = _ => {
-      switch buttonClickFn {
-      | Some(fn) => fn(input.name)
-      | None => ()
-      }
-      setShowDropDown(_ => !showDropDown)
-      setIsGrowDown(_ => true)
-      let _id = setTimeout(() => setIsGrowDown(_ => false), 250)
-      if isInitialRender {
-        setIsInitialRender(_ => false)
+      if !disableSelect {
+        switch buttonClickFn {
+        | Some(fn) => fn(input.name)
+        | None => ()
+        }
+        setShowDropDown(_ => !showDropDown)
+        setIsGrowDown(_ => true)
+        let _id = setTimeout(() => setIsGrowDown(_ => false), 250)
+        if isInitialRender {
+          setIsInitialRender(_ => false)
+        }
       }
     }
 
@@ -1952,7 +1954,7 @@ module BaseDropdown = {
         size=arrowIconSize
         className={`transition duration-[250ms] ease-out-[cubic-bezier(0.33, 1, 0.68, 1)] ${showDropDown
             ? "-rotate-180"
-            : ""}`}
+            : ""} ${disableSelect ? "opacity-50" : ""}`}
       />
 
     let textStyle = if isSelectTextDark && selectButtonText !== buttonText {
@@ -1961,11 +1963,16 @@ module BaseDropdown = {
       textStyle
     }
 
-    <div className={`flex relative  flex-row  flex-wrap`}>
+    <div
+      className={`flex relative flex-row flex-wrap ${disableSelect
+          ? "opacity-50 cursor-not-allowed"
+          : ""}`}>
       <div className={`flex relative ${flexWrapper} ${fullLength ? "w-full" : ""}`}>
         <div
           ref={selectBoxRef->ReactDOM.Ref.domRef}
-          className={`text-opacity-50 ${fullLength ? "w-full" : ""}`}>
+          className={`text-opacity-50 ${fullLength ? "w-full" : ""} ${disableSelect
+              ? "pointer-events-none"
+              : ""}`}>
           {switch baseComponent {
           | Some(comp) => <span onClick> {comp} </span>
           | None =>

--- a/src/container/InsightsAnalyticsContainer.res
+++ b/src/container/InsightsAnalyticsContainer.res
@@ -19,7 +19,7 @@ let make = () => {
     UserInfoProvider.defaultContext,
   )
   let mixpanelEvent = MixpanelHook.useSendEvent()
-
+  let isSampleDataEnabled = filterValueJson->getStringFromDictAsBool(sampleDataKey, false)
   let tempRecallAmountMetrics = async () => {
     try {
       //Currency Conversion is failing in Backend for the first time so to fix that we are the calling the api for one time and ignoring the error
@@ -136,7 +136,7 @@ let make = () => {
             ~compareWithStartTime=startTimeVal,
             ~compareWithEndTime=endTimeVal,
             ~events=dateDropDownTriggerMixpanelCallback,
-            ~sampleDataIsEnabled=filterValueJson->getStringFromDictAsBool(sampleDataKey, false),
+            ~sampleDataIsEnabled=isSampleDataEnabled,
           )}
           defaultFilterKeys=[
             startTimeFilterKey,
@@ -159,6 +159,8 @@ let make = () => {
           selectedEntity={analyticsEntity}
           onChange={updateAnalytcisEntity}
           entityMapper=UserInfoUtils.analyticsEntityMapper
+          disabled=isSampleDataEnabled
+          disabledDisplayName="Hyperswitch_test"
         />
       </Portal>
       <Tabs

--- a/src/screens/NewAnalytics/InsightsAnalyticsFilters/InsightsAnalyticsFilters.res
+++ b/src/screens/NewAnalytics/InsightsAnalyticsFilters/InsightsAnalyticsFilters.res
@@ -7,6 +7,7 @@ open InsightsTypes
 module RefundsFilter = {
   @react.component
   let make = (~filterValueJson, ~dimensions, ~loadFilters, ~screenState, ~updateFilterContext) => {
+    open InsightsContainerUtils
     let startTimeVal = filterValueJson->getString("startTime", "")
     let endTimeVal = filterValueJson->getString("endTime", "")
     let (currencOptions, setCurrencOptions) = React.useState(_ => [])
@@ -16,7 +17,7 @@ module RefundsFilter = {
       dict->Dict.set((#currency: filters :> string), selectedCurrency.value)
       dict
     }
-
+    let isSampleDataEnabled = filterValueJson->getStringFromDictAsBool(sampleDataKey, false)
     let responseHandler = json => {
       let options = json->getOptions
       setCurrencOptions(_ => options)
@@ -45,7 +46,11 @@ module RefundsFilter = {
 
     <PageLoaderWrapper screenState customLoader={<FilterLoader />}>
       <InsightsHelper.CustomDropDown
-        buttonText={selectedCurrency} options={currencOptions} setOption positionClass="left-0"
+        buttonText={selectedCurrency}
+        options={currencOptions}
+        setOption
+        positionClass="left-0"
+        disabled=isSampleDataEnabled
       />
     </PageLoaderWrapper>
   }

--- a/src/screens/NewAnalytics/InsightsContainerUtils.res
+++ b/src/screens/NewAnalytics/InsightsContainerUtils.res
@@ -78,7 +78,7 @@ let initialFixedFilterFields = (
       LastMonth,
     ]
   }
-
+  let textStyle = sampleDataIsEnabled ? "text-gray-400" : "text-primary"
   let newArr = [
     (
       {
@@ -123,6 +123,7 @@ let initialFixedFilterFields = (
             ~compareWithStartTime,
             ~compareWithEndTime,
             ~disable=sampleDataIsEnabled,
+            ~textStyle,
           ),
           ~inputFields=[],
         ),

--- a/src/screens/NewAnalytics/InsightsUtils.res
+++ b/src/screens/NewAnalytics/InsightsUtils.res
@@ -627,7 +627,7 @@ let fillMissingDataPoints = (
 let getSampleDateRange = (~useSampleDates) => {
   let defaultDateRange: filterBody = getDateFilteredObject(~range=7)
   let sampleDateRange: filterBody = {
-    start_time: "2024-09-05T00:00:00.000Z",
+    start_time: "2024-09-04T00:00:00.000Z",
     end_time: "2024-10-03T00:00:00.000Z",
   }
   let dates = useSampleDates ? sampleDateRange : defaultDateRange

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -152,7 +152,13 @@ let generateDropdownOptionsOMPViews = (dropdownList: OMPSwitchTypes.ompViews, ge
 
 module OMPViewsComp = {
   @react.component
-  let make = (~input, ~options, ~displayName, ~entityMapper=UserInfoUtils.entityMapper) => {
+  let make = (
+    ~input,
+    ~options,
+    ~displayName,
+    ~entityMapper=UserInfoUtils.entityMapper,
+    ~disabled=false,
+  ) => {
     let (arrow, setArrow) = React.useState(_ => false)
 
     let toggleChevronState = () => {
@@ -187,6 +193,7 @@ module OMPViewsComp = {
         shouldDisplaySelectedOnTop=true
         descriptionOnHover=true
         textEllipsisForDropDownOptions=true
+        disableSelect=disabled
       />
     </div>
   }
@@ -199,6 +206,8 @@ module OMPViews = {
     ~selectedEntity: UserInfoTypes.entity,
     ~onChange,
     ~entityMapper=UserInfoUtils.entityMapper,
+    ~disabled=false,
+    ~disabledDisplayName="",
   ) => {
     let (_, getNameForId) = OMPSwitchHooks.useOMPData()
 
@@ -216,9 +225,8 @@ module OMPViews = {
 
     let options = views->generateDropdownOptionsOMPViews(getNameForId)
 
-    let displayName = selectedEntity->getNameForId
-
-    <OMPViewsComp input options displayName />
+    let displayName = disabled ? disabledDisplayName : selectedEntity->getNameForId
+    <OMPViewsComp input options displayName disabled />
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

1. Disabled Currency Filter for Refunds
 - The "All Currencies (Converted to USD*)" filter is now disabled in the Refunds section, as currency conversion is not applicable here.

2. Disabled OMP View Filter

- The "View Data for" dropdown is now disabled with hyperswitch_test as the selected (and grayed-out) option, since data remains static regardless of selection.

3. Updated sample date range to 4th September – 3rd October across all graphs and tables to ensure consistency.

4. Updated Sample Data for Graph Accuracy
refunds.json and payments.json have been updated with more realistic, non-linear values to reflect actual behavior.
Tables and graphs are now consistent and accurate based on the revised data files.

5. Aligned Date Ranges Across Graphs and Tables
Sample Data are as follows: ( Uploaded to s3 )
[refunds.json](https://github.com/user-attachments/files/20347414/refunds.json)
[payments.json](https://github.com/user-attachments/files/20347415/payments.json)

## Motivation and Context

Requirement.

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

