### PR TITLE
fix: sample analytics group by bugfix

### DIFF
--- a/src/screens/NewAnalytics/Insights/PaymentAnalytics/FailedPaymentsDistribution/FailedPaymentsDistribution.res
+++ b/src/screens/NewAnalytics/Insights/PaymentAnalytics/FailedPaymentsDistribution/FailedPaymentsDistribution.res
@@ -135,6 +135,7 @@ let make = (
         ->getDictFromJsonObject
         ->getArrayFromDict("queryData", [])
         ->filterQueryData(groupBy.value)
+        ->aggregateSampleDataByGroupBy(groupBy.value)
 
       if responseData->Array.length > 0 {
         setfailedPaymentsDistribution(_ => responseData->JSON.Encode.array)

--- a/src/screens/NewAnalytics/Insights/PaymentAnalytics/InsightsPaymentAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/Insights/PaymentAnalytics/InsightsPaymentAnalyticsUtils.res
@@ -96,7 +96,7 @@ let aggregateSampleDataByGroupBy = (data: array<JSON.t>, groupByKey: string) => 
       itemDict->getString(groupByKey, "")
     }
 
-    if groupValue->isNonEmptyString && groupValue !== "," {
+    if groupValue->isNonEmptyString {
       switch aggregatedDict->Dict.get(groupValue) {
       | Some(existingItem) => {
           let existingDict = existingItem->getDictFromJsonObject

--- a/src/screens/NewAnalytics/Insights/PaymentAnalytics/InsightsPaymentAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/Insights/PaymentAnalytics/InsightsPaymentAnalyticsUtils.res
@@ -88,12 +88,10 @@ let aggregateSampleDataByGroupBy = (data: array<JSON.t>, groupByKey: string) => 
 
   data->Array.forEach(item => {
     let itemDict = item->getDictFromJsonObject
-    // Handle composite keys (e.g., "payment_method,payment_method_type")
-    let groupValue = if groupByKey->String.includes(",") {
-      groupByKey
-      ->String.split(",")
-      ->Array.map(key => itemDict->getString(key->String.trim, ""))
-      ->Array.joinWith(",")
+    let groupValue = if groupByKey === "payment_method,payment_method_type" {
+      let paymentMethod = itemDict->getString("payment_method", "")
+      let paymentMethodType = itemDict->getString("payment_method_type", "")
+      `${paymentMethod},${paymentMethodType}`
     } else {
       itemDict->getString(groupByKey, "")
     }

--- a/src/screens/NewAnalytics/Insights/PaymentAnalytics/SuccessfulPaymentsDistribution/SuccessfulPaymentsDistribution.res
+++ b/src/screens/NewAnalytics/Insights/PaymentAnalytics/SuccessfulPaymentsDistribution/SuccessfulPaymentsDistribution.res
@@ -113,6 +113,7 @@ let make = (
         ->getDictfromDict("paymentsRateDataWithConnectors")
         ->getArrayFromDict("queryData", [])
         ->filterQueryData(groupBy.value)
+        ->aggregateSampleDataByGroupBy(groupBy.value)
       } else {
         let url = getURL(
           ~entityName=V1(ANALYTICS_PAYMENTS),

--- a/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/FailureSmartRetryDistribution/FailureSmartRetryDistribution.res
+++ b/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/FailureSmartRetryDistribution/FailureSmartRetryDistribution.res
@@ -5,6 +5,7 @@ open BarGraphTypes
 open InsightsSmartRetryAnalyticsEntity
 open FailureSmartRetryDistributionUtils
 open FailureSmartRetryDistributionTypes
+open InsightsPaymentAnalyticsUtils
 
 module TableModule = {
   @react.component
@@ -121,7 +122,15 @@ let make = (
         )
         await updateDetails(url, body, Post)
       }
-      let responseData = response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+      let responseData = if isSampleDataEnabled {
+        let sampleData =
+          response
+          ->getDictFromJsonObject
+          ->getArrayFromDict("queryData", [])
+        sampleData->aggregateSampleDataByGroupBy(groupBy.value)
+      } else {
+        response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+      }
 
       if responseData->Array.length > 0 {
         setpaymentsDistribution(_ => responseData->JSON.Encode.array)

--- a/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/FailureSmartRetryDistribution/FailureSmartRetryDistribution.res
+++ b/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/FailureSmartRetryDistribution/FailureSmartRetryDistribution.res
@@ -123,11 +123,10 @@ let make = (
         await updateDetails(url, body, Post)
       }
       let responseData = if isSampleDataEnabled {
-        let sampleData =
-          response
-          ->getDictFromJsonObject
-          ->getArrayFromDict("queryData", [])
-        sampleData->aggregateSampleDataByGroupBy(groupBy.value)
+        response
+        ->getDictFromJsonObject
+        ->getArrayFromDict("queryData", [])
+        ->aggregateSampleDataByGroupBy(groupBy.value)
       } else {
         response->getDictFromJsonObject->getArrayFromDict("queryData", [])
       }

--- a/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/SuccessfulSmartRetryDistribution/SuccessfulSmartRetryDistribution.res
+++ b/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/SuccessfulSmartRetryDistribution/SuccessfulSmartRetryDistribution.res
@@ -5,6 +5,7 @@ open BarGraphTypes
 open InsightsSmartRetryAnalyticsEntity
 open SuccessfulSmartRetryDistributionUtils
 open SuccessfulSmartRetryDistributionTypes
+open InsightsPaymentAnalyticsUtils
 
 module TableModule = {
   @react.component
@@ -121,7 +122,15 @@ let make = (
         )
         await updateDetails(url, body, Post)
       }
-      let responseData = response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+      let responseData = if isSampleDataEnabled {
+        let sampleData =
+          response
+          ->getDictFromJsonObject
+          ->getArrayFromDict("queryData", [])
+        sampleData->aggregateSampleDataByGroupBy(groupBy.value)
+      } else {
+        response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+      }
 
       if responseData->Array.length > 0 {
         setpaymentsDistribution(_ => responseData->JSON.Encode.array)

--- a/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/SuccessfulSmartRetryDistribution/SuccessfulSmartRetryDistribution.res
+++ b/src/screens/NewAnalytics/Insights/SmartRetryAnalytics/SuccessfulSmartRetryDistribution/SuccessfulSmartRetryDistribution.res
@@ -123,11 +123,10 @@ let make = (
         await updateDetails(url, body, Post)
       }
       let responseData = if isSampleDataEnabled {
-        let sampleData =
-          response
-          ->getDictFromJsonObject
-          ->getArrayFromDict("queryData", [])
-        sampleData->aggregateSampleDataByGroupBy(groupBy.value)
+        response
+        ->getDictFromJsonObject
+        ->getArrayFromDict("queryData", [])
+        ->aggregateSampleDataByGroupBy(groupBy.value)
       } else {
         response->getDictFromJsonObject->getArrayFromDict("queryData", [])
       }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

For all filters , metrics were repeating as group by api wasn't being called.

<img width="1050" height="619" alt="Screenshot 2025-08-26 at 6 41 14 PM" src="https://github.com/user-attachments/assets/ccc3fdee-a0a0-48b0-8c45-c1b6d62594f8" />

But for sample data created a aggregator function to aggregate repetitive values:

<img width="1274" height="616" alt="Screenshot 2025-08-26 at 6 46 19 PM" src="https://github.com/user-attachments/assets/180c7cf0-68e4-415a-ab69-c4ee810c113b" />

The change is for ->
Payments -> Successful Payments Distribution -> Authentication Type
Payments -> Failed Payments Distribution -> Authentication Type
Smart retries -> Successful Distribution of Smart Retry Payments -> Authentication Type
Smart retries -> Failed Distribution of Smart Retry Payments -> Authentication Type

## Motivation and Context

Bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
