### PR TITLE
chore: disable create configuration flow only for auth rate routing

### DIFF
--- a/cypress/e2e/6-workflow/PaymentRouting.cy.js
+++ b/cypress/e2e/6-workflow/PaymentRouting.cy.js
@@ -24,7 +24,7 @@ describe("Volume based routing", () => {
     paymentRouting.volumeBasedRoutingSetupButton.click();
     cy.get('[class="px-3 text-fs-16"]').should(
       "contains.text",
-      "Please configure atleast 1 connector",
+      "Please configure at least 1 connector",
     );
   });
 

--- a/cypress/e2e/6-workflow/PaymentRouting.cy.js
+++ b/cypress/e2e/6-workflow/PaymentRouting.cy.js
@@ -178,7 +178,7 @@ describe("Rule based routing", () => {
     paymentRouting.ruleBasedRoutingSetupButton.click();
     cy.get('[class="px-3 text-fs-16"]').should(
       "contains.text",
-      "Please configure atleast 1 connector",
+      "Please configure at least 1 connector",
     );
   });
 });

--- a/src/screens/Routing/AuthRateRouting/AuthRateRouting.res
+++ b/src/screens/Routing/AuthRateRouting/AuthRateRouting.res
@@ -368,6 +368,7 @@ let make = (
                   customSumbitButtonStyle="w-1/5 rounded-lg"
                   tooltipWidthClass="w-48"
                 />}
+                showCancelButton=false
                 submitButton={<RoutingUtils.SaveAndActivateButton
                   onSubmit handleActivateConfiguration
                 />}

--- a/src/screens/Routing/AuthRateRouting/AuthRateRouting.res
+++ b/src/screens/Routing/AuthRateRouting/AuthRateRouting.res
@@ -373,7 +373,7 @@ let make = (
                   onSubmit handleActivateConfiguration
                 />}
                 headingText="Activate Current Configuration?"
-                subHeadingText="Activating this configuration will override the current one. Alternatively, save it to access later from the configuration history. Please confirm."
+                subHeadingText="Activating this configuration will override the current one. Please confirm."
                 leftIcon="warning-modal"
                 iconSize=35
               />

--- a/src/screens/Routing/CustomModal.res
+++ b/src/screens/Routing/CustomModal.res
@@ -9,6 +9,7 @@ module RoutingCustomModal = {
     ~subHeadingText,
     ~leftIcon,
     ~iconSize=25,
+    ~showCancelButton=true,
   ) => {
     <Modal
       showModal
@@ -30,7 +31,7 @@ module RoutingCustomModal = {
         />
       </div>
       <div className="flex items-end justify-end gap-4">
-        {cancelButton}
+        <RenderIf condition={showCancelButton}> {cancelButton} </RenderIf>
         {submitButton}
       </div>
     </Modal>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

save rule option hidden for auth rate routing because toggle api will activate the configuration also

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
