### PR TITLE
chore: already configured frm cannot be configured again

### DIFF
--- a/src/screens/Connectors/FraudAndRisk/FRMSelect.res
+++ b/src/screens/Connectors/FraudAndRisk/FRMSelect.res
@@ -69,9 +69,7 @@ module NewProcessorCards = {
     let headerText = "Connect a new fraud & risk management player"
 
     <RenderIf condition={unConfiguredFRMCount > 0}>
-      <div className="flex flex-col gap-4">
-        {frmAvailableForIntegration->descriptedFRMs(headerText)}
-      </div>
+      <div className="flex flex-col gap-4"> {unConfiguredFRMs->descriptedFRMs(headerText)} </div>
     </RenderIf>
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- In FRM connectors currently we display two connectors Signifyd and Riskified
- When both are configured we do not display any of them to reconfigure again
- When one of the two is configured we display both, but the user cannot re-configure a new frm processor that has already been configured so it should not be displayed 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- configure FRM processor

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
