### PR TITLE
refactor: make sidebar route matching dynamic instead of hardcoded depth

### DIFF
--- a/src/screens/Sidebar/Sidebar.res
+++ b/src/screens/Sidebar/Sidebar.res
@@ -5,8 +5,8 @@ open ProductUtils
 open LogicUtils
 
 let defaultLinkSelectionCheck = (firstPart, tabLink) => {
-  let normalizedFirstPart = firstPart->LogicUtils.removeTrailingSlash
-  let normalizedTabLink = tabLink->LogicUtils.removeTrailingSlash
+  let normalizedFirstPart = firstPart->removeTrailingSlash
+  let normalizedTabLink = tabLink->removeTrailingSlash
   // Exact match or prefix match (for detail pages like /route/id)
   normalizedFirstPart === normalizedTabLink ||
     normalizedFirstPart->String.startsWith(normalizedTabLink ++ "/")
@@ -671,16 +671,8 @@ let make = (
     }
   }
 
-  let rec buildPathFromSegments = segments => {
-    switch (List.head(segments), List.tail(segments)) {
-    | (Some(segment), Some(rest)) => `/${segment}` ++ buildPathFromSegments(rest)
-    | (Some(segment), None) => `/${segment}`
-    | (_, _) => ""
-    }
-  }
-
   let firstPart = switch List.tail(path) {
-  | Some(tail) => buildPathFromSegments(tail)
+  | Some(tail) => `/${tail->List.toArray->Array.joinWith("/")}`
   | None => "/"
   }
 


### PR DESCRIPTION
## Type of Change

- [x] Refactoring

## Description

Refactored sidebar route matching from hardcoded 3-level depth to dynamic depth handling that works for any route structure.

**Changes:**
1. **Replaced `level2`/`level3` functions with `List.toArray->Array.joinWith`** — Removed separate recursive/nested functions in favor of a single-line path join from list segments
2. **Dynamic depth handling** — No longer limited to 3 levels; works for any route depth (v1, v2, or any future versioning) without special-casing
3. **Added prefix matching in `defaultLinkSelectionCheck`** — Supports both exact and prefix matching so detail pages (e.g., `/payments/pay_123`) correctly highlight their parent sidebar item (`/payments`)

Closes #3832

## Motivation and Context

The current sidebar implementation uses hardcoded functions (`level2`, `level3`) that:
- Are repetitive and hard to maintain
- Limit route depth to exactly 3 levels
- Require special-casing for `v1`/`v2` route prefixes
- Don't scale if routes need more or fewer levels

This refactor:
- Makes the code more maintainable with a single `joinWith` expression instead of recursive functions
- Supports routes of any depth dynamically — v1/v2 cases are handled naturally without explicit checks
- Adds prefix matching so detail pages correctly highlight their parent route in the sidebar

## How did you test it?

Tested locally across:
- Non-versioned routes (e.g., `/payments`, `/connectors`, `/routing`)
- Versioned routes (e.g., `/v2/orchestrator/onboarding`, `/v1/recon-engine/sources`)
- Detail pages (e.g., `/payments/pay_123` correctly highlights the Payments sidebar item)
- Sidebar highlighting remains correct when navigating between different products and route depths

https://github.com/user-attachments/assets/efb01e3c-af74-4137-ae6c-89e8ae36b63e

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible