### PR TITLE
feat: recon engine add `order_id` in entries for exception resolution

### DIFF
--- a/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
+++ b/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
@@ -1,7 +1,8 @@
+open ReconEngineUtils
+
 let useGetIngestionHistory = () => {
   open APIUtils
   open LogicUtils
-  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -15,7 +16,9 @@ let useGetIngestionHistory = () => {
         ~queryParamerters,
       )
       let res = await fetchDetails(url)
-      res->getArrayDataFromJson(ingestionHistoryItemToObjMapper)
+      let ingestionHistory = res->getArrayDataFromJson(ingestionHistoryItemToObjMapper)
+      ingestionHistory->Array.sort((a, b) => compareLogic(b.created_at, a.created_at))
+      ingestionHistory
     } catch {
     | _ => Exn.raiseError("Something went wrong")
     }
@@ -25,7 +28,6 @@ let useGetIngestionHistory = () => {
 let useGetTransactions = () => {
   open APIUtils
   open LogicUtils
-  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -39,7 +41,9 @@ let useGetTransactions = () => {
         ~queryParamerters,
       )
       let res = await fetchDetails(url)
-      res->getArrayDataFromJson(transactionItemToObjMapper)
+      let transactions = res->getArrayDataFromJson(transactionItemToObjMapper)
+      transactions->Array.sort((a, b) => compareLogic(b.effective_at, a.effective_at))
+      transactions
     } catch {
     | _ => Exn.raiseError("Something went wrong")
     }
@@ -49,7 +53,6 @@ let useGetTransactions = () => {
 let useGetAccounts = () => {
   open APIUtils
   open LogicUtils
-  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -63,7 +66,9 @@ let useGetAccounts = () => {
         ~queryParamerters,
       )
       let res = await fetchDetails(url)
-      res->getArrayDataFromJson(accountItemToObjMapper)
+      let accounts = res->getArrayDataFromJson(accountItemToObjMapper)
+      accounts->Array.sort((a, b) => compareLogic(b.created_at, a.created_at))
+      accounts
     } catch {
     | _ => Exn.raiseError("Something went wrong")
     }
@@ -73,7 +78,6 @@ let useGetAccounts = () => {
 let useGetProcessingEntries = () => {
   open APIUtils
   open LogicUtils
-  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -87,7 +91,9 @@ let useGetProcessingEntries = () => {
         ~queryParamerters,
       )
       let res = await fetchDetails(url)
-      res->getArrayDataFromJson(processingItemToObjMapper)
+      let processedEntries = res->getArrayDataFromJson(processingItemToObjMapper)
+      processedEntries->Array.sort((a, b) => compareLogic(b.effective_at, a.effective_at))
+      processedEntries
     } catch {
     | _ => Exn.raiseError("Something went wrong")
     }
@@ -97,7 +103,6 @@ let useGetProcessingEntries = () => {
 let useGetTransformationHistory = () => {
   open APIUtils
   open LogicUtils
-  open ReconEngineUtils
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
@@ -111,7 +116,9 @@ let useGetTransformationHistory = () => {
         ~queryParamerters,
       )
       let res = await fetchDetails(url)
-      res->getArrayDataFromJson(transformationHistoryItemToObjMapper)
+      let transformationHistory = res->getArrayDataFromJson(transformationHistoryItemToObjMapper)
+      transformationHistory->Array.sort((a, b) => compareLogic(b.created_at, a.created_at))
+      transformationHistory
     } catch {
     | _ => Exn.raiseError("Something went wrong")
     }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsSources/ReconEngineAccountsSourcesDetails/ReconEngineAccountSourceDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsSources/ReconEngineAccountsSourcesDetails/ReconEngineAccountSourceDetails.res
@@ -37,6 +37,7 @@ let make = (~accountId) => {
       let accountRes = await fetchDetails(accountUrl)
       let ingestionConfigs =
         ingestionConfigsRes->getArrayDataFromJson(getIngestionConfigPayloadFromDict)
+      ingestionConfigs->Array.sort((a, b) => compareLogic(b.created_at, a.created_at))
       let accountData = accountRes->getDictFromJsonObject->getAccountPayloadFromDict
       setAccountData(_ => accountData)
       setIngestionConfigs(_ => ingestionConfigs)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetails.res
@@ -38,6 +38,7 @@ let make = (~accountId) => {
       let accountRes = await fetchDetails(accountUrl)
       let transformationConfigs =
         transformationConfigsRes->getArrayDataFromJson(getTransformationConfigPayloadFromDict)
+      transformationConfigs->Array.sort((a, b) => compareLogic(b.created_at, a.created_at))
       let accountData = accountRes->getDictFromJsonObject->getAccountPayloadFromDict
 
       switch url.search->getTransformationIdFromUrl {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineCustomExpandableSelectionTable.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineCustomExpandableSelectionTable.res
@@ -118,6 +118,7 @@ module TableBody = {
     ~showOptions: bool,
     ~selectedRows: array<JSON.t>,
     ~onRowSelect: option<(array<JSON.t> => array<JSON.t>) => unit>=?,
+    ~isRowSelectable: option<JSON.t => bool>=?,
   ) => {
     <tbody>
       {rowInfo
@@ -144,6 +145,7 @@ module TableBody = {
           selectedRows
           ?onRowSelect
           rowData={rowData->Array.get(rowIndex)->Option.getOr(JSON.Encode.null)}
+          ?isRowSelectable
         />
       })
       ->React.array}
@@ -168,6 +170,7 @@ let make = (
   ~totalResults: int,
   ~showSearchFilter=false,
   ~searchFilterElement: option<React.element>=?,
+  ~isRowSelectable: option<JSON.t => bool>=?,
 ) => {
   let heading = if showOptions {
     [makeHeaderInfo(~key="options", ~title="")]->Array.concat(headingProp)
@@ -265,6 +268,7 @@ let make = (
       showOptions
       selectedRows
       ?onRowSelect
+      ?isRowSelectable
     />
   }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
@@ -1,3 +1,5 @@
+open Typography
+
 @react.component
 let make = (~ruleId: string) => {
   open LogicUtils
@@ -38,7 +40,8 @@ let make = (~ruleId: string) => {
         switch Nullable.toOption(obj) {
         | Some(obj) =>
           isContainingStringLowercase(obj.transaction_id, searchText) ||
-          isContainingStringLowercase((obj.transaction_status :> string), searchText)
+          isContainingStringLowercase((obj.transaction_status :> string), searchText) ||
+          obj.entries->Array.some(entry => isContainingStringLowercase(entry.order_id, searchText))
         | None => false
         }
       })
@@ -119,38 +122,50 @@ let make = (~ruleId: string) => {
   <div className="flex flex-col gap-4">
     <PageLoaderWrapper screenState>
       <div className="flex-shrink-0"> {topFilterUi} </div>
-      <LoadedTableWithCustomColumns
-        title="Exception Entries - Expected & Mismatched"
-        actualData={filteredExceptionData}
-        entity={hierarchicalTransactionsLoadedTableEntity(
-          `v1/recon-engine/exceptions`,
-          ~authorization=userHasAccess(~groupAccess=UsersManage),
-        )}
-        resultsPerPage=6
-        filters={<TableSearchFilter
-          data={exceptionData->Array.map(Nullable.make)}
-          filterLogic
-          placeholder="Search Transaction ID or Status"
-          customSearchBarWrapperWidth="w-full lg:w-1/3"
-          customInputBoxWidth="w-full rounded-xl"
-          searchVal=searchText
-          setSearchVal=setSearchText
-        />}
-        totalResults={filteredExceptionData->Array.length}
-        offset
-        setOffset
-        currrentFetchCount={exceptionData->Array.length}
-        customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
-        defaultColumns={defaultColumns}
-        showSerialNumberInCustomizeColumns=false
-        sortingBasedOnDisabled=false
-        hideTitle=true
-        remoteSortEnabled=true
-        customizeColumnButtonIcon="nd-filter-horizontal"
-        hideRightTitleElement=true
-        showAutoScroll=true
-        customSeparation=[(2, 3)]
-      />
+      <RenderIf condition={exceptionData->Array.length == 0}>
+        <div className="h-40-vh flex flex-col justify-center items-center gap-2">
+          <p className={`${heading.sm.semibold} text-gray-800`}>
+            {"No exceptions to show."->React.string}
+          </p>
+          <p className={`${body.md.medium} text-gray-500`}>
+            {"All transactions are matched and reconciled successfully across this system."->React.string}
+          </p>
+        </div>
+      </RenderIf>
+      <RenderIf condition={exceptionData->Array.length > 0}>
+        <LoadedTableWithCustomColumns
+          title="Exception Entries - Expected & Mismatched"
+          actualData={filteredExceptionData}
+          entity={hierarchicalTransactionsLoadedTableEntity(
+            `v1/recon-engine/exceptions`,
+            ~authorization=userHasAccess(~groupAccess=UsersManage),
+          )}
+          resultsPerPage=6
+          filters={<TableSearchFilter
+            data={exceptionData->Array.map(Nullable.make)}
+            filterLogic
+            placeholder="Search Transaction ID or Order ID or Status"
+            customSearchBarWrapperWidth="w-full lg:w-1/3"
+            customInputBoxWidth="w-full rounded-xl"
+            searchVal=searchText
+            setSearchVal=setSearchText
+          />}
+          totalResults={filteredExceptionData->Array.length}
+          offset
+          setOffset
+          currrentFetchCount={exceptionData->Array.length}
+          customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
+          defaultColumns={defaultColumns}
+          showSerialNumberInCustomizeColumns=false
+          sortingBasedOnDisabled=false
+          hideTitle=true
+          remoteSortEnabled=true
+          customizeColumnButtonIcon="nd-filter-horizontal"
+          hideRightTitleElement=true
+          showAutoScroll=true
+          customSeparation=[(2, 3)]
+        />
+      </RenderIf>
     </PageLoaderWrapper>
   </div>
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
@@ -22,7 +22,16 @@ let make = (
   let (updatedEntriesList, setUpdatedEntriesList) = React.useState(_ =>
     entriesList->addUniqueIdsToEntries
   )
-  let detailsFields = [EntryType, Amount, Currency, Status, EntryId, EffectiveAt, CreatedAt]
+  let detailsFields = [
+    EntryType,
+    Amount,
+    Currency,
+    Status,
+    EntryId,
+    OrderID,
+    EffectiveAt,
+    CreatedAt,
+  ]
   let (showConfirmationModal, setShowConfirmationModal) = React.useState(_ => false)
   let (offset, setOffset) = React.useState(_ => 0)
   let (resultsPerPage, setResultsPerPage) = React.useState(_ => 10)
@@ -101,6 +110,20 @@ let make = (
     setShowConfirmationModal(_ => false)
   }
 
+  let isRowSelectable = switch exceptionStage {
+  | ResolvingException(MarkAsReceived) =>
+    Some(
+      (rowData: JSON.t) => {
+        let entry =
+          rowData
+          ->getDictFromJsonObject
+          ->exceptionTransactionEntryItemToItemMapper
+        entry.status == Expected
+      },
+    )
+  | _ => None
+  }
+
   <div className="flex flex-col gap-4 mt-6 mb-16">
     <ReconEngineExceptionTransactionResolution
       accountInfoMap
@@ -130,6 +153,7 @@ let make = (
       resultsPerPage
       setResultsPerPage
       totalResults={updatedEntriesList->Array.length}
+      ?isRowSelectable
     />
     <RenderIf
       condition={exceptionStage == ConfirmResolution(EditEntry) ||
@@ -170,7 +194,7 @@ let make = (
       <div className="flex flex-col gap-4">
         <Form
           onSubmit validate={validateReasonField} initialValues={Dict.make()->JSON.Encode.object}>
-          {reasonMultiLineTextInputField(~label="Resolution Remark")}
+          {reasonMultiLineTextInputField(~label="Add Remark")}
           <div className="flex flex-col">
             {<RenderIf condition={summaryItems->Array.length > 0}>
               {<React.Fragment>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
@@ -9,7 +9,7 @@ module IgnoreTransactionModalContent = {
 
     <div className="flex flex-col gap-4">
       <Form onSubmit validate={validateReasonField} initialValues={Dict.make()->JSON.Encode.object}>
-        {reasonMultiLineTextInputField(~label="Reason to ignore")}
+        {reasonMultiLineTextInputField(~label="Add Remark")}
         <div className="flex justify-end gap-3 mt-4 items-center">
           <Button
             buttonType=Secondary
@@ -38,7 +38,7 @@ module ForceReconcileModalContent = {
 
     <div className="flex flex-col gap-4">
       <Form onSubmit validate={validateReasonField} initialValues={Dict.make()->JSON.Encode.object}>
-        {reasonMultiLineTextInputField(~label="Resolution Remark")}
+        {reasonMultiLineTextInputField(~label="Add Remark")}
         <div className="flex justify-end gap-3 mt-4 items-center">
           <Button
             buttonType=Secondary
@@ -99,6 +99,7 @@ module EditEntryModalContent = {
           ~disabled=false,
         )}
         {amountTextInputField(~disabled=false)}
+        {orderIdTextInputField(~disabled=false)}
         {effectiveAtDatePickerInputField()}
         {metadataCustomInputField(~disabled=false)}
         <div className="absolute bottom-4 left-0 right-0 bg-white p-4">
@@ -147,6 +148,7 @@ module MarkAsReceivedModalContent = {
           ~disabled=true,
         )}
         {amountTextInputField(~disabled=false)}
+        {orderIdTextInputField(~disabled=false)}
         {effectiveAtDatePickerInputField()}
         {metadataCustomInputField(~disabled=false)}
         <div className="absolute bottom-4 left-0 right-0 bg-white p-4">
@@ -183,6 +185,7 @@ module CreateEntryModalContent = {
           ~entryDetails=entryDetails->getEntryTypeFromExceptionEntryType,
         )}
         {amountTextInputField()}
+        {orderIdTextInputField()}
         {effectiveAtDatePickerInputField()}
         {metadataCustomInputField()}
         <div className="absolute bottom-4 left-0 right-0 bg-white p-4">
@@ -421,6 +424,7 @@ module LinkStagingEntryModalContent = {
           />
         </div>
       </div>
+      <FormValuesSpy />
     </Form>
   }
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
@@ -424,7 +424,6 @@ module LinkStagingEntryModalContent = {
           />
         </div>
       </div>
-      <FormValuesSpy />
     </Form>
   }
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
@@ -364,7 +364,7 @@ let reasonMultiLineTextInputField = (~label) => {
     field={FormRenderer.makeFieldInfo(
       ~label,
       ~name="reason",
-      ~placeholder="Enter reason",
+      ~placeholder="Enter remark",
       ~customInput=InputFields.multiLineTextInput(
         ~isDisabled=false,
         ~rows=Some(4),
@@ -468,6 +468,20 @@ let amountTextInputField = (~disabled: bool=false) => {
       ~label="Amount",
       ~name="amount",
       ~placeholder="Enter amount",
+      ~customInput=InputFields.textInput(~inputStyle="!rounded-xl", ~isDisabled=disabled),
+      ~isRequired=true,
+      ~disabled,
+    )}
+  />
+}
+
+let orderIdTextInputField = (~disabled: bool=false) => {
+  <FormRenderer.FieldRenderer
+    labelClass="font-semibold"
+    field={FormRenderer.makeFieldInfo(
+      ~label="Order ID",
+      ~name="order_id",
+      ~placeholder="Enter Order ID",
       ~customInput=InputFields.textInput(~inputStyle="!rounded-xl", ~isDisabled=disabled),
       ~isRequired=true,
       ~disabled,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -150,7 +150,7 @@ let validateReasonField = (values: JSON.t) => {
   let errors = Dict.make()
 
   let errorMessage = if data->getString("reason", "")->isEmptyString {
-    "Reason cannot be empty!"
+    "Remark cannot be empty!"
   } else {
     ""
   }
@@ -173,6 +173,7 @@ let exceptionTransactionEntryItemToItemMapper = (
     account_name: dict->getString("account_name", ""),
     amount: dict->getFloat("amount", 0.0),
     currency: dict->getString("currency", ""),
+    order_id: dict->getString("order_id", ""),
     status: dict->getString("status", "")->getEntryStatusVariantFromString,
     discarded_status: dict->getOptionString("discarded_status"),
     version: dict->getInt("version", 0),
@@ -209,6 +210,7 @@ let exceptionTransactionProcessingEntryItemToObjMapper = dict => {
     ->getProcessingEntryStatusVariantFromString,
     transformation_id: dict->getString("transformation_id", ""),
     transformation_history_id: dict->getString("transformation_history_id", ""),
+    order_id: dict->getString("order_id", ""),
   }
 }
 
@@ -227,8 +229,13 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
     let initialMetadataJson = initialMetadata->JSON.Encode.object
     currentMetadataJson->JSON.stringify != initialMetadataJson->JSON.stringify
   }
+  let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
 
-  isEntryTypeChanged || isAmountChanged || isEffectiveAtChanged || isMetadataChanged
+  isEntryTypeChanged ||
+  isAmountChanged ||
+  isEffectiveAtChanged ||
+  isMetadataChanged ||
+  isOrderIdChanged
 }
 
 let validateFields = (
@@ -261,6 +268,7 @@ let validateCreateEntryDetails = (values: JSON.t): JSON.t => {
     ("account", requiredString("account", "Cannot be empty!")),
     ("entry_type", requiredString("entry_type", "Cannot be empty!")),
     ("currency", requiredString("currency", "Cannot be empty!")),
+    ("order_id", requiredString("order_id", "Cannot be empty!")),
     ("effective_at", requiredString("effective_at", "Cannot be empty!")),
     ("amount", positiveFloat("amount", "Should be greater than 0!")),
   ]
@@ -276,6 +284,7 @@ let validateEditEntryDetails = (values: JSON.t, ~initialEntryDetails: entryType)
     ("entry_type", requiredString("entry_type", "Cannot be empty!")),
     ("currency", requiredString("currency", "Cannot be empty!")),
     ("effective_at", requiredString("effective_at", "Cannot be empty!")),
+    ("order_id", requiredString("order_id", "Cannot be empty!")),
     ("amount", positiveFloat("amount", "Should be greater than 0!")),
   ]
 
@@ -294,6 +303,7 @@ let getInitialValuesForEditEntries = (entryDetails: entryType) => {
     ("entry_type", (entryDetails.entry_type :> string)->JSON.Encode.string),
     ("currency", entryDetails.currency->JSON.Encode.string),
     ("amount", entryDetails.amount->JSON.Encode.float),
+    ("order_id", entryDetails.order_id->JSON.Encode.string),
     ("effective_at", entryDetails.effective_at->JSON.Encode.string),
     ("metadata", entryDetails.metadata->getFilteredMetadataFromEntries->JSON.Encode.object),
     (
@@ -316,6 +326,7 @@ let getConvertedEntriesFromStagingEntry = (stagingEntry: processingEntryType) =>
     ("entry_type", stagingEntry.entry_type->JSON.Encode.string),
     ("currency", stagingEntry.currency->JSON.Encode.string),
     ("amount", stagingEntry.amount->JSON.Encode.float),
+    ("order_id", stagingEntry.order_id->JSON.Encode.string),
     ("effective_at", stagingEntry.effective_at->JSON.Encode.string),
     ("metadata", stagingEntry.metadata),
     ("staging_entry_id", stagingEntry.id->JSON.Encode.string),
@@ -473,6 +484,7 @@ let getExceptionEntryTypeFromEntryType = (
     amount: entry.amount,
     currency: entry.currency,
     status: entry.status,
+    order_id: entry.order_id,
     discarded_status: entry.discarded_status,
     metadata: entry.metadata,
     data: entry.data,
@@ -495,6 +507,7 @@ let getEntryTypeFromExceptionEntryType = (
     transaction_id: entry.transaction_id,
     amount: entry.amount,
     currency: entry.currency,
+    order_id: entry.order_id,
     status: entry.status,
     discarded_status: entry.discarded_status,
     metadata: entry.metadata,
@@ -521,6 +534,7 @@ let constructManualReconciliationBody = (
       ("entry_type", (backendEntry.entry_type :> string)->JSON.Encode.string),
       ("amount", backendEntry.amount->JSON.Encode.float),
       ("currency", backendEntry.currency->JSON.Encode.string),
+      ("order_id", backendEntry.order_id->JSON.Encode.string),
       ("effective_at", backendEntry.effective_at->JSON.Encode.string),
       ("metadata", backendEntry.metadata),
       (
@@ -547,7 +561,7 @@ let getResolutionModalConfig = (
   switch exceptionStage {
   | ResolvingException(VoidTransaction) => {
       heading: "Ignore Transaction",
-      description: "This will ignore the transaction in the system and it won't appear in any future reconciliations.",
+      description: "This will remove the transaction from the current Reconciliation.",
       layout: CenterModal,
       closeOnOutsideClick: true,
     }
@@ -610,6 +624,7 @@ let getUpdatedEntry = (
     amount: formData->getFloat("amount", entryDetails.amount),
     currency: formData->getString("currency", ""),
     status: statusString->getEntryStatusVariantFromString,
+    order_id: formData->getString("order_id", entryDetails.order_id),
     discarded_status: entryDetails.discarded_status,
     version: entryDetails.version,
     metadata: formData->getJsonObjectFromDict("metadata"),
@@ -636,6 +651,7 @@ let getNewEntry = (
     transaction_id: formData->getString("transaction_id", ""),
     amount: formData->getFloat("amount", 0.0),
     currency: formData->getString("currency", ""),
+    order_id: formData->getString("order_id", ""),
     status: Pending,
     discarded_status: None,
     version: updatedEntriesList->Array.reduce(0, (max, entry) =>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummary.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummary.res
@@ -14,7 +14,40 @@ let make = (~reconRulesList) => {
     mixpanelEvent(~eventName="recon_engine_overview_summary_date_filter_opened")
   }
 
+  let setInitialFilters = HSwitchRemoteFilter.useSetInitialFilters(
+    ~updateExistingKeys,
+    ~startTimeFilterKey,
+    ~endTimeFilterKey,
+    ~range=180,
+    ~origin="recon_engine_overview_summary",
+    (),
+  )
+
+  React.useEffect(() => {
+    setInitialFilters()
+    None
+  }, [])
+
   <div className="flex flex-col gap-8 mt-8">
+    <div className="flex flex-row justify-end">
+      <DynamicFilter
+        title="ReconEngineOverviewSummaryFilters"
+        initialFilters=[]
+        options=[]
+        popupFilterFields=[]
+        initialFixedFilters={HSAnalyticsUtils.initialFixedFilterFields(
+          null,
+          ~events=dateDropDownTriggerMixpanelCallback,
+        )}
+        defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
+        tabNames=filterKeys
+        key="ReconEngineOverviewSummaryFilters"
+        updateUrlWith=updateExistingKeys
+        filterFieldsPortalName={HSAnalyticsUtils.filterFieldsPortalName}
+        showCustomFilter=false
+        refreshFilters=false
+      />
+    </div>
     <ReconEngineOverviewSummaryStackedBarGraphs reconRulesList />
     <div className="flex flex-row justify-between items-center">
       <div className="flex flex-col gap-2">
@@ -23,25 +56,6 @@ let make = (~reconRulesList) => {
         </p>
       </div>
       <div className="flex flex-row items-center gap-4">
-        <div>
-          <DynamicFilter
-            title="ReconEngineOverviewSummaryFilters"
-            initialFilters=[]
-            options=[]
-            popupFilterFields=[]
-            initialFixedFilters={HSAnalyticsUtils.initialFixedFilterFields(
-              null,
-              ~events=dateDropDownTriggerMixpanelCallback,
-            )}
-            defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
-            tabNames=filterKeys
-            key="ReconEngineOverviewSummaryFilters"
-            updateUrlWith=updateExistingKeys
-            filterFieldsPortalName={HSAnalyticsUtils.filterFieldsPortalName}
-            showCustomFilter=false
-            refreshFilters=false
-          />
-        </div>
         <TabSwitch viewType setViewType />
       </div>
     </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryAccountsView.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryAccountsView.res
@@ -143,11 +143,7 @@ let make = (~reconRulesList: array<reconRuleType>) => {
   let (accountsData, setAccountsData) = React.useState(_ => [])
   let getTransactions = ReconEngineHooks.useGetTransactions()
   let getAccounts = ReconEngineHooks.useGetAccounts()
-  let {updateExistingKeys, filterValueJson, filterValue} = React.useContext(
-    FilterContext.filterContext,
-  )
-  let startTimeFilterKey = HSAnalyticsUtils.startTimeFilterKey
-  let endTimeFilterKey = HSAnalyticsUtils.endTimeFilterKey
+  let {filterValueJson, filterValue} = React.useContext(FilterContext.filterContext)
 
   let getAccountsData = async _ => {
     try {
@@ -180,20 +176,6 @@ let make = (~reconRulesList: array<reconRuleType>) => {
     | _ => setScreenState(_ => PageLoaderWrapper.Custom)
     }
   }
-
-  let setInitialFilters = HSwitchRemoteFilter.useSetInitialFilters(
-    ~updateExistingKeys,
-    ~startTimeFilterKey,
-    ~endTimeFilterKey,
-    ~range=180,
-    ~origin="recon_engine_overview_summary",
-    (),
-  )
-
-  React.useEffect(() => {
-    setInitialFilters()
-    None
-  }, [])
 
   React.useEffect(() => {
     if !(filterValue->isEmptyDict) {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
@@ -132,11 +132,7 @@ let make = (~reconRulesList: array<ReconEngineTypes.reconRuleType>) => {
   let getAccounts = ReconEngineHooks.useGetAccounts()
   let (reactFlowNodes, setNodes, onNodesChange) = useNodesState([])
   let (reactFlowEdges, setEdges, onEdgesChange) = useEdgesState([])
-  let {updateExistingKeys, filterValueJson, filterValue} = React.useContext(
-    FilterContext.filterContext,
-  )
-  let startTimeFilterKey = HSAnalyticsUtils.startTimeFilterKey
-  let endTimeFilterKey = HSAnalyticsUtils.endTimeFilterKey
+  let {filterValueJson, filterValue} = React.useContext(FilterContext.filterContext)
 
   let handleNodeClick = (nodeId: string) => {
     setSelectedNodeId(prev => {
@@ -185,20 +181,6 @@ let make = (~reconRulesList: array<ReconEngineTypes.reconRuleType>) => {
     | _ => setScreenState(_ => PageLoaderWrapper.Custom)
     }
   }
-
-  let setInitialFilters = HSwitchRemoteFilter.useSetInitialFilters(
-    ~updateExistingKeys,
-    ~startTimeFilterKey,
-    ~endTimeFilterKey,
-    ~range=180,
-    ~origin="recon_engine_overview_summary",
-    (),
-  )
-
-  React.useEffect(() => {
-    setInitialFilters()
-    None
-  }, [])
 
   React.useEffect(() => {
     if !(filterValue->isEmptyDict) {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
@@ -5,26 +5,32 @@ module RuleWiseStackedBarGraph = {
   @react.component
   let make = (~rule: ReconEngineTypes.reconRuleType) => {
     open CurrencyFormatUtils
+    open LogicUtils
 
     let getTransactions = ReconEngineHooks.useGetTransactions()
     let (allTransactionsData, setAllTransactionsData) = React.useState(_ => [])
     let isMiniLaptopView = MatchMedia.useScreenSizeChecker(~screenSize="1600")
+    let {filterValueJson, filterValue} = React.useContext(FilterContext.filterContext)
 
     let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+
     let getAllTransactionsData = async _ => {
       try {
         setScreenState(_ => PageLoaderWrapper.Loading)
-        let transactionsData = await getTransactions(
-          ~queryParamerters=Some(
-            `rule_id=${rule.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`,
-          ),
-        )
+        let baseQueryString = ReconEngineFilterUtils.buildQueryStringFromFilters(~filterValueJson)
+        let queryString = if baseQueryString->isNonEmptyString {
+          `${baseQueryString}&rule_id=${rule.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`
+        } else {
+          `rule_id=${rule.rule_id}&transaction_status=posted,mismatched,expected,partially_reconciled`
+        }
+        let transactionsData = await getTransactions(~queryParamerters=Some(queryString))
         setAllTransactionsData(_ => transactionsData)
         setScreenState(_ => PageLoaderWrapper.Success)
       } catch {
       | _ => setScreenState(_ => PageLoaderWrapper.Custom)
       }
     }
+
     let (postedCount, mismatchedCount, expectedCount) = React.useMemo(() => {
       ReconEngineOverviewUtils.calculateTransactionCounts(allTransactionsData)
     }, [allTransactionsData])
@@ -44,9 +50,11 @@ module RuleWiseStackedBarGraph = {
     }, [postedCount, mismatchedCount, expectedCount])
 
     React.useEffect(() => {
-      getAllTransactionsData()->ignore
+      if !(filterValue->isEmptyDict) {
+        getAllTransactionsData()->ignore
+      }
       None
-    }, [])
+    }, [filterValue])
 
     <PageLoaderWrapper
       screenState

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/EntriesTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/EntriesTableEntity.res
@@ -11,6 +11,7 @@ type entryColType =
   | Metadata
   | CreatedAt
   | EffectiveAt
+  | OrderID
 
 let defaultColumns: array<entryColType> = [
   EntryId,
@@ -22,6 +23,7 @@ let defaultColumns: array<entryColType> = [
   Metadata,
   CreatedAt,
   EffectiveAt,
+  OrderID,
 ]
 
 let allColumns: array<entryColType> = [
@@ -34,6 +36,7 @@ let allColumns: array<entryColType> = [
   Metadata,
   CreatedAt,
   EffectiveAt,
+  OrderID,
 ]
 
 let detailsFields = [
@@ -60,6 +63,7 @@ let getHeading = (colType: entryColType) => {
   | Metadata => Table.makeHeaderInfo(~key="metadata", ~title="Metadata")
   | CreatedAt => Table.makeHeaderInfo(~key="created_at", ~title="Created At")
   | EffectiveAt => Table.makeHeaderInfo(~key="effective_at", ~title="Effective At")
+  | OrderID => Table.makeHeaderInfo(~key="order_id", ~title="Order ID")
   }
 }
 
@@ -94,6 +98,7 @@ let getCell = (entry: entryType, colType: entryColType): Table.cell => {
   | Metadata => Text(entry.metadata->JSON.stringify)
   | CreatedAt => Date(entry.created_at)
   | EffectiveAt => Date(entry.effective_at)
+  | OrderID => EllipsisText(entry.order_id, "w-fit")
   }
 }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
@@ -7,6 +7,7 @@ type hierarchicalColType =
   | TransactionId
   | Status
   | EntryId
+  | OrderId
   | Account
   | EntryStatus
   | Currency
@@ -18,6 +19,7 @@ let defaultColumns: array<hierarchicalColType> = [
   TransactionId,
   Status,
   EntryId,
+  OrderId,
   Account,
   EntryStatus,
   Currency,
@@ -30,6 +32,7 @@ let allColumns: array<hierarchicalColType> = [
   TransactionId,
   Status,
   EntryId,
+  OrderId,
   Account,
   EntryStatus,
   Currency,
@@ -43,6 +46,7 @@ let getHeading = (colType: hierarchicalColType) => {
   | TransactionId => makeHeaderInfo(~key="transaction_id", ~title="Transaction ID")
   | Status => makeHeaderInfo(~key="status", ~title="Status")
   | EntryId => makeHeaderInfo(~key="entry_id", ~title="Entry ID")
+  | OrderId => makeHeaderInfo(~key="order_id", ~title="Order ID")
   | Account => makeHeaderInfo(~key="account", ~title="Account")
   | EntryStatus => makeHeaderInfo(~key="entry_status", ~title="Entry Status")
   | Currency => makeHeaderInfo(~key="currency", ~title="Currency")
@@ -68,7 +72,7 @@ let getStatusLabel = (transactionStatus: transactionStatus): cell => {
 let getCell = (transaction: transactionType, colType: hierarchicalColType): cell => {
   let hierarchicalContainerClassName = "-mx-8 border-r-gray-400 divide-y divide-gray-200"
   switch colType {
-  | Date => DateWithoutTime(transaction.created_at)
+  | Date => DateWithoutTime(transaction.effective_at)
   | TransactionId => Text(transaction.transaction_id)
   | Status =>
     switch transaction.discarded_status {
@@ -88,6 +92,18 @@ let getCell = (transaction: transactionType, colType: hierarchicalColType): cell
         ->React.array}
       </div>
     CustomCell(entryIdContent, "")
+  | OrderId =>
+    let orderIdContent =
+      <div className=hierarchicalContainerClassName>
+        {transaction.entries
+        ->Array.map(entry => {
+          <HierarchicalEntryRenderer
+            fieldValue=entry.order_id key={LogicUtils.randomString(~length=10)}
+          />
+        })
+        ->React.array}
+      </div>
+    CustomCell(orderIdContent, "")
   | Account =>
     let accountContent =
       <div className=hierarchicalContainerClassName>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactions.res
@@ -10,7 +10,6 @@ let make = () => {
   let getAccountsData = async _ => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-
       let accountData = await getAccounts()
       setAccountData(_ => accountData)
       setScreenState(_ => PageLoaderWrapper.Success)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsContent.res
@@ -29,7 +29,8 @@ let make = (~account: ReconEngineTypes.accountType) => {
         switch Nullable.toOption(obj) {
         | Some(obj) =>
           isContainingStringLowercase(obj.transaction_id, searchText) ||
-          isContainingStringLowercase((obj.transaction_status :> string), searchText)
+          isContainingStringLowercase((obj.transaction_status :> string), searchText) ||
+          obj.entries->Array.some(entry => isContainingStringLowercase(entry.order_id, searchText))
         | None => false
         }
       })
@@ -167,7 +168,7 @@ let make = (~account: ReconEngineTypes.accountType) => {
         filters={<TableSearchFilter
           data={configuredTransactions->Array.map(Nullable.make)}
           filterLogic
-          placeholder="Search Transaction Id or Status"
+          placeholder="Search Transaction ID or Order ID or Status"
           searchVal=searchText
           setSearchVal=setSearchText
           customSearchBarWrapperWidth="w-full lg:w-1/3"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsDetails.res
@@ -47,12 +47,9 @@ let make = (~id) => {
 
   let detailsFields = React.useMemo(() => {
     open TransactionsTableEntity
-    switch (
-      currentTransactionDetails.transaction_status,
-      currentTransactionDetails.data.posted_type,
-    ) {
-    | (Posted, Some(_)) => [TransactionId, Status, Variance, ReconciliationType, CreatedAt, Reason]
-    | _ => [TransactionId, Status, Variance, CreatedAt]
+    switch currentTransactionDetails.data.posted_type {
+    | Some(Reconciled) => [TransactionId, Status, Variance, ReconciliationType, CreatedAt]
+    | _ => [TransactionId, Status, Variance, ReconciliationType, CreatedAt, Reason]
     }
   }, [currentTransactionDetails])
 

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -18,6 +18,7 @@ type accountType = {
   expected_credits: balanceType,
   mismatched_debits: balanceType,
   mismatched_credits: balanceType,
+  created_at: string,
 }
 
 type accountRefType = {
@@ -85,6 +86,7 @@ type ingestionConfigType = {
   name: string,
   last_synced_at: string,
   data: JSON.t,
+  created_at: string,
 }
 
 type transformationConfigType = {
@@ -149,6 +151,7 @@ type transactionEntryType = {
   account: accountType,
   amount: balanceType,
   status: entryStatus,
+  order_id: string,
 }
 
 type transactionPostedType =
@@ -187,6 +190,7 @@ type entryType = {
   transaction_id: string,
   amount: float,
   currency: string,
+  order_id: string,
   status: entryStatus,
   discarded_status: option<string>,
   metadata: Js.Json.t,
@@ -218,6 +222,7 @@ type processingEntryType = {
   transformation_id: string,
   transformation_history_id: string,
   effective_at: string,
+  order_id: string,
 }
 
 type processedEntryType = {

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -109,6 +109,7 @@ let accountItemToObjMapper = dict => {
     mismatched_credits: dict
     ->getDictfromDict("mismatched_credits")
     ->getAmountPayload,
+    created_at: dict->getString("created_at", ""),
   }
 }
 
@@ -200,6 +201,7 @@ let ingestionConfigItemToObjMapper = (dict): ingestionConfigType => {
     name: dict->getString("name", ""),
     last_synced_at: dict->getString("last_synced_at", ""),
     data: dict->getJsonObjectFromDict("data"),
+    created_at: dict->getString("created_at", ""),
   }
 }
 
@@ -235,6 +237,7 @@ let transactionsEntryItemToObjMapper = dict => {
     ->accountItemToObjMapper,
     amount: dict->getDictfromDict("amount")->getAmountPayload,
     status: dict->getString("status", "NA")->getEntryStatusVariantFromString,
+    order_id: dict->getString("order_id", ""),
   }
 }
 
@@ -289,6 +292,7 @@ let entryItemToObjMapper = dict => {
     account_name: dict->getDictfromDict("account")->getString("account_name", "N/A"),
     amount: dict->getDictfromDict("amount")->getFloat("value", 0.0),
     currency: dict->getDictfromDict("amount")->getString("currency", "N/A"),
+    order_id: dict->getString("order_id", ""),
     status: dict->getString("status", "")->getEntryStatusVariantFromString,
     discarded_status: dict->getOptionString("discarded_status"),
     version: dict->getInt("version", 0),
@@ -316,5 +320,6 @@ let processingItemToObjMapper = (dict): processingEntryType => {
     metadata: dict->getJsonObjectFromDict("metadata"),
     transformation_id: dict->getString("transformation_id", ""),
     transformation_history_id: dict->getString("transformation_history_id", ""),
+    order_id: dict->getString("order_id", ""),
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Modification of no exceptions screen


Add Remark to be renamed in screen where it says Reason to ignore
Ignore Transaction Heading to be changed to "This will remove the transaction from the current Reconciliation"
Move Date Filters in overview Page one filter for whole page
In Resolve Exception we need to change Resolution Remark to "Add Remark"

I should only allow the right side of transaction to be marked as received when doing "Mark Received"

Order of Account creation to govern tabs (sort by created_at)

Add order id in table view and enable search by order id in bar


<!-- Describe your changes in detail -->

## Motivation and Context

https://github.com/juspay/hyperswitch-control-center/issues/3813

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
