### PR TITLE
fix: routing rule generated statements to exclude empty condition

### DIFF
--- a/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
+++ b/src/screens/Routing/AdvancedRouting/AdvancedRoutingUtils.res
@@ -364,7 +364,11 @@ let generateStatements = statements => {
       filteredArr
     }
 
-    newAcc
+    let filteredAcc = newAcc->Array.filter(item => {
+      item.condition->Array.length > 0
+    })
+
+    filteredAcc
   })
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- generateStatement methods was adding empty condition array in the rules while generating payload 
- removed that empty condition array since that was causing backend to behave unusually while calculating and applying rules

![image](https://github.com/user-attachments/assets/253ebdde-02e2-463a-8e07-cb57b69d8f53)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- check surcharge update api, it should not have empty condition array in the statements inside rules

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
