### PR TITLE
fix: remove unnessary hr for orgsidebar

### DIFF
--- a/src/screens/Sidebar/OrgSidebar.res
+++ b/src/screens/Sidebar/OrgSidebar.res
@@ -450,6 +450,7 @@ let make = () => {
   let handleIdUnderEdit = (selectedEditId: option<int>) => {
     setUnderEdit(_ => selectedEditId)
   }
+  let hasPlatformOrg = platformOrgList->Array.length > 0
 
   <div className={`${backgroundColor.sidebarNormal}  p-2 pt-3 border-r w-14 ${borderColor}`}>
     <div className="flex flex-col gap-5 pt-2 px-2 items-center justify-center ">
@@ -461,14 +462,14 @@ let make = () => {
           onClick={_ => setShowAllOrgs(_ => false)}
         />
       </RenderIf>
-      <RenderIf condition={platformOrgList->Array.length > 0}>
+      <RenderIf condition={hasPlatformOrg}>
         <OrgTileGroup
           customHeading={<div
             className="text-nd_gray-400 uppercase leading-12 text-fs-8 font-bold flex flex-col items-center">
             <div> {"Platform"->React.string} </div>
             <div> {"Org"->React.string} </div>
           </div>}
-          hasPlatformOrg={platformOrgList->Array.length > 0}
+          hasPlatformOrg
           orgList=platformOrgList
           orgSwitch
           currentlyEditingId
@@ -476,10 +477,12 @@ let make = () => {
         />
       </RenderIf>
       <RenderIf condition={standardOrgList->Array.length > 0}>
-        <hr className="w-full" />
+        <RenderIf condition={hasPlatformOrg}>
+          <hr className="w-full" />
+        </RenderIf>
         <OrgTileGroup
           heading="Org"
-          hasPlatformOrg={platformOrgList->Array.length > 0}
+          hasPlatformOrg
           orgList=standardOrgList
           orgSwitch
           currentlyEditingId


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

UI bugfix
Even though no platform org there is a divider shown.

Before:

<img width="511" height="619" alt="Screenshot 2025-08-28 at 2 43 16 PM" src="https://github.com/user-attachments/assets/4ed4c662-a527-4abd-8afa-1360ce07c05f" />

After:

<img width="1174" height="1066" alt="Screenshot 2025-08-28 at 2 44 19 PM" src="https://github.com/user-attachments/assets/93010b79-17e8-40a0-b305-1510357ff042" />

## Motivation and Context

UI bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
