### PR TITLE
fix: amount filter payload

### DIFF
--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
@@ -77,16 +77,11 @@ let validateAmount = dict => {
 }
 
 let createAmountQuery = (~dict) => {
+  Js.log2("dict", dict)
   let hasAmountError = validateAmount(dict)
   let startAmount = dict->getvalFromDict("start_amount")
   let endAmount = dict->getvalFromDict("end_amount")
-
-  let isAmountFilterUsed = switch (startAmount, endAmount) {
-  | (Some(startVal), _) => !(startVal->isNullJson)
-  | (_, Some(endVal)) => !(endVal->isNullJson)
-  | _ => false
-  }
-
+  let isAmountFilterUsed = startAmount->Option.isSome || endAmount->Option.isSome
   if !hasAmountError && isAmountFilterUsed {
     let encodeAmount = value => value->mapOptionOrDefault(JSON.Encode.null, encodeFloatOrDefault)
     dict->Dict.set(

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
@@ -78,13 +78,22 @@ let validateAmount = dict => {
 
 let createAmountQuery = (~dict) => {
   let hasAmountError = validateAmount(dict)
-  if !hasAmountError {
+  let startAmount = dict->getvalFromDict("start_amount")
+  let endAmount = dict->getvalFromDict("end_amount")
+
+  let isAmountFilterUsed = switch (startAmount, endAmount) {
+  | (Some(startVal), _) => !(startVal->isNullJson)
+  | (_, Some(endVal)) => !(endVal->isNullJson)
+  | _ => false
+  }
+
+  if !hasAmountError && isAmountFilterUsed {
     let encodeAmount = value => value->mapOptionOrDefault(JSON.Encode.null, encodeFloatOrDefault)
     dict->Dict.set(
       "amount_filter",
       [
-        ("start_amount", dict->getvalFromDict("start_amount")->encodeAmount),
-        ("end_amount", dict->getvalFromDict("end_amount")->encodeAmount),
+        ("start_amount", startAmount->encodeAmount),
+        ("end_amount", endAmount->encodeAmount),
       ]->getJsonFromArrayOfJson,
     )
   }

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
@@ -77,7 +77,6 @@ let validateAmount = dict => {
 }
 
 let createAmountQuery = (~dict) => {
-  Js.log2("dict", dict)
   let hasAmountError = validateAmount(dict)
   let startAmount = dict->getvalFromDict("start_amount")
   let endAmount = dict->getvalFromDict("end_amount")


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
The `amount_filter` object with `start_amount` and `end_amount` set to `null` was always being included in the filter JSON, even when the amount filter wasn't being used. This is inconsistent with other filters (like `status`, `currency`, `connector`) which only appear in the filter JSON when they have actual values.
Added a check to verify if the amount filter is actually being used before creating the `amount_filter` object. The check validates that at least one of `start_amount` or `end_amount` has a non-null value.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

- Verify that when the amount filter is not used, `amount_filter` does not appear in the filter JSON
- Verify that when the amount filter is used with valid values, `amount_filter` is correctly included in the filter JSON
- Verify that all amount filter types (Greater than or Equal to, Less than or Equal to, Equal to, In Between) still work correctly

Note: the amount filter is not correctly due to some changes pending for payouts/filter api. We need to click twice to enable the filter again
https://github.com/juspay/hyperswitch/issues/10605

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
