### PR TITLE
fix: update merchant detail perms to account permissions

### DIFF
--- a/src/Orchestration/OrchestrationApp.res
+++ b/src/Orchestration/OrchestrationApp.res
@@ -81,10 +81,10 @@ let make = (~setScreenState) => {
     | list{"users", ..._} => <UserManagementContainer />
     | list{"developer-api-keys"} =>
       <AccessControl
-        // TODO: Remove `MerchantDetailsManage` permission in future
+        // TODO: Remove `MerchantDetailsView` permission in future
         authorization={hasAnyGroupAccess(
           userHasAccess(~groupAccess=MerchantDetailsView),
-          userHasAccess(~groupAccess=AccountManage),
+          userHasAccess(~groupAccess=AccountView),
         )}
         isEnabled={!checkUserEntity([#Profile])}>
         <KeyManagement />
@@ -148,7 +148,11 @@ let make = (~setScreenState) => {
     | list{"chat-bot"} =>
       <AccessControl
         isEnabled={featureFlagDetails.devAiChatBot}
-        authorization={userHasAccess(~groupAccess=MerchantDetailsView)}>
+        // TODO: Remove `MerchantDetailsView` permission in future
+        authorization={hasAnyGroupAccess(
+          userHasAccess(~groupAccess=MerchantDetailsView),
+          userHasAccess(~groupAccess=AccountView),
+        )}>
         <ChatBot />
       </AccessControl>
     | _ => <EmptyPage path="/home" />

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -25,7 +25,7 @@ let make = () => {
   let (userGroupACL, setuserGroupACL) = Recoil.useRecoilState(userGroupACLAtom)
   let {getThemesJson} = React.useContext(ThemeProvider.themeContext)
   let {fetchMerchantSpecificConfig} = MerchantSpecificConfigHook.useMerchantSpecificConfig()
-  let {fetchUserGroupACL, userHasAccess} = GroupACLHooks.useUserGroupACLHook()
+  let {fetchUserGroupACL, userHasAccess, hasAnyGroupAccess} = GroupACLHooks.useUserGroupACLHook()
   let {setShowSideBar} = React.useContext(GlobalProvider.defaultContext)
   let fetchMerchantAccountDetails = MerchantDetailsHook.useFetchMerchantDetails()
   let {userInfo: {orgId, merchantId, profileId, roleId, version}} = React.useContext(
@@ -140,7 +140,11 @@ let make = () => {
                           </RenderIf>
                           <RenderIf
                             condition={featureFlagDetails.devAiChatBot &&
-                            userHasAccess(~groupAccess=MerchantDetailsView) == Access &&
+                            // TODO: Remove `MerchantDetailsView` permission in future
+                            hasAnyGroupAccess(
+                              userHasAccess(~groupAccess=MerchantDetailsView),
+                              userHasAccess(~groupAccess=AccountView),
+                            ) == Access &&
                             merchantDetailsTypedValue.product_type == Orchestration(V1)}>
                             <div
                               onClick={_ => onAskPulseClick()}

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -471,7 +471,7 @@ module MerchantDropdownItem = {
       }
     }
 
-    let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
+    let {userHasAccess, hasAnyGroupAccess} = GroupACLHooks.useUserGroupACLHook()
     <>
       <div className={`rounded-lg`}>
         <InlineEditInput
@@ -480,7 +480,12 @@ module MerchantDropdownItem = {
           customStyle={`w-full cursor-pointer mb-0 ${backgroundColor.sidebarSecondary} ${hoverColor} `}
           handleEdit=handleIdUnderEdit
           isUnderEdit
-          showEditIcon={isActive && userHasAccess(~groupAccess=MerchantDetailsManage) === Access}
+          // TODO: Remove `MerchantDetailsManage` permission in future
+          showEditIcon={isActive &&
+          hasAnyGroupAccess(
+            userHasAccess(~groupAccess=MerchantDetailsManage),
+            userHasAccess(~groupAccess=AccountManage),
+          ) === Access}
           showEditIconOnHover={!isMobileView}
           onSubmit
           labelTextCustomStyle={` truncate max-w-28 ${isActive
@@ -594,7 +599,7 @@ module ProfileDropdownItem = {
     }
 
     let leftIconCss = {isActive && !isUnderEdit ? "" : isUnderEdit ? "hidden" : "invisible"}
-    let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
+    let {userHasAccess, hasAnyGroupAccess} = GroupACLHooks.useUserGroupACLHook()
 
     <>
       <div
@@ -608,7 +613,11 @@ module ProfileDropdownItem = {
           handleEdit=handleIdUnderEdit
           isUnderEdit
           showEditIcon={isActive &&
-          userHasAccess(~groupAccess=MerchantDetailsManage) === Access &&
+          // TODO: Remove `MerchantDetailsManage` permission in future
+          hasAnyGroupAccess(
+            userHasAccess(~groupAccess=MerchantDetailsManage),
+            userHasAccess(~groupAccess=AccountManage),
+          ) === Access &&
           version == V1}
           showEditIconOnHover={!isMobileView}
           onSubmit

--- a/src/screens/Developer/APIKeys/KeyManagement.res
+++ b/src/screens/Developer/APIKeys/KeyManagement.res
@@ -15,6 +15,7 @@ let make = () => {
   let bannerText = {
     DeveloperUtils.bannerText(
       ~isPlatformMerchant=isCurrentMerchantPlatform,
+      // TODO: Remove `MerchantDetailsManage` permission in future
       ~hasCreateApiKeyAccess=hasAnyGroupAccess(
         userHasAccess(~groupAccess=MerchantDetailsManage),
         userHasAccess(~groupAccess=AccountManage),

--- a/src/screens/Developer/APIKeys/KeyManagementHelper.res
+++ b/src/screens/Developer/APIKeys/KeyManagementHelper.res
@@ -233,6 +233,7 @@ module TableActionsCell = {
     let showPopUp = PopUpState.useShowPopUp()
     let {userInfo: {version}} = React.useContext(UserInfoProvider.defaultContext)
     let {userHasAccess, hasAnyGroupAccess} = GroupACLHooks.useUserGroupACLHook()
+    // TODO: Remove `MerchantDetailsManage` permission in future
     let showButtons = hasAnyGroupAccess(
       userHasAccess(~groupAccess=MerchantDetailsManage),
       userHasAccess(~groupAccess=AccountManage),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added equivalent `account_view` and `account_manage` permissions wherever `merchant_details_view` and `merchant_details_manage` were used.
Added inline comments to remove deprecated permissions once backend migrations are rolled out across all environments, consistent with earlier cleanup patterns.

## Motivation and Context

bugfix

## How did you test it?

Locally

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
