### PR TITLE
fix: prevent dropdown width shrinking on close

### DIFF
--- a/src/components/InputFields.res
+++ b/src/components/InputFields.res
@@ -32,7 +32,7 @@ let selectInput = (
   ~customButton=React.null,
   ~buttonType=Button.SecondaryFilled,
   ~dropdownCustomWidth="w-80",
-  ~allowButtonTextMinWidth=?,
+  ~allowButtonTextMinWidth=false,
   ~setExtSearchString=_ => (),
   ~textStyleClass=?,
   ~ellipsisOnly=false,
@@ -67,7 +67,7 @@ let selectInput = (
     customButton
     buttonType
     dropdownCustomWidth
-    ?allowButtonTextMinWidth
+    allowButtonTextMinWidth
     setExtSearchString
     ?textStyleClass
     ellipsisOnly

--- a/src/components/SelectBox.res
+++ b/src/components/SelectBox.res
@@ -1869,6 +1869,16 @@ module BaseDropdown = {
     | TopLeft | TopRight => "mb-12"
     }
 
+    // Ensure dropdown keeps a stable width on open/close.
+    let dropdownWidthClass =
+      if fullLength {
+        "w-full"
+      } else if isMobileView {
+        "w-full"
+      } else {
+        dropdownCustomWidth->Option.getOr("w-80")
+      }
+
     let onRadioOptionSelect = ev => {
       newInputRadio.onChange(ev)
       addButton ? setShowDropDown(_ => true) : setShowDropDown(_ => false)
@@ -1898,7 +1908,6 @@ module BaseDropdown = {
         color: condition ? BadgeBlue : NoBadge,
       }
     }, [newInputSelect.value])
-    let widthClass = isMobileView ? "w-full" : dropdownCustomWidth->Option.getOr("")
 
     let optionsElement = if allowMultiSelect {
       <BaseSelect
@@ -2126,9 +2135,7 @@ module BaseDropdown = {
                   dropDirection == BottomMiddle ||
                   dropDirection == BottomRight
                     ? "origin-top"
-                    : "origin-bottom"} ${dropdownOuterClass} ${customDropdownOuterClass} z-20 ${marginBottom} rounded-lg dark:bg-jp-gray-950 ${fullLength
-                    ? "w-full"
-                    : ""}`}
+                    : "origin-bottom"} ${dropdownOuterClass} ${customDropdownOuterClass} z-20 ${marginBottom} rounded-lg dark:bg-jp-gray-950 ${dropdownWidthClass}`}
                 ref={dropdownRef->ReactDOM.Ref.domRef}>
                 optionsElement
                 {showCustomBtnAtEnd ? customButton : React.null}
@@ -2141,7 +2148,7 @@ module BaseDropdown = {
           }
         } else if !isInitialRender && isGrowDown && !isMobileView {
           <div
-            className={`${marginTop} absolute animate-growUp ${widthClass} ${dropDirection ==
+            className={`${marginTop} absolute animate-growUp ${dropdownWidthClass} ${dropDirection ==
                 BottomLeft ||
               dropDirection == BottomMiddle ||
               dropDirection == BottomRight


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Prevent dropdown buttons from applying the shrinking `min-w-min` when using full-length select inputs by defaulting `selectInput` to `allowButtonTextMinWidth=false`.
- Stabilize dropdown panel width during open/close by using a consistent width class.

Fixes #4100 

Touched files:
- `src/components/InputFields.res`
- `src/components/SelectBox.res`

## Motivation and Context

Fixes the visual glitch where currency (and similar) dropdowns in Setup Checkout briefly shrink in width when opened and then closed without selecting an option.

## How did you test it?

- Manually in Setup Checkout: open currency dropdown, close without selection, observe width remains stable (no shrink).

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible