### PR TITLE
refactor: simplify class names in Snackbar, OrderUtils and TableLocalFilters components

### DIFF
--- a/src/components/OrderUtils.res
+++ b/src/components/OrderUtils.res
@@ -89,7 +89,7 @@ module Heading = {
         {switch topic {
         | String(string) =>
           <AddDataAttributes attributes=[("data-heading", string)]>
-            <span className="text-gray-600 dark:text-gray-400 font-bold text-base text-fs-16">
+            <span className="text-gray-600 dark:text-gray-400 font-bold text-base">
               {React.string({string})}
             </span>
           </AddDataAttributes>

--- a/src/components/SnackBarContainer.res
+++ b/src/components/SnackBarContainer.res
@@ -80,9 +80,9 @@ let make = (~children) => {
     children
     <div>
       <div
-        className={`absolute inset-0 overflow-scroll flex flex-col pointer-events-none m-4 items-end grid justify-end content-end no-scrollbar`}>
+        className={`absolute inset-0 overflow-scroll flex flex-col pointer-events-none m-4 items-end justify-end no-scrollbar`}>
         <div
-          className={`flex flex-col font-inter-style pointer-events-auto w-auto self-start w-max max-w-4xl`}>
+          className={`flex flex-col font-inter-style pointer-events-auto self-start w-max max-w-4xl`}>
           {openSnackbar
           ->Array.map(snackbarProps => {
             <Snackbar key={snackbarProps.snackbarKey} snackbarProps hideSnackbar />

--- a/src/components/TableLocalFilters.res
+++ b/src/components/TableLocalFilters.res
@@ -63,7 +63,7 @@ module RangeSliderLocalFilter = {
     <div className="flex relative flex-row flex-wrap">
       <div className="flex relative flex-row flex-wrap w-full">
         <div
-          className="flex justify-center relative h-10 flex flex-row min-w-min items-center bg-white text-jp-gray-900 text-opacity-75 hover:shadow hover:text-jp-gray-900 hover:text-opacity-75 dark:bg-jp-gray-darkgray_background dark:hover:bg-jp-gray-950 dark:text-jp-gray-text_darktheme dark:text-opacity-50 focus:outline-none rounded-md border border-jp-gray-950 border-opacity-20 dark:border-jp-gray-960 dark:border-opacity-100 text-jp-gray-950 hover:text-black dark:text-jp-gray-text_darktheme dark:hover:text-jp-gray-text_darktheme dark:hover:text-opacity-75 cursor-pointer px-2 w-full justify-between overflow-hidden w-full"
+          className="flex relative h-10 flex-row min-w-min items-center bg-white text-jp-gray-950 text-opacity-75 hover:shadow hover:text-black hover:text-opacity-75 dark:bg-jp-gray-darkgray_background dark:hover:bg-jp-gray-950 dark:text-jp-gray-text_darktheme dark:text-opacity-50 focus:outline-none rounded-md border border-jp-gray-950 border-opacity-20 dark:border-jp-gray-960 dark:border-opacity-100 dark:hover:text-jp-gray-text_darktheme dark:hover:text-opacity-75 cursor-pointer px-2 w-full justify-between overflow-hidden"
           type_="button"
           onClick={_ => setShowDropDown(prev => !prev)}>
           {rightIcon}
@@ -71,7 +71,7 @@ module RangeSliderLocalFilter = {
         <RenderIf condition={min !== max && showDropDown}>
           <div
             ref={dropdownRef->ReactDOM.Ref.domRef}
-            className=" top-3.5 px-4 pt-4 pb-2 bg-white border dark:bg-jp-gray-lightgray_background border-jp-gray-lightmode_steelgray border-opacity-75 dark:border-jp-gray-960 rounded shadow-generic_shadow dark:shadow-generic_shadow_dark mt-8 absolute border border-jp-gray-lightmode_steelgray border-opacity-75 dark:border-jp-gray-960 rounded shadow-generic_shadow dark:shadow-generic_shadow_dark z-20 ">
+            className=" top-3.5 px-4 pt-4 pb-2 bg-white dark:bg-jp-gray-lightgray_background mt-8 absolute border border-jp-gray-lightmode_steelgray border-opacity-75 dark:border-jp-gray-960 rounded shadow-generic_shadow dark:shadow-generic_shadow_dark z-20 ">
             <div className="flex">
               <RangeSlider min max maxSlide minSlide />
             </div>
@@ -153,7 +153,7 @@ module FilterDropDown = {
       />
     } else {
       <div
-        className="flex justify-center relative h-10 flex flex-row min-w-min items-center bg-white text-jp-gray-900 text-opacity-75 hover:shadow hover:text-jp-gray-900 hover:text-opacity-75 dark:bg-jp-gray-darkgray_background dark:hover:bg-jp-gray-950 dark:text-jp-gray-text_darktheme dark:text-opacity-50 focus:outline-none rounded-md border border-jp-gray-950 border-opacity-20 dark:border-jp-gray-960 dark:border-opacity-100 text-jp-gray-950 hover:text-black dark:text-jp-gray-text_darktheme dark:hover:text-jp-gray-text_darktheme dark:hover:text-opacity-75 cursor-pointer px-2 w-full justify-between overflow-hidden w-full"
+        className="flex relative h-10 flex-row min-w-min items-center bg-white text-opacity-75 hover:shadow hover:text-jp-gray-900 hover:text-opacity-75 dark:bg-jp-gray-darkgray_background dark:hover:bg-jp-gray-950 dark:text-jp-gray-text_darktheme dark:text-opacity-50 focus:outline-none rounded-md border border-jp-gray-950 border-opacity-20 dark:border-jp-gray-960 dark:border-opacity-100 text-jp-gray-950 dark:hover:text-jp-gray-text_darktheme dark:hover:text-opacity-75 cursor-pointer px-2 w-full justify-between overflow-hidden"
         type_="button">
         <div className="max-w-[250px] md:max-w-xs">
           <div className="px-2 text-fs-13 font-medium truncate whitespace-pre ">


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Simplified and cleaned up className attributes in Snackbar, OrderUtils and TableLocalFilters components by removing duplicate Tailwind CSS width utilities (w-auto and w-max conflicts) and optimizing CSS class usage for better maintainability and performance.

## Motivation and Context

The components had redundant and conflicting Tailwind CSS classes where both `w-auto` and `w-max` were applied to the same element. Since CSS follows the last declaration rule, `w-max` was overriding `w-auto`, creating unnecessary code and potential confusion. This refactor removes the duplication and ensures cleaner, more maintainable styling.

## How did you test it?

- [x] Manually tested the components to ensure visual appearance remains unchanged
- [x] Verified that the simplified class names produce the same layout behavior
- [x] Confirmed no functional regressions in component behavior

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
