### PR TITLE
fix: sidebar active product click bugfix

### DIFF
--- a/src/screens/Sidebar/Sidebar.res
+++ b/src/screens/Sidebar/Sidebar.res
@@ -497,7 +497,7 @@ module ProductTypeSectionItem = {
     let sectionProductVariant = section.name->getProductVariantFromDisplayName
 
     let handleClick = _ => {
-      if activeProduct !== sectionProductVariant {
+      if activeProduct != sectionProductVariant {
         onProductSelectClick(section.name)
       }
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

sidebar bugfix for active product click disabling - Active product click in side should be disabled else the switch popup modal will appear which is not required for active product


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
