### PR TITLE
fix: reconciliation engine naming and style changes

### DIFF
--- a/src/ReconEngine/ReconEngineApp/ReconEngineSidebarValues.res
+++ b/src/ReconEngine/ReconEngineApp/ReconEngineSidebarValues.res
@@ -89,7 +89,7 @@ let transformedEntries = {
 
 let reconAccounts = {
   Section({
-    name: "Accounts",
+    name: "Data",
     icon: "nd-connectors",
     showSection: true,
     links: [sources, transformation, transformedEntries],

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigDetails.res
@@ -75,7 +75,7 @@ let make = (
           labelMargin="!py-0"
         />
       </div>
-      <div className="mt-4 grid xl:grid-cols-2 grid-cols-1 items-start gap-y-8 gap-x-12">
+      <div className="mt-4 grid xl:grid-cols-2 grid-cols-1 items-start gap-y-8 gap-x-20">
         {transformationConfigItems
         ->Array.map(item => {
           <TransformationConfigItem key={(item.label :> string)} data={item} />

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationHelper.res
@@ -12,7 +12,9 @@ module TransformationConfigItem = {
       </span>
       {switch data.valueType {
       | #text =>
-        <span className={`${body.md.medium} text-nd_gray-600`}> {data.value->React.string} </span>
+        <span className={`${body.md.medium} text-nd_gray-600 whitespace-nowrap`}>
+          {data.value->React.string}
+        </span>
       | #date =>
         <span className={`${body.md.medium} text-nd_gray-600`}>
           <TableUtils.DateCell timestamp={data.value} textAlign={Left} />

--- a/src/entryPoints/ProductUtils.res
+++ b/src/entryPoints/ProductUtils.res
@@ -21,7 +21,7 @@ let getProductVariantFromString = (product, ~version: UserInfoTypes.version) => 
 let getProductDisplayName = product =>
   switch product {
   | Recon(V2) => "Recon"
-  | Recon(V1) => "Reconcilliation Engine"
+  | Recon(V1) => "Reconciliation"
   | Recovery => "Revenue Recovery"
   | Orchestration(V1) => "Orchestrator"
   | Vault => "Vault"
@@ -76,7 +76,7 @@ let getProductStringDisplayName = product =>
 
 let getProductVariantFromDisplayName = product => {
   switch product {
-  | "Reconcilliation Engine" => Recon(V1)
+  | "Reconciliation" => Recon(V1)
   | "Recon" => Recon(V2)
   | "Revenue Recovery" => Recovery
   | "Orchestrator" => Orchestration(V1)
@@ -91,7 +91,6 @@ let getProductVariantFromDisplayName = product => {
 let getProductUrl = (~productType: ProductTypes.productTypes, ~isLiveMode) => {
   switch productType {
   | Orchestration(V1) => `/dashboard/home`
-
   | Recon(V2) => `/dashboard/v2/recon/overview`
   | Recon(V1) => `/dashboard/v1/recon-engine/overview`
   | Recovery =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Renamed Reconcilliation Engine to Reconciliation
Sidebar should say Data instead of Accounts
Transformation config cards text no break

<img width="276" height="432" alt="image" src="https://github.com/user-attachments/assets/5c060309-2a8f-4964-8ffb-c6fd42277879" />

<img width="941" height="262" alt="image" src="https://github.com/user-attachments/assets/1f733108-bedb-4e11-aae8-564a1b6c148e" />


<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3589

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
