### PR TITLE
fix: audit logs order and log details mismatch fix

### DIFF
--- a/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
+++ b/src/screens/Analytics/Logs/LogUtils/AuditLogUI.res
@@ -238,7 +238,7 @@ let make = (~id, ~urls, ~logType: LogTypes.pageType) => {
         setScreenState(_ => PageLoaderWrapper.Success)
         logs->Array.sort(sortByCreatedAt)
         setData(_ => logs->reorderLogs)
-        switch logs->Array.get(0) {
+        switch logs->Array.get(logs->Array.length - 1) {
         | Some(value) => {
             let initialData = value->getDictFromJsonObject
             initialData->setDefaultValue(setLogDetails, setSelectedOption)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<img width="1139" height="501" alt="Screenshot 2025-07-14 at 10 03 57 PM" src="https://github.com/user-attachments/assets/953bb96c-d2aa-47d6-98d8-b5c3e4702da2" />

audit log mismatch with the active selected log type 
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
the log deytails in the right side shoudl match with the active selected log details 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
