### PR TITLE
feat: recon engine accounts transformation mappers

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigDetails.res
@@ -1,7 +1,7 @@
 open Typography
 
 @react.component
-let make = (~config: ReconEngineTypes.transformationConfigType, ~tabIndex: string) => {
+let make = (~config: ReconEngineTypes.transformationConfigType) => {
   open ReconEngineAccountsTransformationUtils
   open ReconEngineAccountsTransformationHelper
   open ReconEngineHooks
@@ -32,7 +32,7 @@ let make = (~config: ReconEngineTypes.transformationConfigType, ~tabIndex: strin
 
   let transformationConfigItems = React.useMemo(() => {
     ReconEngineAccountsTransformationUtils.getTransformationConfigData(~config)
-  }, config)
+  }, [config])
 
   let (_percentage, label, labelColor) = React.useMemo(() => {
     getHealthyStatus(~transformationHistoryList)
@@ -44,7 +44,7 @@ let make = (~config: ReconEngineTypes.transformationConfigType, ~tabIndex: strin
     customLoader={<Shimmer styleClass="h-44 w-full rounded-xl" />}>
     <Link
       to_={GlobalVars.appendDashboardPath(
-        ~url=`/v1/recon-engine/transformation/${config.account_id}?transformationConfigTabIndex=${tabIndex}`,
+        ~url=`/v1/recon-engine/transformation/${config.account_id}?transformationId=${config.id}`,
       )}
       className="p-5 border border-nd_gray-200 rounded-lg hover:border-nd_primary_blue-400 transition-colors duration-200 cursor-pointer">
       <div

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigs.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationComponents/ReconEngineAccountTransformationConfigs.res
@@ -42,10 +42,8 @@ let make = (~account: ReconEngineTypes.accountType) => {
     <div
       className="grid 2xl:grid-cols-3 xl:grid-cols-2 md:grid-cols-1 gap-6 items-center w-full p-6">
       {configData
-      ->Array.mapWithIndex((config, index) => {
-        <ReconEngineAccountTransformationConfigDetails
-          key=config.ingestion_id config={config} tabIndex={index->Int.toString}
-        />
+      ->Array.map(config => {
+        <ReconEngineAccountTransformationConfigDetails key=config.id config={config} />
       })
       ->React.array}
     </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
@@ -1,0 +1,111 @@
+open ReconEngineTypes
+open Typography
+open ReconEngineAccountsTransformationUtils
+open LogicUtils
+
+module ColumnMappingDisplay = {
+  @react.component
+  let make = (~columnMapping: Js.Dict.t<JSON.t>) => {
+    let mappingItems =
+      columnMapping
+      ->Dict.toArray
+      ->Array.map(((key, value)) => {
+        let displayKey = key->snakeToTitle
+        let displayValue = value->getStringFromJson("")
+        (key, displayKey, displayValue)
+      })
+
+    <div className="p-6 w-full">
+      <div className="flex flex-col gap-4">
+        {mappingItems
+        ->Array.map(((key, label, value)) => {
+          let sourceFieldInput = createFormInput(~name=`mapping_source_${key}`, ~value=label)
+          let targetFieldInput = createFormInput(~name=`mapping_target_${key}`, ~value)
+
+          let sourceFieldOptions = [createDropdownOption(~label, ~value=label)]
+          let targetFieldOptions = [
+            createDropdownOption(~label=value->isNonEmptyString ? value : "Not configured", ~value),
+          ]
+
+          <div key className="flex items-center gap-4 p-3 border rounded-lg border-nd_gray-150">
+            <div className="flex-1">
+              <SelectBox.BaseDropdown
+                allowMultiSelect=false
+                buttonText={label}
+                input=sourceFieldInput
+                options=sourceFieldOptions
+                hideMultiSelectButtons=true
+                deselectDisable=true
+                disableSelect=true
+                fullLength=true
+              />
+            </div>
+            <div className="flex items-center">
+              <Icon name="nd-arrow-right" size=14 className="text-nd_gray-500" />
+            </div>
+            <div className="flex-1">
+              <SelectBox.BaseDropdown
+                allowMultiSelect=false
+                buttonText={value->isNonEmptyString ? value : "Not configured"}
+                input=targetFieldInput
+                options=targetFieldOptions
+                hideMultiSelectButtons=true
+                deselectDisable=true
+                disableSelect=true
+                fullLength=true
+              />
+            </div>
+          </div>
+        })
+        ->React.array}
+      </div>
+    </div>
+  }
+}
+
+@react.component
+let make = (~showModal, ~setShowModal, ~selectedTransformation: transformationConfigType) => {
+  let modalHeading = {
+    <div className="flex justify-between border-b">
+      <div className="flex gap-4 items-center m-6">
+        <p className={`text-nd_gray-800 ${heading.sm.semibold}`}> {"Mappers"->React.string} </p>
+      </div>
+      <Icon
+        name="modal-close-icon"
+        className="cursor-pointer mr-4"
+        size=30
+        onClick={_ => setShowModal(_ => false)}
+      />
+    </div>
+  }
+
+  let columnMapping = React.useMemo(() => {
+    selectedTransformation.config->getDictFromJsonObject->getDictfromDict("column_mapping")
+  }, [selectedTransformation])
+
+  <Modal
+    setShowModal
+    showModal
+    closeOnOutsideClick=true
+    modalClass="flex flex-col justify-start h-screen w-1/3 float-right overflow-hidden !bg-white"
+    childClass="relative h-full"
+    customModalHeading=modalHeading>
+    <div className="h-full relative">
+      <div className="absolute inset-0 overflow-y-auto py-2">
+        {if columnMapping->isEmptyDict {
+          <NewAnalyticsHelper.NoData height="h-52" message="No data available." />
+        } else {
+          <ColumnMappingDisplay columnMapping />
+        }}
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 bg-white p-4">
+        <Button
+          customButtonStyle="!w-full"
+          buttonType=Button.Primary
+          onClick={_ => setShowModal(_ => false)}
+          text="OK"
+        />
+      </div>
+    </div>
+  </Modal>
+}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
@@ -65,20 +65,6 @@ module ColumnMappingDisplay = {
 
 @react.component
 let make = (~showModal, ~setShowModal, ~selectedTransformation: transformationConfigType) => {
-  let modalHeading = {
-    <div className="flex justify-between border-b">
-      <div className="flex gap-4 items-center m-6">
-        <p className={`text-nd_gray-800 ${heading.sm.semibold}`}> {"Mappers"->React.string} </p>
-      </div>
-      <Icon
-        name="modal-close-icon"
-        className="cursor-pointer mr-4"
-        size=30
-        onClick={_ => setShowModal(_ => false)}
-      />
-    </div>
-  }
-
   let columnMapping = React.useMemo(() => {
     selectedTransformation.config->getDictFromJsonObject->getDictfromDict("column_mapping")
   }, [selectedTransformation])
@@ -87,9 +73,10 @@ let make = (~showModal, ~setShowModal, ~selectedTransformation: transformationCo
     setShowModal
     showModal
     closeOnOutsideClick=true
+    modalHeading="Mappers"
+    modalHeadingClass={`text-nd_gray-800 ${heading.sm.semibold}`}
     modalClass="flex flex-col justify-start h-screen w-1/3 float-right overflow-hidden !bg-white"
-    childClass="relative h-full"
-    customModalHeading=modalHeading>
+    childClass="relative h-full">
     <div className="h-full relative">
       <div className="absolute inset-0 overflow-y-auto py-2">
         {if columnMapping->isEmptyDict {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
@@ -21,6 +21,26 @@ let getProcessedCount = (~transformationHistoryList: array<transformationHistory
   ->Array.length
 }
 
+let getTransformationIdFromUrl = urlSearch => {
+  urlSearch
+  ->getDictFromUrlSearchParams
+  ->getvalFromDict("transformationId")
+}
+
+let createFormInput = (~name, ~value): ReactFinalForm.fieldRenderPropsInput => {
+  name,
+  onBlur: _ => (),
+  onChange: _ => (),
+  onFocus: _ => (),
+  value: value->JSON.Encode.string,
+  checked: true,
+}
+
+let createDropdownOption = (~label, ~value) => {
+  SelectBox.label,
+  value,
+}
+
 let getHealthyStatus = (~transformationHistoryList: array<transformationHistoryType>): (
   string,
   string,


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [ ] Bugfix
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added a column mapping visualization modal for ReconEngine transformation details. This feature provides users with a clear visual representation of how their data fields are mapped to our fields during data transformation processes.

**Key Components:**
- `ColumnMappingDisplay` component that renders source → target field mappings
- Modal interface with proper styling and responsive design
- Integration with existing transformation configuration system
- Visual indicators for unmapped or unconfigured fields


## Motivation and Context

This feature addresses the need for users to understand and verify data transformation mappings in the ReconEngine. Previously, users had no visual way to see how their data fields were being mapped to our fields, making it difficult to:

- Verify transformation configurations are correct
- Debug mapping issues
- Understand data flow during transformations
- Ensure all required fields are properly mapped

## How did you test it?

- Manually tested with various transformation configurations
- Verified modal opens and closes correctly
- Tested with empty/missing column mapping configurations
- Confirmed proper display of source → target field relationships
- Validated responsive design and styling consistency

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
