### PR TITLE
fix: graph not appearing when enabling granularity

### DIFF
--- a/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/ExemptionGraphs/ExemptionGraphsTypes.res
+++ b/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/ExemptionGraphs/ExemptionGraphsTypes.res
@@ -12,6 +12,7 @@ type exemptionGraphsCol =
   | Exemption_Request_Rate
   | User_Drop_Off_Rate
   | Time_Bucket
+  | Time_Range
   | Unknown
 
 type responseKeys = [
@@ -22,6 +23,7 @@ type responseKeys = [
   | #authentication_failure_count
   | #authentication_failure_rate
   | #time_bucket
+  | #time_range
   | #authentication_exemption_approved_count
   | #authentication_exemption_requested_count
   | #exemption_approval_rate
@@ -38,6 +40,7 @@ type exemptionGraphsObject = {
   authentication_failure_count: int,
   authentication_failure_rate: float,
   time_bucket: string,
+  time_range: JSON.t,
   authentication_exemption_approved_count: int,
   authentication_exemption_requested_count: int,
   exemption_approval_rate: float,

--- a/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
+++ b/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
@@ -211,7 +211,11 @@ let make = () => {
         )
         updatedFilters->Dict.set(
           "authentication_status",
-          ["success"->JSON.Encode.string, "failed"->JSON.Encode.string]->JSON.Encode.array,
+          [
+            "success"->JSON.Encode.string,
+            "pending"->JSON.Encode.string,
+            "failed"->JSON.Encode.string,
+          ]->JSON.Encode.array,
         )
 
         let thirdFunnelRequestBody = InsightsUtils.requestBody(

--- a/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalyticsUtils.res
+++ b/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalyticsUtils.res
@@ -191,7 +191,7 @@ let metrics: array<LineChartUtils.metricsConfig> = [
   },
   {
     metric_name_db: "authentication_successful",
-    metric_label: "Authentication Successful",
+    metric_label: "Overall Authentication Success",
     thresholdVal: None,
     step_up_threshold: None,
     metric_type: Rate,

--- a/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/SCAExemptionAnalytics/SCAExemptionAnalytics.res
+++ b/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/SCAExemptionAnalytics/SCAExemptionAnalytics.res
@@ -30,7 +30,7 @@ let make = (
     setScreenState(_ => PageLoaderWrapper.Loading)
     try {
       if isSampleDataEnabled {
-        let paymentsUrl = `${GlobalVars.getHostUrl}/test-data/analytics/payments.json`
+        let paymentsUrl = `${GlobalVars.getHostUrl}/test-data/analytics/authentication.json`
         let res = await fetchApi(
           paymentsUrl,
           ~method_=Get,
@@ -51,10 +51,8 @@ let make = (
           ]->getJsonFromArrayOfJson
 
         let scaExemptionResponse = await updateDetails(url, scaExemptionBody, Post)
-        setScreenState(_ => PageLoaderWrapper.Custom)
-
         setData(_ => scaExemptionResponse->SCAExemptionAnalyticsUtils.scaExemptionResponseMapper)
-        setScreenState(_ => PageLoaderWrapper.Custom)
+        setScreenState(_ => PageLoaderWrapper.Success)
       }
     } catch {
     | _ => setScreenState(_ => PageLoaderWrapper.Custom)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes analytics visualization issues by correcting granularity-based graph rendering, funnel chart data, and Sankey chart display.

## Motivation and Context

1. The graph was not appearing correctly after enabling granularity
2. Funnel chart data representation was incorrect
3. Sankey chart did not render despite receiving a valid response

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

before: 
<img width="965" height="808" alt="image" src="https://github.com/user-attachments/assets/0b9fd7a7-f1be-4bcf-a114-27ee9d9fc329" />

after:
<img width="920" height="795" alt="image" src="https://github.com/user-attachments/assets/05ff06d7-3bb8-4d08-873c-7610767ee316" />


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
