### PR TITLE
chore: make `processing_account_id` non required field in payload auth keys

### DIFF
--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -1634,6 +1634,13 @@ let getWebHookRequiredFields = (connector: connectorTypes, fieldName: string) =>
   }
 }
 
+let checkAuthKeyMapRequiredFields = (connector: connectorTypes, fieldName) => {
+  switch (connector, fieldName) {
+  | (Processors(PAYLOAD), "processing_account_id") => false
+  | _ => true
+  }
+}
+
 let getAuthKeyMapFromConnectorAccountFields = connectorAccountFields => {
   open LogicUtils
   let authKeyMap =
@@ -1665,7 +1672,11 @@ let checkCashtoCodeInnerField = (valuesFlattenJson, dict, country: string): bool
 
 let checkPayloadFields = (dict, country, valuesFlattenJson) => {
   open LogicUtils
-  let keys = dict->getDictfromDict(country)->Dict.keysToArray
+  let keys =
+    dict
+    ->getDictfromDict(country)
+    ->Dict.keysToArray
+    ->Array.filter(field => checkAuthKeyMapRequiredFields(Processors(PAYLOAD), field))
 
   keys->Array.every(field => {
     let key = `connector_account_details.auth_key_map.${country}.${field}`

--- a/src/screens/Connectors/PaymentProcessor/ConnectorAccountDetailsHelper.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorAccountDetailsHelper.res
@@ -303,6 +303,7 @@ module Payload = {
         dict
         ->getDictfromDict(country)
         ->Dict.keysToArray
+        ->Array.filter(field => checkAuthKeyMapRequiredFields(Processors(PAYLOAD), field))
 
       wasmValues
       ->Array.find(ele => formValues->getString(ele, "")->String.length <= 0)
@@ -333,6 +334,7 @@ module Payload = {
                 name={`connector_account_details.auth_key_map.${country}`}
                 connector
                 selectedConnector
+                checkRequiredFields={ConnectorUtils.checkAuthKeyMapRequiredFields}
               />
             </div>,
         }


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Make `processing_account_id` non required field in payload auth keys

<!-- Describe your changes in detail -->

## Motivation and Context

Fixes: #4121 

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally


https://github.com/user-attachments/assets/dd5f4efe-0dd5-4e58-a840-84393adb43df



<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
