### PR TITLE
chore: count the `staging_entries` based on the `transformation_history_id`

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewComponents/ReconEngineAccountsOverviewTransformedEntries.res
@@ -154,7 +154,9 @@ let make = (
     customUI={<NewAnalyticsHelper.NoData height="h-96" message="No data available." />}
     customLoader={<Shimmer styleClass="h-96 w-full rounded-b-xl" />}>
     <div className="flex flex-col gap-4 my-4 px-6 pb-16">
-      <ReconEngineAccountsTransformedEntriesOverviewCards />
+      <ReconEngineAccountsTransformedEntriesOverviewCards
+        selectedTransformationHistoryId=Some(selectedTransformationHistoryId)
+      />
       <div className="flex-shrink-0"> {topFilterUi} </div>
       <LoadedTable
         title="Staging Entries"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsOverview/ReconEngineAccountsOverviewHelper.res
@@ -63,7 +63,9 @@ module StagingEntryHeader = {
   let make = (~manualReviewStatus) => {
     <div className="flex flex-row items-center justify-between w-full px-6">
       <div className="flex flex-row items-center gap-2">
-        <p className={`${body.lg.semibold} text-nd_gray-800`}> {"Staging Entry"->React.string} </p>
+        <p className={`${body.lg.semibold} text-nd_gray-800`}>
+          {"Transformed Entries"->React.string}
+        </p>
       </div>
       {switch manualReviewStatus {
       | #Loading => <Shimmer styleClass="h-5 w-24 rounded-lg" />
@@ -118,7 +120,7 @@ let getAccordionConfig = (
       renderContentOnTop: Some(() => <TransformationHeader transformationStatus />),
     },
     {
-      title: "Staging Entry",
+      title: "Transformed Entries",
       renderContent: () => {
         <FilterContext
           key={`recon-engine-accounts-sources-staging-${selectedTransformationHistoryId}`}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsSources/ReconEngineAccountsSourcesComponents/ReconEngineAccountSourceConfigDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsSources/ReconEngineAccountsSourcesComponents/ReconEngineAccountSourceConfigDetails.res
@@ -48,8 +48,10 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~tabIndex: string) =>
       )}
       className="p-5 border border-nd_gray-200 rounded-lg hover:border-nd_primary_blue-400 transition-colors duration-200 cursor-pointer">
       <div
-        className="flex md:flex-row items-center justify-between w-full border-b pb-2 border-nd_gray-150">
-        <p className={`${body.md.semibold} text-nd_gray-800`}> {config.name->React.string} </p>
+        className="flex md:flex-row items-center justify-between gap-4 w-full border-b pb-2 border-nd_gray-150">
+        <p className={`${body.md.semibold} text-nd_gray-800 truncate`}>
+          {config.name->React.string}
+        </p>
         <Table.TableCell
           cell={Label({
             title: label,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntries.res
@@ -161,7 +161,7 @@ let make = () => {
         customHeadingStyle="py-0"
       />
     </div>
-    <ReconEngineAccountsTransformedEntriesOverviewCards />
+    <ReconEngineAccountsTransformedEntriesOverviewCards selectedTransformationHistoryId=None />
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-4">
         <div className="flex-shrink-0"> {topFilterUi} </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntriesComponents/ReconEngineAccountsTransformedEntriesOverviewCards.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformedEntries/ReconEngineAccountsTransformedEntriesComponents/ReconEngineAccountsTransformedEntriesOverviewCards.res
@@ -1,5 +1,5 @@
 @react.component
-let make = () => {
+let make = (~selectedTransformationHistoryId: option<string>) => {
   open APIUtils
   open LogicUtils
   open ReconEngineAccountsTransformedEntriesHelper
@@ -15,11 +15,15 @@ let make = () => {
   let fetchStagingData = async () => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-
+      let queryParams = switch selectedTransformationHistoryId {
+      | Some(id) => Some(`transformation_history_id=${id}`)
+      | None => None
+      }
       let stagingUrl = getURL(
         ~entityName=V1(HYPERSWITCH_RECON),
         ~methodType=Get,
         ~hyperswitchReconType=#PROCESSING_ENTRIES_LIST,
+        ~queryParamerters=queryParams,
       )
       let res = await fetchDetails(stagingUrl)
       let stagingList = res->LogicUtils.getArrayDataFromJson(getProcessingEntryPayloadFromDict)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

count the `staging_entries` based on the `transformation_history_id`

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
