### PR TITLE
fix: global search payout pagination issue

### DIFF
--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
@@ -103,8 +103,11 @@ let make = () => {
       setScreenState(_ => PageLoaderWrapper.Success)
     }
 
-    clearPageDetails()->ignore
-    None
+    Some(
+      () => {
+        clearPageDetails()
+      },
+    )
   }, (offset, searchText))
 
   open ResultsTableUtils


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed pagination state management in PayoutTable by properly returning a cleanup function in the useEffect hook. Changed the return value from `None` to `Some(() => { clearPageDetails() })` to ensure proper cleanup of page details when the component unmounts or dependencies change.

## Motivation and Context

The pagination was not working correctly because the useEffect cleanup function was not being properly returned. In ReScript/React, when you need to provide a cleanup function for useEffect, it must be wrapped in `Some()` rather than returning `None`. This ensures that `clearPageDetails()` is called at the appropriate time to reset pagination state.


## How did you test it?

- [x] Manually tested pagination functionality in payout table

<img width="2556" height="1033" alt="Screenshot 2025-11-17 at 2 06 46 PM" src="https://github.com/user-attachments/assets/76e735a5-5acd-4e44-a54f-5f0ec4fe2e37" />

<img width="2556" height="824" alt="Screenshot 2025-11-17 at 2 07 43 PM" src="https://github.com/user-attachments/assets/838948bf-675f-40cf-a329-1551f970946b" />


## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

