### PR TITLE
fix: prod access form not visible

### DIFF
--- a/src/screens/Home/ProdIntent/GetProductionAccess.res
+++ b/src/screens/Home/ProdIntent/GetProductionAccess.res
@@ -39,11 +39,12 @@ let make = () => {
   | None => React.null
   }
 
-  let productsToShowProductionAccess: array<ProductTypes.productTypes> = [
-    Orchestration(V1),
-    DynamicRouting,
-    Recon,
-  ]
+  let isProdAccessAvailableForProduct = switch activeProduct {
+  | Orchestration(V1)
+  | DynamicRouting
+  | Recon => true
+  | _ => false
+  }
 
   let showGetProductionAccess =
     !isLiveMode &&
@@ -53,7 +54,7 @@ let make = () => {
       userHasAccess(~groupAccess=UserManagementTypes.MerchantDetailsManage),
       userHasAccess(~groupAccess=UserManagementTypes.AccountManage),
     ) === CommonAuthTypes.Access &&
-    productsToShowProductionAccess->Array.includes(activeProduct)
+    isProdAccessAvailableForProduct
 
   <RenderIf condition={showGetProductionAccess}> {prodAccess} </RenderIf>
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- prod access form not visible due to product type change 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
