### PR TITLE
fix: Update created_at field mapping to use timestamp and adjust display type in table

### DIFF
--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTableEntity.res
@@ -30,8 +30,8 @@ type payoutsObject = {
   business_country: string,
   business_label: string,
   entity_type: string,
-  created_at: string,
-  last_modified_at: string,
+  created_at: float,
+  last_modified_at: float,
   additional_payout_method_data: option<JSON.t>,
   metadata: option<JSON.t>,
 }
@@ -104,7 +104,7 @@ let colMapper = (col: cols) => {
   | BusinessCountry => "business_country"
   | BusinessLabel => "business_label"
   | EntityType => "entity_type"
-  | CreatedAt => "timestamp"
+  | CreatedAt => "created_at"
   | LastModifiedAt => "last_modified_at"
   | AdditionalPayoutMethodData => "additional_payout_method_data"
   | Metadata => "metadata"
@@ -143,8 +143,8 @@ let tableItemToObjMapper: Dict.t<JSON.t> => payoutsObject = dict => {
     business_country: dict->getString(BusinessCountry->colMapper, "NA"),
     business_label: dict->getString(BusinessLabel->colMapper, "NA"),
     entity_type: dict->getString(EntityType->colMapper, "NA"),
-    created_at: dict->getString(CreatedAt->colMapper, "NA"),
-    last_modified_at: dict->getString(LastModifiedAt->colMapper, "NA"),
+    created_at: dict->getFloat(CreatedAt->colMapper, 0.0),
+    last_modified_at: dict->getFloat(LastModifiedAt->colMapper, 0.0),
     additional_payout_method_data: None,
     metadata: None,
   }
@@ -267,8 +267,8 @@ let getCell = (payoutObj, colType): Table.cell => {
   | BusinessCountry => Text(payoutObj.business_country)
   | BusinessLabel => Text(payoutObj.business_label)
   | EntityType => Text(payoutObj.entity_type)
-  | CreatedAt => Date(payoutObj.created_at)
-  | LastModifiedAt => Text(payoutObj.last_modified_at)
+  | CreatedAt => Date(payoutObj.created_at->DateTimeUtils.unixToISOString)
+  | LastModifiedAt => Date(payoutObj.last_modified_at->DateTimeUtils.unixToISOString)
   | AdditionalPayoutMethodData => Text("N/A")
   | Metadata => Text("N/A")
   }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed the `created_at` date field display issue in the Payouts table shown on customer detail pages. The field was incorrectly showing "Nov 30, 1899, 12:00 PM IST" instead of the actual creation date because the data in the created_at field is in unix timestamp before display we need to convert that data to ISO 8601 format.

## Motivation and Context

When viewing payouts on a customer detail page (e.g., `/customers/payout_customer`), the OpenSearch search API returns payout data with the created_at stored in a unix timestamp need to convert that to ISO 8601 format (e.g., `2026-01-19T13:20:38Z`). 

This resulted in:

- The `created_at` field being set to its actual ISO format otherwise default value `"0.0"`

The fix changes the data extraction to read directly from the `"created_at"` key that exists in the OpenSearch response, ensuring the `created_at` field converted to a valid ISO 8601 timestamp string.

## Files Changed

  - `src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTableEntity.res`
  - Modified `tableItemToObjMapper` to map `created_at` in unix timestamp to ISO 8601 fromat
  - Simplified the `CreatedAt` cell renderer to use `Date(payoutObj.created_at)` directly

## How did you test it?

<img width="1722" height="994" alt="Screenshot 2026-01-19 at 7 27 22 PM" src="https://github.com/user-attachments/assets/f64b3629-8d0e-46b2-8035-7c14221bf2fb" />


## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

