### PR TITLE
fix: user logout when product switch from recon engine to orchestrator

### DIFF
--- a/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
+++ b/src/entryPoints/AuthModule/ProductSelection/ProductSelectionProvider.res
@@ -126,7 +126,7 @@ let make = (~children) => {
         showModal
         setShowModal
         action={actionVariant}
-        selectedProduct={selectedProduct->Option.getOr(Vault)}
+        selectedProduct={selectedProduct->Option.getOr(UnknownProduct)}
         setActiveProductValue
       />
     | None => React.null

--- a/src/screens/OrchestrationHooks/OMPSwitchHooks.res
+++ b/src/screens/OrchestrationHooks/OMPSwitchHooks.res
@@ -148,7 +148,7 @@ let useMerchantSwitch = (~setActiveProductValue) => {
   }
 }
 
-let useProfileSwitch = (~setActiveProductValue) => {
+let useProfileSwitch = () => {
   open APIUtils
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
@@ -161,10 +161,6 @@ let useProfileSwitch = (~setActiveProductValue) => {
     try {
       // Need to remove the Empty string check once userInfo contains the profileId
       if expectedProfileId !== currentProfileId && currentProfileId->LogicUtils.isNonEmptyString {
-        switch setActiveProductValue {
-        | Some(fn) => fn(ProductTypes.UnknownProduct)
-        | None => ()
-        }
         let url = getURL(~entityName=V1(USERS), ~userType=#SWITCH_PROFILE, ~methodType=Post)
         let body =
           [("profile_id", expectedProfileId->JSON.Encode.string)]->LogicUtils.getJsonFromArrayOfJson
@@ -191,7 +187,7 @@ let useInternalSwitch = (~setActiveProductValue: option<ProductTypes.productType
   let orgSwitch = useOrgSwitch(~setActiveProductValue)
   let merchSwitch = useMerchantSwitch(~setActiveProductValue)
   let {product_type} = Recoil.useRecoilValueFromAtom(merchantDetailsValueAtom)
-  let profileSwitch = useProfileSwitch(~setActiveProductValue)
+  let profileSwitch = useProfileSwitch()
   let {userInfo, setUserInfoData} = React.useContext(UserInfoProvider.defaultContext)
   let url = RescriptReactRouter.useUrl()
   async (


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When switching from the Recon Engine v1 to the Orchestrator product via the sidebar, the Recon Rules API is still triggered due to the active product state change. Since this API call is unauthorized (403) for the Orchestrator product, it forces the user to be logged out of the dashboard.

<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3507

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible
