### PR TITLE
feat: recon engine entry details with account level grouping

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummary.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummary.res
@@ -28,7 +28,7 @@ let make = (~reconRulesList) => {
     None
   }, [])
 
-  <div className="flex flex-col gap-8 mt-8">
+  <div className="flex flex-col gap-8 mt-8 pb-40">
     <div className="flex flex-row justify-end">
       <DynamicFilter
         title="ReconEngineOverviewSummaryFilters"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryFlowDiagram.res
@@ -211,12 +211,12 @@ let make = (~reconRulesList: array<ReconEngineRulesTypes.rulePayload>) => {
     None
   }, [selectedNodeId])
 
-  <div className="border rounded-xl border-nd_gray-200">
+  <div className="border rounded-xl border-nd_gray-200 resize-y overflow-auto h-30-rem">
     <PageLoaderWrapper
       screenState
       customUI={<NewAnalyticsHelper.NoData height="h-30-rem" message="No data available." />}
       customLoader={<Shimmer styleClass="h-30-rem w-full rounded-b-xl" />}>
-      <div className="h-30-rem overflow-hidden">
+      <div className="h-full overflow-hidden">
         <ReactFlowProvider>
           <FlowWithLayoutControls
             nodes={reactFlowNodes}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
@@ -147,7 +147,7 @@ module EntryAuditTrailInfo = {
       )
       let entry = group.entries->getValueFromArray(rowIndex, Dict.make()->entryItemToObjMapper)
       let filteredEntryMetadata = entry.metadata->getFilteredMetadataFromEntries
-      let hasEntryMetadata = filteredEntryMetadata->Dict.keysToArray->Array.length > 0
+      let hasEntryMetadata = !(filteredEntryMetadata->isEmptyDict)
 
       <RenderIf condition={rowIndex < group.entries->Array.length}>
         <RenderIf condition={hasEntryMetadata}>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
@@ -121,8 +121,7 @@ module EntryAuditTrailInfo = {
       entriesList->Array.forEach(entry => {
         let accountId = entry.account_id
         switch groupsDict->Dict.get(accountId) {
-        | Some(existingEntries) =>
-          groupsDict->Dict.set(accountId, existingEntries->Array.concat([entry]))
+        | Some(existingEntries) => groupsDict->Dict.set(accountId, [...existingEntries, entry])
         | None => groupsDict->Dict.set(accountId, [entry])
         }
       })
@@ -130,7 +129,8 @@ module EntryAuditTrailInfo = {
       groupsDict
       ->Dict.toArray
       ->Array.map(((accountId, entries)) => {
-        let accountName = entries->Array.get(0)->Option.mapOr("", e => e.account_name)
+        let entry = entries->getValueFromArray(0, Dict.make()->entryItemToObjMapper)
+        let accountName = entry.account_name
         {ReconEngineTransactionsTypes.accountId, accountName, entries}
       })
     }, [entriesList])
@@ -178,13 +178,12 @@ module EntryAuditTrailInfo = {
 
         let onAccountExpandIconClick = (isExpanded, rowIndex) => {
           setAccountExpandedRowsDict(prev => {
-            let newDict = prev->Dict.toArray->Dict.fromArray
-            let currentExpanded = newDict->Dict.get(accountKey)->Option.getOr([])
+            let currentExpanded = prev->Dict.get(accountKey)->Option.getOr([])
             let updatedExpanded = isExpanded
               ? currentExpanded->Array.filter(idx => idx !== rowIndex)
               : currentExpanded->Array.concat([rowIndex])
-            newDict->Dict.set(accountKey, updatedExpanded)
-            newDict
+            prev->Dict.set(accountKey, updatedExpanded)
+            prev
           })
         }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsTypes.res
@@ -1,1 +1,7 @@
 type entriesMetadataKeysToExclude = Amount | Currency
+
+type accountGroup = {
+  accountId: string,
+  accountName: string,
+  entries: array<ReconEngineTypes.entryType>,
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


Audit Trail – Entries Page (Recon V1 Merchant)
1. Go to Transactions
2. Open any transaction
3. Click Audit Trail
4. Open Entries

Verify
- Entries page opens
- Correct audit records shown
- Verify the UI

Overview Page – Graph Resize
1. Open Overview page
2. Drag graph up/down (Y-axis)

Verify
- Graph resizes vertically
- No UI break or overlap
- Data remains readable


<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
