### PR TITLE
chore: added fieldstoignore parameter in useUpdateMethod

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -1444,12 +1444,23 @@ let useUpdateMethod = (~showErrorToast=true) => {
     url,
     body,
     method,
+    ~fieldsToIgnore=?,
     ~bodyFormData=?,
     ~headers=Dict.make(),
     ~contentType=AuthHooks.Headers("application/json"),
     ~version=UserInfoTypes.V1,
   ) => {
     try {
+      let modifiedBodyDict = switch fieldsToIgnore {
+      | Some(array) => {
+          let bodyDict = body->getDictFromJsonObject
+          array->Array.forEach(item => Dict.delete(bodyDict, item))
+          bodyDict->JSON.Encode.object
+        }
+
+      | None => body
+      }
+      let body = modifiedBodyDict
       let res = await fetchApi(
         url,
         ~method_=method,

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
@@ -8,6 +8,7 @@ let useGetData = () => {
       string,
       JSON.t,
       Fetch.requestMethod,
+      ~fieldsToIgnore: array<string>=?,
       ~bodyFormData: Fetch.formData=?,
       ~headers: Dict.t<'a>=?,
       ~contentType: AuthHooks.contentType=?,

--- a/src/screens/Payouts/PayoutsUtils.res
+++ b/src/screens/Payouts/PayoutsUtils.res
@@ -4,6 +4,7 @@ let getPayoutsList = async (
     string,
     JSON.t,
     Fetch.requestMethod,
+    ~fieldsToIgnore: array<string>=?,
     ~bodyFormData: Fetch.formData=?,
     ~headers: Dict.t<'a>=?,
     ~contentType: AuthHooks.contentType=?,

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -133,7 +133,14 @@ let getAuthenticationCell = (orderDetais: order, colType: authenticationColType)
   }
 }
 
-let refundColumns: array<refundsColType> = [RefundId, PaymentId, Amount, RefundStatus, Created, LastUpdated]
+let refundColumns: array<refundsColType> = [
+  RefundId,
+  PaymentId,
+  Amount,
+  RefundStatus,
+  Created,
+  LastUpdated,
+]
 
 let attemptsColumns: array<attemptColType> = [
   Status,

--- a/src/screens/Transaction/Refunds/RefundUtils.res
+++ b/src/screens/Transaction/Refunds/RefundUtils.res
@@ -32,6 +32,7 @@ let getRefundsList = async (
     string,
     JSON.t,
     Fetch.requestMethod,
+    ~fieldsToIgnore: array<string>=?,
     ~bodyFormData: Fetch.formData=?,
     ~headers: Dict.t<'a>=?,
     ~contentType: AuthHooks.contentType=?,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Added a fieldsToIgnore parameter in useUpdateMethod hook in APIUtils . This can be used to remove a few fields from the payload right before making the api call.
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
