### PR TITLE
feat: stripe refund for split payment

### DIFF
--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -928,6 +928,7 @@ let itemToObjMapper = dict => {
     merchant_order_reference_id: dict->getString("merchant_order_reference_id", ""),
     attempt_count: dict->getInt("attempt_count", 0),
     connector_label: dict->getString("connector_label", "NA"),
+    split_payments: dict->getDictfromDict("split_payments"),
   }
 }
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -114,6 +114,7 @@ type order = {
   merchant_order_reference_id: string,
   attempt_count: int,
   connector_label: string,
+  split_payments: Dict.t<JSON.t>,
 }
 
 type refundsColType =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add Support for Stripe Split Payments via Hyperswitch

Payment creation logic is not handled in this PR — it was referenced only for context and testing purposes.

During the refund creation:

1. Retrieves the original payment.
2. Checks the `split_payments.stripe_split_payment.charge_type` value.
3. Applies the appropriate refund behavior based on the charge type:
4. direct → Passes revert_platform_fee in the refund request.
```
    "split_refunds": {
        "stripe_split_refund": {
            "revert_platform_fee": true
        }
    }
```
5. destination → Passes revert_transfer and revert_platform_fee in the refund request.

```
     "split_refunds": {
        "stripe_split_refund": {
            "revert_platform_fee": true,
            "revert_transfer": true
        }
    }
 ```

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
