### PR TITLE
fix: theme colors for sidebar ompchart and border fix

### DIFF
--- a/src/Recon/ReconScreens/ReconConfiguration/ConnectProcessors/ConnectProcessorsHelper.res
+++ b/src/Recon/ReconScreens/ReconConfiguration/ConnectProcessors/ConnectProcessorsHelper.res
@@ -45,7 +45,7 @@ module ListBaseComp = {
             : "rotate-180"} transition duration-[250ms] opacity-70 ${secondaryTextColor}`
 
     <div
-      className={`flex flex-row cursor-pointer items-center py-5 px-4 gap-2 min-w-44 justify-between h-8 bg-white border rounded-lg border-nd_gray-100 shadow-sm`}>
+      className={`flex flex-row cursor-pointer items-center py-5 px-4 gap-2 min-w-44 justify-between h-8 bg-white border rounded-lg border-nd_gray-150 shadow-sm`}>
       <div className="flex flex-row items-center gap-2">
         <RenderIf condition={subHeading->String.length > 0}>
           <GatewayIcon gateway={subHeading->String.toUpperCase} className="w-6 h-6" />

--- a/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
+++ b/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
@@ -93,7 +93,7 @@ module ListBaseComp = {
     let bgClass = subHeading->String.length > 0 ? "bg-white" : "bg-nd_gray-50"
 
     <div
-      className={`flex flex-row cursor-pointer items-center py-5 px-4 gap-2 min-w-44 justify-between h-8 ${bgClass} border rounded-lg border-nd_gray-100 shadow-sm`}>
+      className={`flex flex-row cursor-pointer items-center py-5 px-4 gap-2 min-w-44 justify-between h-8 ${bgClass} border rounded-lg border-nd_gray-150 shadow-sm`}>
       <div className="flex flex-row items-center gap-2">
         <RenderIf condition={subHeading->String.length > 0}>
           <p

--- a/src/Recon/ReconScreens/ReconReports/ReconReportsHelper.res
+++ b/src/Recon/ReconScreens/ReconReports/ReconReportsHelper.res
@@ -93,7 +93,7 @@ module ListBaseComp = {
     let bgClass = subHeading->String.length > 0 ? "bg-white" : "bg-nd_gray-50"
 
     <div
-      className={`flex flex-row cursor-pointer items-center px-4 gap-2 min-w-44 justify-between h-36-px ${bgClass} border rounded-lg border-nd_gray-100 shadow-sm`}>
+      className={`flex flex-row cursor-pointer items-center px-4 gap-2 min-w-44 justify-between h-36-px ${bgClass} border rounded-lg border-nd_gray-150 shadow-sm`}>
       <div className="flex flex-row items-center gap-2">
         <RenderIf condition={subHeading->String.length > 0}>
           <p

--- a/src/screens/OMPSwitch/OMPSwitchHelper.res
+++ b/src/screens/OMPSwitch/OMPSwitchHelper.res
@@ -10,9 +10,9 @@ module ListBaseComp = {
     ~showDropdownArrow=true,
     ~user: UserInfoTypes.entity,
   ) => {
-    let {globalUIConfig: {sidebarColor: {secondaryTextColor}}} = React.useContext(
-      ThemeProvider.themeContext,
-    )
+    let {
+      globalUIConfig: {sidebarColor: {secondaryTextColor, backgroundColor, borderColor}},
+    } = React.useContext(ThemeProvider.themeContext)
     let {devOmpChart} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let arrowClassName = isDarkBg
       ? `${arrow
@@ -36,14 +36,14 @@ module ListBaseComp = {
                 description="Organisation Chart"
                 customStyle="!whitespace-nowrap"
                 toolTipFor={<button
-                  className="bg-nd_gray-150 w-5 h-5 rounded-sm flex items-center justify-center"
+                  className={`${backgroundColor.sidebarNormal} border ${borderColor} w-5 h-5 rounded-md flex items-center justify-center`}
                   onClick={ev => {
                     ReactEvent.Mouse.stopPropagation(ev)
                     RescriptReactRouter.push(
                       GlobalVars.appendDashboardPath(~url="/organization-chart"),
                     )
                   }}>
-                  <Icon name="github-fork" size=14 className="text-gray-500" />
+                  <Icon name="github-fork" size=14 className={`${secondaryTextColor}`} />
                 </button>}
                 toolTipPosition=ToolTip.Right
               />
@@ -62,7 +62,7 @@ module ListBaseComp = {
 
       | #Profile =>
         <div
-          className="flex flex-row cursor-pointer items-center p-3 gap-2 md:min-w-44 justify-between h-8 bg-white border rounded-lg border-nd_gray-100 shadow-sm">
+          className="flex flex-row cursor-pointer items-center p-3 gap-2 md:min-w-44 justify-between h-8 bg-white border rounded-lg border-nd_gray-150 shadow-sm">
           <div className="md:max-w-40 max-w-16">
             <p
               className="overflow-scroll text-nowrap text-sm font-medium text-nd_gray-500 whitespace-pre">


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The nd_gray-100 wasn't present before in tailwind and components that had border-nd_gray-100 were actually using default border color. The expected color for profile border is nd_gray-150.
Also OMP chart icon should use theme colors so that it can fit fill in all scenarios.

## Motivation and Context

UI Fix

## How did you test it?

locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
