### PR TITLE
chore: display prefilled merchant name in create merchant modal

### DIFF
--- a/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
+++ b/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
@@ -179,10 +179,10 @@ module CreateNewMerchantBody = {
     let merchantList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
     let initialValues = React.useMemo(() => {
       let dict = Dict.make()
-      dict->Dict.set(
-        "product_type",
-        selectedProduct->ProductUtils.getProductStringName->JSON.Encode.string,
-      )
+      let productName = selectedProduct->ProductUtils.getProductStringName
+      dict->Dict.set("product_type", productName->JSON.Encode.string)
+      let randomString = randomString(~length=10)
+      dict->Dict.set("company_name", JSON.Encode.string(`${productName}_${randomString}`))
       dict->JSON.Encode.object
     }, [selectedProduct])
 

--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -202,8 +202,7 @@ let make = () => {
         []
       }
       let concatenatedList = v1MerchantResponse->getArrayFromJson([])->Array.concat(v2MerchantList)
-      let response =
-        concatenatedList->LogicUtils.uniqueObjectFromArrayOfObjects(keyExtractorForMerchantid)
+      let response = concatenatedList->uniqueObjectFromArrayOfObjects(keyExtractorForMerchantid)
       let concatenatedListTyped = response->getMappedValueFromArrayOfJson(merchantItemToObjMapper)
       setMerchantList(_ => concatenatedListTyped)
     } catch {

--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -40,10 +40,10 @@ module NewMerchantCreationModal = {
 
     let initialValues = React.useMemo(() => {
       let dict = Dict.make()
-      let productName = activeProduct->ProductUtils.getProductStringName
-      dict->Dict.set("product_type", productName->String.toLowerCase->JSON.Encode.string)
-      let randomString = randomString(~length=10)
-      dict->Dict.set("company_name", JSON.Encode.string(`${productName}_${randomString}`))
+      dict->Dict.set(
+        "product_type",
+        activeProduct->ProductUtils.getProductStringName->String.toLowerCase->JSON.Encode.string,
+      )
       dict->JSON.Encode.object
     }, [activeProduct])
 

--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -2,6 +2,7 @@ module NewMerchantCreationModal = {
   @react.component
   let make = (~setShowModal, ~showModal, ~getMerchantList) => {
     open APIUtils
+    open LogicUtils
     let getURL = useGetURL()
     let mixpanelEvent = MixpanelHook.useSendEvent()
     let updateDetails = useUpdateMethod()
@@ -39,15 +40,14 @@ module NewMerchantCreationModal = {
 
     let initialValues = React.useMemo(() => {
       let dict = Dict.make()
-      dict->Dict.set(
-        "product_type",
-        activeProduct->ProductUtils.getProductStringName->String.toLowerCase->JSON.Encode.string,
-      )
+      let productName = activeProduct->ProductUtils.getProductStringName
+      dict->Dict.set("product_type", productName->String.toLowerCase->JSON.Encode.string)
+      let randomString = randomString(~length=10)
+      dict->Dict.set("company_name", JSON.Encode.string(`${productName}_${randomString}`))
       dict->JSON.Encode.object
     }, [activeProduct])
 
     let onSubmit = (values, _) => {
-      open LogicUtils
       let dict = values->getDictFromJsonObject
       let trimmedData = dict->getString("company_name", "")->String.trim
       Dict.set(dict, "company_name", trimmedData->JSON.Encode.string)
@@ -73,7 +73,6 @@ module NewMerchantCreationModal = {
     )
 
     let validateForm = (values: JSON.t) => {
-      open LogicUtils
       let errors = Dict.make()
       let companyName = values->getDictFromJsonObject->getString("company_name", "")->String.trim
       let isDuplicate =


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- showing a prefilled merchant name in create merchant modal, with `productName_randomString` format
![image](https://github.com/user-attachments/assets/4af7bb60-4a10-4c5d-b891-70911f68de30)


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
