### PR TITLE
fix: recon engine use `field_name` in metadata validations

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationDetails/ReconEngineAccountsTransformationDetailsMappers.res
@@ -110,7 +110,7 @@ module TabDetails = {
               {metadataSchema.schema_data.fields.metadata_fields
               ->Array.map(field => {
                 <FileAndSystemColumnMapping
-                  fileColumn=field.identifier systemColumn={field.field_name}
+                  fileColumn=field.identifier systemColumn={field.field_name->entryFieldToString}
                 />
               })
               ->React.array}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
@@ -11,6 +11,13 @@ let basicFieldMappingList: array<basicFieldType> = [
   OrderId,
 ]
 
+let entryFieldToString = (field: entryField): string => {
+  switch field {
+  | Metadata(key) => "metadata." ++ key
+  | String => ""
+  }
+}
+
 let getBasicFieldIdentifier = (fields: schemaFieldsType, fieldType: basicFieldType): string => {
   let fieldName = switch fieldType {
   | Currency => "currency"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAccounts/ReconEngineAccountsTransformation/ReconEngineAccountsTransformationUtils.res
@@ -13,7 +13,7 @@ let basicFieldMappingList: array<basicFieldType> = [
 
 let entryFieldToString = (field: entryField): string => {
   switch field {
-  | Metadata(key) => "metadata." ++ key
+  | Metadata(key) => `metadata.${key}`
   | String => ""
   }
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
@@ -167,7 +167,7 @@ module EditEntryModalContent = {
             ~setMetadataRows,
             ~isMetadataLoading,
           )}
-          <div className="flex justify-end mt-4">
+          <div className="flex justify-end my-4">
             <FormRenderer.SubmitButton
               tooltipForWidthClass="w-full"
               text="Save changes"
@@ -285,7 +285,7 @@ module MarkAsReceivedModalContent = {
             ~setMetadataRows,
             ~isMetadataLoading,
           )}
-          <div className="absolute bottom-2 left-0 right-0 bg-white p-2">
+          <div className="flex justify-end my-4">
             <FormRenderer.SubmitButton
               tooltipForWidthClass="w-full"
               text="Mark as Received"
@@ -367,7 +367,7 @@ module CreateEntryModalContent = {
             ~setMetadataRows,
             ~isMetadataLoading,
           )}
-          <div className="absolute bottom-2 left-0 right-0 bg-white p-2">
+          <div className="flex justify-end my-4">
             <FormRenderer.SubmitButton
               tooltipForWidthClass="w-full"
               text="Create new entry"
@@ -589,8 +589,7 @@ module LinkStagingEntryModalContent = {
             />}
           />
         </PageLoaderWrapper>
-        <div
-          className="absolute bottom-2 left-0 right-0 bg-white p-4 flex flex-row gap-3 items-center">
+        <div className="flex justify-end gap-3 my-4 items-center">
           <Button
             buttonType=Secondary
             buttonSize=Medium

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -228,9 +228,14 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
   let isEffectiveAtChanged =
     currentData->getString("effective_at", "") != initialEntryDetails.effective_at
   let isMetadataChanged = {
-    let currentMetadata = currentData->getJsonObjectFromDict("metadata")
-    let initialMetadataJson = initialMetadata->JSON.Encode.object
-    currentMetadata->JSON.stringify != initialMetadataJson->JSON.stringify
+    let currentMetadataArray = currentData->getDictfromDict("metadata")->Dict.toArray
+
+    currentMetadataArray->Array.some(((key, value)) => {
+      switch initialMetadata->Dict.get(key) {
+      | Some(initialValue) => initialValue != value
+      | None => true
+      }
+    })
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
 
@@ -264,11 +269,15 @@ let validateEntryDetailsCommon = (
     let metadataDict = data->getJsonObjectFromDict("metadata")->getDictFromJsonObject
 
     metadataSchema.schema_data.fields.metadata_fields->Array.forEach(field => {
-      let value = metadataDict->getString(field.identifier, "")
-      let error = validateMetadataFieldValue(field.identifier, value, metadataSchema)
+      let fieldKey = switch field.field_name {
+      | Metadata(key) => key
+      | _ => ""
+      }
+      let value = metadataDict->getString(fieldKey, "")
+      let error = validateMetadataFieldValue(fieldKey, value, metadataSchema)
       switch error {
       | Some(err) => {
-          let errorKey = `metadata.${field.identifier}`
+          let errorKey = `metadata.${fieldKey}`
           fieldErrors->Dict.set(errorKey, err->JSON.Encode.string)
         }
       | None => ()
@@ -413,16 +422,21 @@ let generateResolutionSummary = (initialEntry: entryType, updatedEntry: entryTyp
     summary->Array.push(message)
   }
 
-  let initialMetadata = initialEntry.metadata->getFilteredMetadataFromEntries
-  let updatedMetadata = updatedEntry.metadata->getFilteredMetadataFromEntries
-  let initialMetadataJson = initialMetadata->JSON.Encode.object
-  let updatedMetadataJson = updatedMetadata->JSON.Encode.object
+  let initialMetadata = initialEntry.metadata->getFilteredMetadataFromEntries->Dict.toArray
+  initialMetadata->Array.forEach(((key, initialValue)) => {
+    let updatedValue =
+      updatedEntry.metadata
+      ->getFilteredMetadataFromEntries
+      ->Dict.get(key)
+      ->Option.getOr(""->JSON.Encode.string)
 
-  if initialMetadataJson->JSON.stringify != updatedMetadataJson->JSON.stringify {
-    let message = `Metadata updated in ${updatedEntry.account_name} account.`
-    summary->Array.push(message)
-  }
-
+    if initialValue != updatedValue {
+      let message = `Metadata field '${key}' changed from '${initialValue->getStringFromJson(
+          "",
+        )}' to '${updatedValue->getStringFromJson("")}' in ${updatedEntry.account_name} account.`
+      summary->Array.push(message)
+    }
+  })
   summary
 }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -232,10 +232,7 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
     let initialMetadataArray = initialMetadata->Dict.toArray
     currentMetadataArray->Array.length != initialMetadataArray->Array.length ||
       currentMetadataArray->Array.some(((key, value)) => {
-        switch initialMetadata->Dict.get(key) {
-        | Some(initialValue) => initialValue != value
-        | None => true
-        }
+        initialMetadata->Dict.get(key)->Option.mapOr(true, initialValue => initialValue != value)
       })
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
@@ -422,16 +419,14 @@ let generateResolutionSummary = (initialEntry: entryType, updatedEntry: entryTyp
 
   let initialMetadata = initialEntry.metadata->getFilteredMetadataFromEntries->Dict.toArray
   initialMetadata->Array.forEach(((key, initialValue)) => {
-    let updatedValue =
+    let updatedValueStr =
       updatedEntry.metadata
       ->getFilteredMetadataFromEntries
-      ->Dict.get(key)
-      ->Option.getOr(""->JSON.Encode.string)
+      ->getString(key, "")
 
-    if initialValue != updatedValue {
-      let message = `Metadata field '${key}' changed from '${initialValue->getStringFromJson(
-          "",
-        )}' to '${updatedValue->getStringFromJson("")}' in ${updatedEntry.account_name} account.`
+    let initialValueStr = initialValue->getStringFromJson("")
+    if initialValueStr != updatedValueStr {
+      let message = `Metadata field '${key}' changed from '${initialValueStr}' to '${updatedValueStr}' in ${updatedEntry.account_name} account.`
       summary->Array.push(message)
     }
   })

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -229,13 +229,14 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
     currentData->getString("effective_at", "") != initialEntryDetails.effective_at
   let isMetadataChanged = {
     let currentMetadataArray = currentData->getDictfromDict("metadata")->Dict.toArray
-
-    currentMetadataArray->Array.some(((key, value)) => {
-      switch initialMetadata->Dict.get(key) {
-      | Some(initialValue) => initialValue != value
-      | None => true
-      }
-    })
+    let initialMetadataArray = initialMetadata->Dict.toArray
+    currentMetadataArray->Array.length != initialMetadataArray->Array.length ||
+      currentMetadataArray->Array.some(((key, value)) => {
+        switch initialMetadata->Dict.get(key) {
+        | Some(initialValue) => initialValue != value
+        | None => true
+        }
+      })
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
 
@@ -269,10 +270,7 @@ let validateEntryDetailsCommon = (
     let metadataDict = data->getJsonObjectFromDict("metadata")->getDictFromJsonObject
 
     metadataSchema.schema_data.fields.metadata_fields->Array.forEach(field => {
-      let fieldKey = switch field.field_name {
-      | Metadata(key) => key
-      | _ => ""
-      }
+      let fieldKey = getFieldNameFromMetadataField(field)
       let value = metadataDict->getString(fieldKey, "")
       let error = validateMetadataFieldValue(fieldKey, value, metadataSchema)
       switch error {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsHelper.res
@@ -52,10 +52,7 @@ module MetadataInput = {
           metadataSchema.schema_data.fields.metadata_fields->Array.filter(field => field.required)
 
         let requiredRows = requiredFields->Array.map(field => {
-          let fieldKeyName = switch field.field_name {
-          | Metadata(key) => key
-          | _ => ""
-          }
+          let fieldKeyName = getFieldNameFromMetadataField(field)
           let existingValue =
             existingRows
             ->Array.find(row => row.key == fieldKeyName)
@@ -73,10 +70,7 @@ module MetadataInput = {
           metadataSchema.schema_data.fields.metadata_fields->Array.filter(field => !field.required)
 
         let optionalRows = optionalFields->Array.map(field => {
-          let fieldKeyName = switch field.field_name {
-          | Metadata(key) => key
-          | _ => ""
-          }
+          let fieldKeyName = getFieldNameFromMetadataField(field)
           let existingValue =
             existingRows
             ->Array.find(row => row.key == fieldKeyName)
@@ -286,12 +280,9 @@ module MetadataInput = {
                 checked: false,
               }
               options={unusedOptionalFields->Array.map((field): SelectBox.dropdownOption => {
-                let fieldValue = switch field.field_name {
-                | Metadata(key) => key
-                | _ => ""
-                }
+                let fieldKeyName = getFieldNameFromMetadataField(field)
                 {
-                  value: fieldValue,
+                  value: fieldKeyName,
                   label: field.identifier ++ " (Optional)",
                 }
               })}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsTypes.res
@@ -26,6 +26,7 @@ type resolutionConfig = {
 type metadataRow = {
   id: string,
   key: string,
+  displayKey: string,
   value: string,
 }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
@@ -135,8 +135,12 @@ let validateMetadataFieldValue = (
   metadataSchema: metadataSchemaType,
 ): option<string> => {
   if metadataSchema.id->isNonEmptyString {
-    let field =
-      metadataSchema.schema_data.fields.metadata_fields->Array.find(f => f.identifier == key)
+    let field = metadataSchema.schema_data.fields.metadata_fields->Array.find(f => {
+      switch f.field_name {
+      | Metadata(fieldKey) => fieldKey == key
+      | _ => false
+      }
+    })
     let checkEmptyValue = value->String.trim->isEmptyString
 
     switch field {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
@@ -1,6 +1,13 @@
 open LogicUtils
 open ReconEngineTypes
 
+let getFieldNameFromMetadataField = (field: metadataFieldType): string => {
+  switch field.field_name {
+  | Metadata(key) => key
+  | _ => ""
+  }
+}
+
 let requiredString = (fieldName: string, errorMsg: string) => {
   (data: Dict.t<JSON.t>) => data->getString(fieldName, "")->isEmptyString ? Some(errorMsg) : None
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionResolution.res
@@ -137,15 +137,14 @@ module EditEntryModalContent = {
             ~setMetadataRows,
             ~isMetadataLoading,
           )}
-          <div className="absolute bottom-4 left-0 right-0 bg-white p-4">
-            <FormRenderer.DesktopRow itemWrapperClass="" wrapperClass="items-center">
-              <FormRenderer.SubmitButton
-                tooltipForWidthClass="w-full"
-                text="Save changes"
-                buttonType={Primary}
-                customSumbitButtonStyle="!w-full"
-              />
-            </FormRenderer.DesktopRow>
+          <div className="flex justify-end my-4">
+            <FormRenderer.SubmitButton
+              tooltipForWidthClass="w-full"
+              text="Save changes"
+              buttonType={Primary}
+              showToolTip=false
+              customSumbitButtonStyle="!w-full"
+            />
           </div>
         </Form>
       </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
@@ -190,10 +190,7 @@ let hasFormValuesChanged = (
     let initialMetadataArray = initialMetadata->Dict.toArray
     currentMetadataArray->Array.length != initialMetadataArray->Array.length ||
       currentMetadataArray->Array.some(((key, value)) => {
-        switch initialMetadata->Dict.get(key) {
-        | Some(initialValue) => initialValue != value
-        | None => true
-        }
+        initialMetadata->Dict.get(key)->Option.mapOr(true, initialValue => initialValue != value)
       })
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
@@ -333,15 +330,12 @@ let generateResolutionSummary = (
   let initialMetadata = currentEntry.metadata->getFilteredMetadataFromEntries->Dict.toArray
 
   initialMetadata->Array.forEach(((key, initialValue)) => {
-    let updatedValue =
+    let updatedStr =
       updatedEntry.metadata
       ->getFilteredMetadataFromEntries
-      ->Dict.get(key)
-      ->Option.getOr(""->JSON.Encode.string)
-
-    if initialValue != updatedValue {
-      let initialStr = initialValue->getStringFromJson("")
-      let updatedStr = updatedValue->getStringFromJson("")
+      ->getString(key, "")
+    let initialStr = initialValue->getStringFromJson("")
+    if initialStr != updatedStr {
       let message = `Metadata field '${key}' changed from '${initialStr}' to '${updatedStr}'.`
       summary->Array.push(message)
     }

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -312,9 +312,13 @@ type fieldTypeVariant =
   | DateTimeField
   | BalanceDirectionField({credit_values: array<string>, debit_values: array<string>})
 
+type entryField =
+  | String
+  | Metadata(string)
+
 type metadataFieldType = {
   identifier: string,
-  field_name: string,
+  field_name: entryField,
   field_type: fieldTypeVariant,
   required: bool,
   description: string,

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -482,8 +482,9 @@ let fieldTypeMapper = (dict): fieldTypeVariant => {
 }
 
 let entryFieldFromString = (str: string): entryField => {
-  if str->String.startsWith("metadata.") {
-    let key = str->String.slice(~start=9, ~end=str->String.length)
+  let metadataPrefix = "metadata."
+  if str->String.startsWith(metadataPrefix) {
+    let key = str->String.slice(~start=metadataPrefix->String.length, ~end=str->String.length)
     Metadata(key)
   } else {
     String

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -481,10 +481,19 @@ let fieldTypeMapper = (dict): fieldTypeVariant => {
   }
 }
 
+let entryFieldFromString = (str: string): entryField => {
+  if str->String.startsWith("metadata.") {
+    let key = str->String.slice(~start=9, ~end=str->String.length)
+    Metadata(key)
+  } else {
+    String
+  }
+}
+
 let metadataFieldItemToObjMapper = (dict): metadataFieldType => {
   {
     identifier: dict->getString("identifier", ""),
-    field_name: dict->getString("field_name", ""),
+    field_name: dict->getString("field_name", "")->entryFieldFromString,
     field_type: dict->fieldTypeMapper,
     required: dict->getBool("required", false),
     description: dict->getString("description", ""),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Use field name in the metadata validations instead of identifier.

<!-- Describe your changes in detail -->

## Motivation and Context


Fixes: https://github.com/juspay/hyperswitch-control-center/issues/4104
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally



<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
