### PR TITLE
fix: recon engine data overview `transformed_entries` list with `transformation_history`

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverview.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverview.res
@@ -23,7 +23,7 @@ let make = (~breadCrumbNavigationPath, ~ingestionHistoryId) => {
 
   let (transformationStatus, setTransformationStatus) = React.useState(_ => #Loading)
   let (manualReviewStatus, setManualReviewStatus) = React.useState(_ => #Loading)
-  let (transformationConfigTabIndex, setTransformationConfigTabIndex) = React.useState(_ => None)
+  let (transformationHistoryId, setTransformationHistoryId) = React.useState(_ => None)
   let (stagingEntryId, setStagingEntryId) = React.useState(_ => None)
 
   let fetchIngestionHistoryData = async () => {
@@ -60,7 +60,7 @@ let make = (~breadCrumbNavigationPath, ~ingestionHistoryId) => {
   }, [])
 
   let getActiveTabIndex = () => {
-    let transformationConfigTabIndex =
+    let transformationHistoryId =
       url.search
       ->getDictFromUrlSearchParams
       ->getvalFromDict("transformationHistoryId")
@@ -68,7 +68,7 @@ let make = (~breadCrumbNavigationPath, ~ingestionHistoryId) => {
       url.search
       ->getDictFromUrlSearchParams
       ->getvalFromDict("stagingEntryId")
-    setTransformationConfigTabIndex(_ => transformationConfigTabIndex)
+    setTransformationHistoryId(_ => transformationHistoryId)
     setStagingEntryId(_ => stagingEntryId)
   }
 
@@ -80,12 +80,12 @@ let make = (~breadCrumbNavigationPath, ~ingestionHistoryId) => {
   let initialExpandedArray = React.useMemo(() => {
     if Option.isSome(stagingEntryId) {
       2
-    } else if Option.isSome(transformationConfigTabIndex) {
+    } else if Option.isSome(transformationHistoryId) {
       1
     } else {
       0
     }
-  }, transformationConfigTabIndex)
+  }, transformationHistoryId)
 
   <PageLoaderWrapper screenState>
     <div className="flex flex-col gap-6 w-full">
@@ -115,7 +115,7 @@ let make = (~breadCrumbNavigationPath, ~ingestionHistoryId) => {
             ~setSelectedTransformationHistoryId,
             ~manualReviewStatus,
             ~setManualReviewStatus,
-            ~transformationConfigTabIndex,
+            ~transformationHistoryId,
             ~stagingEntryId,
           )}
           accordianTopContainerCss="!border !border-nd_gray-150 !rounded-xl !overflow-scroll"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformation.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformation.res
@@ -5,7 +5,7 @@ let make = (
   ~ingestionHistoryId: string,
   ~setSelectedTransformationHistoryId: (string => string) => unit,
   ~onTransformationStatusChange: option<bool => unit>=?,
-  ~transformationConfigTabIndex: option<string>,
+  ~transformationHistoryId,
 ) => {
   open ReconEngineAccountsSourcesHelper
   open APIUtils
@@ -44,7 +44,7 @@ let make = (
 
         switch transformationHistoryList->getNonEmptyArray {
         | Some(arr) => {
-            let selectedIndex = transformationConfigTabIndex->Option.getOr("0")->getIntFromString(0)
+            let selectedIndex = transformationHistoryId->Option.getOr("0")->getIntFromString(0)
             let selectedItem =
               arr->getValueFromArray(
                 selectedIndex,
@@ -64,7 +64,7 @@ let make = (
   React.useEffect(() => {
     fetchTransformationHistory()->ignore
     None
-  }, (ingestionHistoryId, transformationConfigTabIndex))
+  }, (ingestionHistoryId, transformationHistoryId))
 
   let detailsFields: array<ReconEngineAccountsSourcesEntity.transformationHistoryColType> = [
     TransformationName,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformation.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformation.res
@@ -81,10 +81,12 @@ let make = (
       ->getvalFromDict("transformationHistoryId")
 
     switch urlTransformationHistoryId {
-    | Some(historyId) =>
-      transformationHistoryData->Array.findIndex(config =>
-        config.transformation_history_id === historyId
-      )
+    | Some(historyId) => {
+        setSelectedTransformationHistoryId(_ => historyId)
+        transformationHistoryData->Array.findIndex(config =>
+          config.transformation_history_id === historyId
+        )
+      }
     | None => 0
     }
   }, (url.search, transformationHistoryData))

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewHelper.res
@@ -95,8 +95,8 @@ let getAccordionConfig = (
   ~setSelectedTransformationHistoryId,
   ~manualReviewStatus,
   ~setManualReviewStatus,
-  ~transformationConfigTabIndex,
   ~stagingEntryId,
+  ~transformationHistoryId,
 ): array<Accordion.accordion> => {
   [
     {
@@ -113,7 +113,7 @@ let getAccordionConfig = (
           setSelectedTransformationHistoryId
           onTransformationStatusChange={isProcessed =>
             setTransformationStatus(_ => isProcessed ? #Processed : #AttentionRequired)}
-          transformationConfigTabIndex
+          transformationHistoryId
         />,
       renderContentOnTop: Some(() => <TransformationHeader transformationStatus />),
     },

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntries.res
@@ -145,7 +145,7 @@ let make = () => {
 
       RescriptReactRouter.push(
         GlobalVars.appendDashboardPath(
-          ~url=`/v1/recon-engine/transformed-entries/ingestion-history/${transformationHistoryData.ingestion_history_id}?stagingEntryId=${transformedEntry.staging_entry_id}`,
+          ~url=`/v1/recon-engine/transformed-entries/ingestion-history/${transformationHistoryData.ingestion_history_id}?transformationHistoryId=${transformedEntry.transformation_history_id}&stagingEntryId=${transformedEntry.staging_entry_id}`,
         ),
       )
     } catch {


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When we select particular transformed entry in the account which has multiple transformations, the data overview page, is selecting the default tab, but instead it should be picked from the transformationHistoryId query parameter from the url




<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3608

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
