### PR TITLE
chore: remove sync for terminal payment intent status

### DIFF
--- a/src/screens/Transaction/Order/HSwitchOrderUtils.res
+++ b/src/screens/Transaction/Order/HSwitchOrderUtils.res
@@ -3,6 +3,7 @@ type status =
   | Succeeded
   | Failed
   | Cancelled
+  | Expired
   | Processing
   | RequiresCustomerAction
   | RequiresPaymentMethod
@@ -68,6 +69,7 @@ let statusVariantMapper: string => status = statusLabel =>
   | "REQUIRES_CONFIRMATION" => RequiresConfirmation
   | "PARTIALLY_CAPTURED" => PartiallyCaptured
   | "CANCELLED_POST_CAPTURE" => CancelledPostCapture
+  | "EXPIRED" => Expired
   | _ => None
   }
 

--- a/src/screens/Transaction/Order/ShowOrder.res
+++ b/src/screens/Transaction/Order/ShowOrder.res
@@ -666,6 +666,8 @@ let make = (~id, ~profileId, ~merchantId, ~orgId) => {
     !(id->isTestData) &&
     status !== Succeeded &&
     status !== Failed &&
+    status !== Cancelled &&
+    status !== Expired &&
     status !== CancelledPostCapture
   }, [orderData])
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Remove sync button in the payment detail page if it is a terminal status, Cancelled and Expired are the terminal payment intent statuses

<img width="1396" height="685" alt="Screenshot 2025-08-21 at 6 35 14 PM" src="https://github.com/user-attachments/assets/179dd3fa-a26a-47b0-95a2-8fb05583a804" />

<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3468

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
