### PR TITLE
fix: signup coming up even when in auth methods its disabled

### DIFF
--- a/src/entryPoints/AuthModule/AuthModuleHooks.res
+++ b/src/entryPoints/AuthModule/AuthModuleHooks.res
@@ -85,34 +85,28 @@ let useAuthMethods = (): authMethodProps => {
     open SSOTypes
     let magicLinkmethod = getAuthMethod(MAGIC_LINK)
     let passwordmethod = getAuthMethod(PASSWORD)
+    let emailFeatureFlagEnable = featureFlagValues.email
 
     let isSingUpAllowedinMagicLink = switch magicLinkmethod {
     | Some(magicLinkData) => magicLinkData->Array.some(v => v.allow_signup)
-    | None => false
+    | None => emailFeatureFlagEnable
     }
+
     let isSingUpAllowedinPassword = switch passwordmethod {
     | Some(passwordData) => passwordData->Array.some(v => v.allow_signup)
-    | None => false
+    | None => !emailFeatureFlagEnable
     }
-    let emailFeatureFlagEnable = featureFlagValues.email
-    // let isTotpFeatureDisable = featureFlagValues.totp
 
     let isLiveMode = featureFlagValues.isLiveMode
 
     if isLiveMode {
       // Singup not allowed in Prod
       (false, INVALID)
-    } else if isSingUpAllowedinMagicLink && emailFeatureFlagEnable {
+    } else if isSingUpAllowedinMagicLink {
       // Singup is allowed if email feature flag and allow_signup in the magicLink method is true
       (true, MAGIC_LINK)
     } else if isSingUpAllowedinPassword {
-      // Singup is allowed if email feature flag and allow_signup in the passowrd method is true
-      (true, PASSWORD)
-    } else if emailFeatureFlagEnable {
-      // Singup is allowed if totp feature  is disable and email feature is enabled
-      (true, MAGIC_LINK)
-    } else if !isLiveMode {
-      // Singup is allowed if totp feature  is disable
+      // Singup is allowed if email feature flag and allow_signup in the password method is true
       (true, PASSWORD)
     } else {
       (false, INVALID)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
If the auth methods say password and magic link and says allow_signup to be false , signup shouldn't show up in FE .
<img width="2028" height="702" alt="image" src="https://github.com/user-attachments/assets/0e3a141f-f49e-4f89-9b1b-980f07b7e04f" />
<img width="2028" height="702" alt="image" src="https://github.com/user-attachments/assets/453bedf6-b0ea-4fd1-b7ed-9f5822161b3f" />


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- in integ 
- for auth_id disable allow signup as false and UI shouldn't even render signup 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [X] INTEG
- [X] SANDBOX
- [X] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
