### PR TITLE
fix: Addition of recon v1 in switches

### DIFF
--- a/src/screens/Home/ProdIntent/GetProductionAccess.res
+++ b/src/screens/Home/ProdIntent/GetProductionAccess.res
@@ -19,6 +19,7 @@ let make = () => {
   let eventName = switch activeProduct {
   | DynamicRouting => "intelligent_routing_get_production_access"
   | Orchestration(V1) => "get_production_access"
+  | Recon(V1) => "recon_v1_get_production_access"
   | _ => `${activeProduct->ProductUtils.getProductStringName}_get_production_access`
   }
 
@@ -42,7 +43,7 @@ let make = () => {
   let isProdAccessAvailableForProduct = switch activeProduct {
   | Orchestration(V1)
   | DynamicRouting
-  | Recon(V2) => true
+  | Recon(V1) => true
   | _ => false
   }
 

--- a/src/screens/OMPSwitch/MerchantSwitch.res
+++ b/src/screens/OMPSwitch/MerchantSwitch.res
@@ -14,6 +14,7 @@ module NewMerchantCreationModal = {
         switch activeProduct {
         | Orchestration(V1)
         | DynamicRouting
+        | Recon(V1)
         | CostObservability => {
             let url = getURL(~entityName=V1(USERS), ~userType=#CREATE_MERCHANT, ~methodType=Post)
             let _ = await updateDetails(url, values, Post)

--- a/src/screens/UserManagement/UserRevamp/UserUtils.res
+++ b/src/screens/UserManagement/UserRevamp/UserUtils.res
@@ -238,7 +238,8 @@ let getVersion = (product: ProductTypes.productTypes) => {
   switch product {
   | Orchestration(V1)
   | DynamicRouting
-  | CostObservability =>
+  | CostObservability
+  | Recon(V1) =>
     UserInfoTypes.V1
   | _ => UserInfoTypes.V2
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Addition of Recon V1 in all places of V1 products routes.

## Motivation and Context

While switching it was going to v2 route.

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
