### PR TITLE
fix: recon engine overview transactions filtering

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
@@ -537,7 +537,11 @@ let getEntriesSections = (
         </p>
         <RenderIf condition={showTotalAmount}>
           <div className={`${amountColorClass} ${body.lg.medium}`}>
-            {`${currency} ${totalAmount->Float.toString}`->React.string}
+            {CurrencyFormatUtils.valueFormatter(
+              totalAmount,
+              AmountWithSuffix,
+              ~currency,
+            )->React.string}
           </div>
         </RenderIf>
       </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewAccountDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewAccountDetails.res
@@ -18,7 +18,9 @@ let make = (~ruleDetails: ReconEngineTypes.reconRuleType) => {
       let accounts = await getAccounts()
       setAccountData(_ => accounts)
       let transactionsData = await getTransactions(
-        ~queryParamerters=Some(`rule_id=${ruleDetails.rule_id}`),
+        ~queryParamerters=Some(
+          `rule_id=${ruleDetails.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+        ),
       )
       setAllTransactionsData(_ => transactionsData)
       setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewCardDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewCardDetails.res
@@ -17,7 +17,9 @@ let make = (~ruleDetails: ReconEngineTypes.reconRuleType) => {
       let accountData = await getAccounts()
       setAccountData(_ => accountData)
       let transactionsData = await getTransactions(
-        ~queryParamerters=Some(`rule_id=${ruleDetails.rule_id}`),
+        ~queryParamerters=Some(
+          `rule_id=${ruleDetails.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+        ),
       )
       setAllTransactionsData(_ => transactionsData)
       setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewStackedBarGraph.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewStackedBarGraph.res
@@ -12,7 +12,9 @@ let make = (~ruleDetails: ReconEngineTypes.reconRuleType) => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
       let transactionsData = await getTransactions(
-        ~queryParamerters=Some(`rule_id=${ruleDetails.rule_id}`),
+        ~queryParamerters=Some(
+          `rule_id=${ruleDetails.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+        ),
       )
       setAllTransactionsData(_ => transactionsData)
       setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryAccountsView.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryAccountsView.res
@@ -155,7 +155,12 @@ let make = (~reconRulesList: array<reconRuleType>) => {
       let accountData = await getAccounts()
 
       let queryString = ReconEngineFilterUtils.buildQueryStringFromFilters(~filterValueJson)
-      let allTransactions = await getTransactions(~queryParamerters=Some(queryString))
+      let allTransactions = await getTransactions(
+        ~queryParamerters=Some(
+          `${queryString}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+        ),
+      )
+
       let accountTransactionData = processAllTransactionsWithAmounts(
         reconRulesList,
         allTransactions,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
@@ -153,7 +153,11 @@ let make = (~reconRulesList: array<ReconEngineTypes.reconRuleType>) => {
       let accountData = await getAccounts()
 
       let queryString = ReconEngineFilterUtils.buildQueryStringFromFilters(~filterValueJson)
-      let allTransactions = await getTransactions(~queryParamerters=Some(queryString))
+      let allTransactions = await getTransactions(
+        ~queryParamerters=Some(
+          `${queryString}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+        ),
+      )
       let accountTransactionData = processAllTransactionsWithAmounts(
         reconRulesList,
         allTransactions,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
@@ -15,7 +15,9 @@ module RuleWiseStackedBarGraph = {
       try {
         setScreenState(_ => PageLoaderWrapper.Loading)
         let transactionsData = await getTransactions(
-          ~queryParamerters=Some(`rule_id=${rule.rule_id}`),
+          ~queryParamerters=Some(
+            `rule_id=${rule.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`,
+          ),
         )
         setAllTransactionsData(_ => transactionsData)
         setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryUtils.res
@@ -2,6 +2,12 @@ open ReconEngineOverviewUtils
 open LogicUtils
 open CurrencyFormatUtils
 
+let roundCurrency = (value: float, currency: string): float => {
+  let precision = CurrencyUtils.getAmountPrecisionDigits(currency)
+  let factor = Math.pow(10.0, ~exp=precision->Int.toFloat)
+  Math.round(value *. factor) /. factor
+}
+
 let getSummaryStackedBarGraphData = (
   ~postedCount: int,
   ~mismatchedCount: int,
@@ -341,7 +347,10 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             posted_confirmation_count: accountData.posted_confirmation_count + 1,
             posted_confirmation_amount: {
-              value: accountData.posted_confirmation_amount.value +. transaction.debit_amount.value,
+              value: roundCurrency(
+                accountData.posted_confirmation_amount.value +. transaction.debit_amount.value,
+                transaction.debit_amount.currency,
+              ),
               currency: transaction.debit_amount.currency,
             },
           }
@@ -349,8 +358,10 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             pending_confirmation_count: accountData.pending_confirmation_count + 1,
             pending_confirmation_amount: {
-              value: accountData.pending_confirmation_amount.value +.
-              transaction.debit_amount.value,
+              value: roundCurrency(
+                accountData.pending_confirmation_amount.value +. transaction.debit_amount.value,
+                transaction.debit_amount.currency,
+              ),
               currency: transaction.debit_amount.currency,
             },
           }
@@ -358,8 +369,21 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             mismatched_confirmation_count: accountData.mismatched_confirmation_count + 1,
             mismatched_confirmation_amount: {
-              value: accountData.mismatched_confirmation_amount.value +.
-              transaction.debit_amount.value,
+              value: roundCurrency(
+                accountData.mismatched_confirmation_amount.value +. transaction.debit_amount.value,
+                transaction.debit_amount.currency,
+              ),
+              currency: transaction.debit_amount.currency,
+            },
+          }
+        | PartiallyReconciled => {
+            ...accountData,
+            pending_confirmation_count: accountData.pending_confirmation_count + 1,
+            pending_confirmation_amount: {
+              value: roundCurrency(
+                accountData.pending_confirmation_amount.value +. transaction.debit_amount.value,
+                transaction.debit_amount.currency,
+              ),
               currency: transaction.debit_amount.currency,
             },
           }
@@ -379,7 +403,10 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             posted_transaction_count: accountData.posted_transaction_count + 1,
             posted_transaction_amount: {
-              value: accountData.posted_transaction_amount.value +. transaction.credit_amount.value,
+              value: roundCurrency(
+                accountData.posted_transaction_amount.value +. transaction.credit_amount.value,
+                transaction.credit_amount.currency,
+              ),
               currency: transaction.credit_amount.currency,
             },
           }
@@ -387,8 +414,10 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             pending_transaction_count: accountData.pending_transaction_count + 1,
             pending_transaction_amount: {
-              value: accountData.pending_transaction_amount.value +.
-              transaction.credit_amount.value,
+              value: roundCurrency(
+                accountData.pending_transaction_amount.value +. transaction.credit_amount.value,
+                transaction.credit_amount.currency,
+              ),
               currency: transaction.credit_amount.currency,
             },
           }
@@ -396,8 +425,21 @@ let processAllTransactionsWithAmounts = (
             ...accountData,
             mismatched_transaction_count: accountData.mismatched_transaction_count + 1,
             mismatched_transaction_amount: {
-              value: accountData.mismatched_transaction_amount.value +.
-              transaction.credit_amount.value,
+              value: roundCurrency(
+                accountData.mismatched_transaction_amount.value +. transaction.credit_amount.value,
+                transaction.credit_amount.currency,
+              ),
+              currency: transaction.credit_amount.currency,
+            },
+          }
+        | PartiallyReconciled => {
+            ...accountData,
+            pending_transaction_count: accountData.pending_transaction_count + 1,
+            pending_transaction_amount: {
+              value: roundCurrency(
+                accountData.pending_transaction_amount.value +. transaction.credit_amount.value,
+                transaction.credit_amount.currency,
+              ),
               currency: transaction.credit_amount.currency,
             },
           }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewUtils.res
@@ -79,6 +79,14 @@ let calculateAccountAmounts = (
         sExpected +. creditAmount,
         tExpected +. debitAmount,
       )
+    | PartiallyReconciled => (
+        sPosted,
+        tPosted,
+        sMismatched,
+        tMismatched,
+        sExpected +. creditAmount,
+        tExpected +. debitAmount,
+      )
     | _ => (sPosted, tPosted, sMismatched, tMismatched, sExpected, tExpected)
     }
   })
@@ -113,6 +121,7 @@ let calculateTransactionCounts = (transactionsData: array<ReconEngineTypes.trans
     | Posted => (posted + 1, mismatched, expected)
     | Mismatched => (posted, mismatched + 1, expected)
     | Expected => (posted, mismatched, expected + 1)
+    | PartiallyReconciled => (posted, mismatched, expected + 1)
     | _ => (posted, mismatched, expected)
     }
   })


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Recon Engine Filter Transactions

Dont show void,archived, only filter expected,posted,partially_reconciled,mismatched transactions for stats and amount calculations

<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3808

Before: No sync between chart and the rules stacked bar graphs


After: Filter out the transactions and calculate the metrics



<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
