### PR TITLE
fix: payout details bugfix

### DIFF
--- a/src/screens/Payouts/PayoutsEntity.res
+++ b/src/screens/Payouts/PayoutsEntity.res
@@ -1,4 +1,5 @@
 open LogicUtils
+open ConnectorTypes
 
 let concatValueOfGivenKeysOfDict = (dict, keys) => {
   Array.reduceWithIndex(keys, "", (acc, key, i) => {
@@ -194,12 +195,22 @@ let getAttemptCell = (attemptData, colType): Table.cell => {
     )
   | Currency => Text(attemptData.currency)
   | Connector =>
-    CustomCell(<HelperComponents.ConnectorCustomCell connectorName=attemptData.connector />, "")
+    CustomCell(
+      <HelperComponents.ConnectorCustomCell
+        connectorName=attemptData.connector connectorType=PayoutProcessor
+      />,
+      "",
+    )
   | ErrorCode => Text(attemptData.error_code)
   | Error_message => Text(attemptData.error_message)
   | PaymentMethod => Text(attemptData.payment_method)
   | PayoutMethodType => Text(attemptData.payout_method_type)
-  | ConnectorTransactionId => DisplayCopyCell(attemptData.connector_transaction_id)
+  | ConnectorTransactionId =>
+    if attemptData.connector_transaction_id->isNonEmptyString {
+      DisplayCopyCell(attemptData.connector_transaction_id)
+    } else {
+      Text("NA")
+    }
   | CancellationReason => Text(attemptData.cancellation_reason)
   | UnifiedCode => Text(attemptData.unified_code)
   | UnifiedMessage => Text(attemptData.unified_message)
@@ -278,8 +289,7 @@ type aboutPayoutColType =
   | Connector
   | ProfileId
   | ProfileName
-  | PayoutMethodType
-  | PayoutMethod
+  | PayoutType
   | CardBrand
   | ConnectorLabel
   | AuthenticationType
@@ -565,13 +575,17 @@ let getCellForSummary = (order, summaryColType): Table.cell => {
   | ClientSecret => Text(order.client_secret)
   | ErrorMessage => Text(order.error_message)
   | ConnectorTransactionID =>
-    CustomCell(
-      <HelperComponents.CopyTextCustomComp
-        customTextCss="w-36 truncate whitespace-nowrap"
-        displayValue=Some(order.connector_transaction_id)
-      />,
-      "",
-    )
+    if order.connector_transaction_id->isNonEmptyString {
+      CustomCell(
+        <HelperComponents.CopyTextCustomComp
+          customTextCss="w-36 truncate whitespace-nowrap"
+          displayValue=Some(order.connector_transaction_id)
+        />,
+        "",
+      )
+    } else {
+      Text("NA")
+    }
   }
 }
 
@@ -600,8 +614,7 @@ let getHeadingForAboutPayment = aboutPaymentColType => {
   | ProfileName => Table.makeHeaderInfo(~key="profile_name", ~title="Profile Name")
   | CardBrand => Table.makeHeaderInfo(~key="card_brand", ~title="Card Brand")
   | ConnectorLabel => Table.makeHeaderInfo(~key="connector_label", ~title="Connector Label")
-  | PayoutMethod => Table.makeHeaderInfo(~key="payout_method", ~title="Payout Method")
-  | PayoutMethodType => Table.makeHeaderInfo(~key="payout_method_type", ~title="Payout Method Type")
+  | PayoutType => Table.makeHeaderInfo(~key="payout_type", ~title="Payout Type")
   | AuthenticationType => Table.makeHeaderInfo(~key="authentication_type", ~title="Auth Type")
   | CaptureMethod => Table.makeHeaderInfo(~key="capture_method", ~title="Capture Method")
   | CardNetwork => Table.makeHeaderInfo(~key="card_network", ~title="Card Network")
@@ -649,8 +662,7 @@ let getCellForAboutPayment = (payoutData, aboutPaymentColType): Table.cell => {
     )
   | ProfileId => DisplayCopyCell(payoutData.profile_id)
   | ProfileName => Text("")
-  | PayoutMethod => Text(payoutData.payout_type)
-  | PayoutMethodType => Text(payoutData.payout_type)
+  | PayoutType => Text(payoutData.payout_type)
   | CardBrand => Text("")
   | ConnectorLabel => Text(payoutData.connector)
   | AuthenticationType => Text("")

--- a/src/screens/Payouts/ShowPayout.res
+++ b/src/screens/Payouts/ShowPayout.res
@@ -176,8 +176,7 @@ module PayoutInfo = {
               ProfileName,
               Connector,
               ConnectorLabel,
-              PayoutMethodType,
-              PayoutMethod,
+              PayoutType,
               CardNetwork,
             ]
           />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

1. **Connector names display**  
   - Adyen Platform and Wise connector names are now shown correctly.  

   <img width="1216" height="1154" alt="Screenshot 2025-09-01 at 1 10 01 PM" src="https://github.com/user-attachments/assets/41921a66-b81f-4d72-8052-5579ed0b1afb" />  

2. **Connector transaction ID handling**  
   - When the connector transaction ID for a payout detail is `null`, it indicates either:  
     - The payout has not been confirmed yet (no request made to the connector), or  
     - The payout attempt failed and no reference was returned by the connector.  
   - In such cases, display **`NA`** instead of leaving it blank.  

   <img width="631" height="480" alt="Screenshot 2025-09-01 at 1 11 54 PM" src="https://github.com/user-attachments/assets/a6eec815-c11c-4e7f-9f87-0a95e793fbc0" />  

3. **Payout type vs method type**  
   - `payout_type` is available in the "About" section of payouts and should be displayed there.  
   - `payout_method_type` is not sent in the "About" section but is available in individual attempt details, where it should be shown.  

   <img width="1211" height="1148" alt="Screenshot 2025-09-01 at 1 13 32 PM" src="https://github.com/user-attachments/assets/d3d5ea0f-890e-4af8-9708-b41a14e1094a" />  

## Motivation and Context

https://github.com/juspay/hyperswitch-cloud/issues/10537

## How did you test it?

Local

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
