### PR TITLE
fix: dropdown select all - keep menu open until apply

### DIFF
--- a/src/components/FilterSelectBox.res
+++ b/src/components/FilterSelectBox.res
@@ -449,7 +449,7 @@ module BaseSelect = {
     ~isMobileView=false,
     ~isModalView=false,
     ~customSearchStyle="bg-jp-gray-100 dark:bg-jp-gray-950 p-2",
-    ~hasApplyButton=false,
+    ~hasApplyButton=true,
     ~setShowDropDown=?,
     ~dropdownCustomWidth="w-full md:max-w-md min-w-[10rem]",
     ~sortingBasedOnDisabled=true,
@@ -533,10 +533,12 @@ module BaseSelect = {
           Array.concat(saneValue, [itemDataValue])
         }
         onSelect(data)
-        switch onBlur {
-        | Some(fn) =>
-          "blur"->Webapi.Dom.FocusEvent.make->Identity.webAPIFocusEventToReactEventFocus->fn
-        | None => ()
+        if !hasApplyButton {
+          switch onBlur {
+          | Some(fn) =>
+            "blur"->Webapi.Dom.FocusEvent.make->Identity.webAPIFocusEventToReactEventFocus->fn
+          | None => ()
+          }
         }
       }
     }
@@ -557,10 +559,12 @@ module BaseSelect = {
       }
 
       onSelect(newValues)
-      switch onBlur {
-      | Some(fn) =>
-        "blur"->Webapi.Dom.FocusEvent.make->Identity.webAPIFocusEventToReactEventFocus->fn
-      | None => ()
+      if !hasApplyButton {
+        switch onBlur {
+        | Some(fn) =>
+          "blur"->Webapi.Dom.FocusEvent.make->Identity.webAPIFocusEventToReactEventFocus->fn
+        | None => ()
+        }
       }
     }
 
@@ -1534,7 +1538,7 @@ module BaseDropdown = {
     ~descriptionOnHover=false,
     ~addDynamicValue=false,
     ~showMatchingRecordsText=true,
-    ~hasApplyButton=false,
+    ~hasApplyButton=true,
     ~dropdownCustomWidth=?,
     ~customMarginStyle=?,
     ~customButtonLeftIcon: option<Button.iconType>=?,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes an issue where clicking the **"Select all"** checkbox inside a filter dropdown caused the dropdown to close immediately.  
The dropdown now remains open, allowing users to make multiple selections, and only closes when the user clicks **Apply** or explicitly closes it.

## Motivation and Context

Selecting multiple filters is a common workflow. Closing the dropdown on "Select all" interrupts this flow and forces users to reopen it repeatedly.

This change ensures a smoother multi-select experience and aligns the behavior with user expectations.

Fixes #4031

## How did you test it?

- Manually tested the filter dropdown behavior
- Verified that:
  - Dropdown stays open when clicking **Select all**
  - Dropdown closes correctly on **Apply**
  - Dropdown closes on outside click
- Confirmed no regression in existing filter behavior

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

## Screenshots / Video

https://github.com/user-attachments/assets/15755b01-2bde-4a92-8a0e-42c88df29bd7





