### PR TITLE
fix: standardize amount format in recon engine

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewCardDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewCardDetails.res
@@ -4,6 +4,7 @@ let make = (~ruleDetails: ReconEngineOverviewTypes.reconRuleType) => {
   open ReconEngineOverviewUtils
   open ReconEngineOverviewHelper
   open APIUtils
+  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -74,18 +75,19 @@ let make = (~ruleDetails: ReconEngineOverviewTypes.reconRuleType) => {
     <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
       <OverviewCard
         title={`Expected from ${sourceAccountName}`}
-        value={formatAmountWithCurrency(sourcePostedAmount, sourceAccountCurrency)}
+        value={sourcePostedAmount->formatAmountWithCurrency(~currency=sourceAccountCurrency)}
       />
       <OverviewCard
         title={`Received by ${targetAccountName}`}
-        value={formatAmountWithCurrency(targetPostedAmount, targetAccountCurrency)}
+        value={targetPostedAmount->formatAmountWithCurrency(~currency=targetAccountCurrency)}
       />
       <OverviewCard
-        title="Variance" value={formatAmountWithCurrency(netVariance, sourceAccountCurrency)}
+        title="Variance"
+        value={netVariance->formatAmountWithCurrency(~currency=sourceAccountCurrency)}
       />
       <OverviewCard
         title={`Missing in ${targetAccountName}`}
-        value={formatAmountWithCurrency(missingInTargetAmount, targetAccountCurrency)}
+        value={missingInTargetAmount->formatAmountWithCurrency(~currency=targetAccountCurrency)}
       />
     </div>
   </PageLoaderWrapper>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewUtils.res
@@ -82,11 +82,6 @@ let getAccountNameAndCurrency = (accountData: array<accountType>, accountId: str
   (account.account_name, account.currency->LogicUtils.isEmptyString ? "N/A" : account.currency)
 }
 
-let formatAmountWithCurrency = (amount: float, currency: string) => {
-  let roundedAmount = (amount *. 100.0)->Math.round /. 100.0
-  `${roundedAmount->Float.toString} ${currency}`
-}
-
 let calculateAccountAmounts = (
   transactionsData: array<ReconEngineTransactionsTypes.transactionPayload>,
 ) => {
@@ -134,9 +129,10 @@ let calculateAccountAmounts = (
     }
   })
 
-  let totalSourceAmount = sourcePosted +. sourceMismatched +. sourceExpected
-  let totalTargetAmount = targetPosted +. targetMismatched
-  let variance = Math.abs(totalSourceAmount -. totalTargetAmount)
+  let totalSourceAmount =
+    (sourcePosted +. sourceMismatched +. sourceExpected) *. 100.0->Math.round /. 100.0
+  let totalTargetAmount = (targetPosted +. targetMismatched) *. 100.0->Math.round /. 100.0
+  let variance = (Math.abs(totalSourceAmount -. totalTargetAmount) *. 100.0)->Math.round /. 100.0
 
   (totalSourceAmount, totalTargetAmount, targetExpected, variance)
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsUtils.res
@@ -6,10 +6,6 @@ let getArrayDictFromRes = res => {
   res->getDictFromJsonObject->getArrayFromDict("data", [])
 }
 
-let formatAmountToString = (amount, ~currency) => {
-  `${amount->Float.toString} ${currency}`
-}
-
 let getAmountPayload = dict => {
   {
     value: dict->getFloat("value", 0.0),

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/TransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/TransactionsTableEntity.res
@@ -68,19 +68,21 @@ let getCell = (transaction: transactionPayload, colType: transactionColType): Ta
   | DebitAccount => Text(getAccounts(transaction.entries, "debit"))
   | CreditAmount =>
     Text(
-      transaction.credit_amount.value->formatAmountToString(
+      formatAmountWithCurrency(
+        transaction.credit_amount.value,
         ~currency=transaction.credit_amount.currency,
       ),
     )
   | DebitAmount =>
     Text(
-      transaction.debit_amount.value->formatAmountToString(
+      formatAmountWithCurrency(
+        transaction.debit_amount.value,
         ~currency=transaction.debit_amount.currency,
       ),
     )
   | Variance =>
     Text(
-      formatAmountToString(
+      formatAmountWithCurrency(
         Math.abs(transaction.credit_amount.value -. transaction.debit_amount.value),
         ~currency=transaction.credit_amount.currency,
       ),

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -1,6 +1,10 @@
 open LogicUtils
 open ReconEngineTransactionsTypes
 
+let formatAmountWithCurrency = (value, ~currency) => {
+  `${value->Float.toFixedWithPrecision(~digits=2)} ${currency}`
+}
+
 let getAccountOptionsFromTransactions = (
   transactions: array<transactionPayload>,
   entryType: string,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Standardize amount format in the recon engine
<img width="1319" height="254" alt="Screenshot 2025-07-29 at 1 11 26 PM" src="https://github.com/user-attachments/assets/7ef26c65-ae8d-4acc-baf7-ad0b478d06af" />
<img width="554" height="626" alt="Screenshot 2025-07-29 at 1 11 38 PM" src="https://github.com/user-attachments/assets/bf80cd59-eb93-4960-9220-2d99616a4f37" />


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
