### PR TITLE
fix: webhooks retry mixpanel event added

### DIFF
--- a/src/screens/Developer/Webhooks/WebhooksDetails.res
+++ b/src/screens/Developer/Webhooks/WebhooksDetails.res
@@ -118,6 +118,7 @@ let make = (~id) => {
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
   let updateDetails = useUpdateMethod()
+  let mixpanelEvent = MixpanelHook.useSendEvent()
   let showToast = ToastState.useShowToast()
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (data, setData) = React.useState(_ => JSON.Encode.null)
@@ -173,6 +174,7 @@ let make = (~id) => {
         ~id=Some(selectedEvent.eventId),
       )
       let _ = await updateDetails(url, Dict.make()->JSON.Encode.object, Post)
+      mixpanelEvent(~eventName="webhooks_retry")
       fetchWebhooksEventDetails()->ignore
     } catch {
     | Exn.Error(_) => showToast(~message="Failed to retry webhook", ~toastType=ToastError)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- added retry webhook mixpanel event

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
