### PR TITLE
fix: Custom daterange selector overlap with sidebar

### DIFF
--- a/src/components/DateRangeCompareFields.res
+++ b/src/components/DateRangeCompareFields.res
@@ -153,7 +153,7 @@ module Base = {
 
     let (isDropdownExpanded, setIsDropdownExpanded) = React.useState(_ => false)
     let (calendarVisibility, setCalendarVisibility) = React.useState(_ => false)
-
+    let (selectedOption, setSelectedOption) = React.useState(_ => No_Comparison)
     let isMobileView = MatchMedia.useMobileChecker()
     let isFilterSection = React.useContext(TableFilterSectionContext.filterSectionContext)
 
@@ -552,7 +552,8 @@ module Base = {
         setLocalDate(_ => date)
       }
     }
-    let handleCompareOptionClick = value => {
+    let handleCompareOptionClick = (value: compareOption) => {
+      setSelectedOption(_ => value)
       switch value {
       | Custom =>
         setCalendarVisibility(_ => true)
@@ -584,14 +585,19 @@ module Base = {
     }
 
     let dropDownElement = () => {
-      <div className={"flex md:flex-row flex-col w-full py-2"}>
+      <div className={"flex flex-col tablet:flex-row w-full gap-2 p-2"}>
         <AddDataAttributes attributes=[("data-date-picker-predifined", "predefined-options")]>
           <div className="flex flex-wrap gap-1 md:flex-col">
             {[No_Comparison, Previous_Period, Custom]
             ->Array.mapWithIndex((value, i) => {
               <div key={i->Int.toString} className="w-full md:min-w-max text-center md:text-start">
                 <CompareOption
-                  value comparison startDateVal endDateVal onClick=handleCompareOptionClick
+                  value
+                  selectedOption
+                  comparison
+                  startDateVal
+                  endDateVal
+                  onClick=handleCompareOptionClick
                 />
               </div>
             })

--- a/src/components/DateRangeField.res
+++ b/src/components/DateRangeField.res
@@ -711,7 +711,7 @@ module Base = {
     }
 
     let calendarElement =
-      <div className={`flex md:flex-row flex-col w-full py-2`}>
+      <div className={`flex flex-col tablet:flex-row w-full py-2`}>
         {if predefinedDays->Array.length > 0 && showOption {
           <AddDataAttributes attributes=[("data-date-picker-predifined", "predefined-options")]>
             <div className="flex flex-wrap gap-1 md:flex-col">
@@ -740,7 +740,7 @@ module Base = {
               ->React.array}
               <AddDataAttributes attributes=[("data-daterange-dropdown-value", "Custom Range")]>
                 <div
-                  className={`text-center md:text-start min-w-max bg-white dark:bg-jp-gray-lightgray_background w-1/3   hover:bg-jp-gray-100 hover:bg-opacity-75 dark:hover:bg-jp-gray-850 dark:hover:bg-opacity-100 cursor-pointer mx-2 rounded-md p-2 text-sm font-medium text-grey-900 ${customeRangeBg}}`}
+                  className={`text-center md:text-start min-w-max bg-white dark:bg-jp-gray-lightgray_background w-full hover:bg-jp-gray-100 hover:bg-opacity-75 dark:hover:bg-jp-gray-850 dark:hover:bg-opacity-100 cursor-pointer mx-2 rounded-md p-2 text-sm font-medium text-grey-900 ${customeRangeBg}}`}
                   onClick={_ => {
                     setCalendarVisibility(_ => true)
                     setIsCustomSelected(_ => true)

--- a/src/components/DateRangeHelper.res
+++ b/src/components/DateRangeHelper.res
@@ -12,7 +12,7 @@ module CompareOption = {
   ) => {
     open Typography
     let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
-    let selectedBg = if value->compareOptionToString == selectedOption->compareOptionToString {
+    let selectedBg = if value == selectedOption {
       "bg-jp-gray-100 "
     } else {
       "bg-white "

--- a/src/components/DateRangeHelper.res
+++ b/src/components/DateRangeHelper.res
@@ -2,9 +2,21 @@ open DateRangeUtils
 
 module CompareOption = {
   @react.component
-  let make = (~value: compareOption, ~comparison, ~startDateVal, ~endDateVal, ~onClick) => {
+  let make = (
+    ~value: compareOption,
+    ~selectedOption,
+    ~comparison,
+    ~startDateVal,
+    ~endDateVal,
+    ~onClick,
+  ) => {
+    open Typography
     let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
-
+    let selectedBg = if value->compareOptionToString == selectedOption->compareOptionToString {
+      "bg-jp-gray-100 "
+    } else {
+      "bg-white "
+    }
     let previousPeriod = React.useMemo(() => {
       let startDateStr = formatDateString(
         ~dateVal=startDateVal,
@@ -24,7 +36,7 @@ module CompareOption = {
 
     <div
       onClick={_ => onClick(value)}
-      className={`text-center md:text-start min-w-max bg-white w-full   hover:bg-jp-gray-100 hover:bg-opacity-75 cursor-pointer mx-2 rounded-md p-2 text-sm font-medium text-grey-900 `}>
+      className={`text-left ${selectedBg} w-full hover:bg-jp-gray-100 cursor-pointer rounded-md p-2 ${body.md.medium} text-grey-900`}>
       {switch value {
       | No_Comparison => "No Comparison"->React.string
       | Previous_Period =>

--- a/src/utils/DateRangeUtils.res
+++ b/src/utils/DateRangeUtils.res
@@ -25,13 +25,6 @@ let comparisonMapprer = val => {
   }
 }
 
-let compareOptionToString = (option: compareOption) =>
-  switch option {
-  | No_Comparison => "No_Comparison"
-  | Previous_Period => "Previous_Period"
-  | Custom => "Custom"
-  }
-
 let getDateString = (value, isoStringToCustomTimeZone: string => TimeZoneHook.dateTimeString) => {
   try {
     let {year, month, date} = isoStringToCustomTimeZone(value)

--- a/src/utils/DateRangeUtils.res
+++ b/src/utils/DateRangeUtils.res
@@ -25,6 +25,13 @@ let comparisonMapprer = val => {
   }
 }
 
+let compareOptionToString = (option: compareOption) =>
+  switch option {
+  | No_Comparison => "No_Comparison"
+  | Previous_Period => "Previous_Period"
+  | Custom => "Custom"
+  }
+
 let getDateString = (value, isoStringToCustomTimeZone: string => TimeZoneHook.dateTimeString) => {
   try {
     let {year, month, date} = isoStringToCustomTimeZone(value)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -374,7 +374,7 @@ module.exports = {
         nd_gray: {
           25: "#FCFCFD",
           50: "#F5F7FA",
-          100: "FBFBFB",
+          100: "#FBFBFB",
           150: "#ECEFF3",
           200: "#E1E4EA",
           300: "#CACFD8",


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- to resolve #3123 

13 inch:
<img width="1606" alt="Screenshot 2025-06-09 at 1 49 03 PM" src="https://github.com/user-attachments/assets/43c471b8-c3da-4299-8563-2eb7f0a0ec7e" />

14 inch:
<img width="1606" alt="Screenshot 2025-06-09 at 1 48 54 PM" src="https://github.com/user-attachments/assets/363dd0d2-cdb3-40a4-a010-791704e38c23" />

16 inch:
<img width="1606" alt="Screenshot 2025-06-09 at 1 49 11 PM" src="https://github.com/user-attachments/assets/c88348c6-628a-4f55-ab81-43d6698271e0" />

- Also added a highlight for the selected option to improve visibility and enhance the user experience.

## Motivation and Context

UX

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
