### PR TITLE
fix: correct 3DS sankey data calculation and ui

### DIFF
--- a/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
+++ b/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
@@ -80,6 +80,8 @@ let make = () => {
     setScreenState(_ => PageLoaderWrapper.Loading)
     try {
       if isSampleDataEnabled {
+        setQueryData(_ => Dict.make()->itemToObjMapperForQueryData)
+        setFunnelData(_ => Dict.make()->itemToObjMapperForFunnelData)
         let paymentsUrl = `${GlobalVars.getHostUrl}/test-data/analytics/payments.json`
         let res = await fetchApi(
           paymentsUrl,
@@ -132,6 +134,8 @@ let make = () => {
         setFunnelData(_ => funnelDict)
         setScreenState(_ => PageLoaderWrapper.Success)
       } else {
+        setQueryData(_ => Dict.make()->itemToObjMapperForQueryData)
+        setFunnelData(_ => Dict.make()->itemToObjMapperForFunnelData)
         let metricsUrl = getURL(~entityName=V1(ANALYTICS_AUTHENTICATION_V2), ~methodType=Post)
         let metricsRequestBody = InsightsUtils.requestBody(
           ~startTime=startTimeVal,
@@ -255,14 +259,14 @@ let make = () => {
       getMetricsDetails()->ignore
     }
     None
-  }, (startTimeVal, endTimeVal, filterValue))
+  }, (startTimeVal, endTimeVal, filterValue, isSampleDataEnabled))
 
   let topFilterUi = switch filterDataJson {
   | Some(filterData) =>
     <div className="flex flex-row">
       <DynamicFilter
         title="AuthenticationAnalyticsV2"
-        initialFilters={HSAnalyticsUtils.initialFilterFields(filterData)}
+        initialFilters={isSampleDataEnabled ? [] : HSAnalyticsUtils.initialFilterFields(filterData)}
         options=[]
         popupFilterFields={HSAnalyticsUtils.options(filterData)}
         initialFixedFilters={initialFixedFilterFields(
@@ -285,7 +289,10 @@ let make = () => {
         initialFilters=[]
         options=[]
         popupFilterFields=[]
-        initialFixedFilters={initialFixedFilterFields(~events=dateDropDownTriggerMixpanelCallback)}
+        initialFixedFilters={initialFixedFilterFields(
+          ~events=dateDropDownTriggerMixpanelCallback,
+          ~sampleDataIsEnabled=isSampleDataEnabled,
+        )}
         defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
         tabNames
         key="1"
@@ -360,7 +367,7 @@ let make = () => {
     <Insights />
     <hr className="w-full mt-6" />
     <div className="my-4">
-      <h2 className={`${heading.xl.semibold} text-jp-gray-900`}>
+      <h2 className={`${heading.md.semibold} text-jp-gray-900`}>
         {"3DS Exemption Analytics"->React.string}
       </h2>
     </div>

--- a/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalyticsHelper.res
+++ b/src/screens/NewAnalytics/NewAuthenticationAnalytics/NewAuthenticationAnalyticsHelper.res
@@ -134,7 +134,7 @@ module ModuleHeader = {
   let make = (~title, ~description="") => {
     open Typography
     <div className="p-4 bg-nd_gray-25 border-b dark:border-jp-gray-850">
-      <h2 className={`${heading.xl.semibold} text-jp-gray-900`}> {title->React.string} </h2>
+      <h2 className={`${heading.md.semibold} text-jp-gray-900`}> {title->React.string} </h2>
       <div className={`${body.md.medium} text-jp-gray-800 dark:text-dark_theme my-2`}>
         {description->React.string}
       </div>

--- a/src/screens/NewAnalytics/NewAuthenticationAnalytics/SCAExemptionAnalytics/SCAExemptionAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/NewAuthenticationAnalytics/SCAExemptionAnalytics/SCAExemptionAnalyticsUtils.res
@@ -96,8 +96,10 @@ let scaExemptionResponseMapper = (json: JSON.t) => {
         }
       }
 
-    | "pending" =>
-      countersDict->Dict.set("3ds_incomplete", countersDict->getInt("3ds_incomplete", 0) + count)
+    | "pending" => {
+        countersDict->Dict.set("3ds_incomplete", countersDict->getInt("3ds_incomplete", 0) + count)
+        countersDict->Dict.set("auth_failure", countersDict->getInt("auth_failure", 0) + count)
+      }
     | _ =>
       countersDict->Dict.set("3ds_incomplete", countersDict->getInt("3ds_incomplete", 0) + count)
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR fixes the Sankey chart data calculation logic to ensure accurate mapping of authentication and exemption statuses. It also includes minor UI adjustments to font size and the "+ Add Filters" button is now hidden when sample data is in use to avoid confusion. Also fixed a latency issue where old data was briefly shown when switching from sample data to real data.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
I have tested it in local setup.
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
