### PR TITLE
feat: update 'Modified' column to enable sorting in payments table

### DIFF
--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -376,7 +376,7 @@ let getHeading = (colType: colType) => {
   | ConnectorTransactionID =>
     Table.makeHeaderInfo(~key="connector_transaction_id", ~title="Connector Transaction ID")
   | Created => Table.makeHeaderInfo(~key="created", ~title="Created", ~showSort=true)
-  | Modified => Table.makeHeaderInfo(~key="modified_at", ~title="Modified")
+  | Modified => Table.makeHeaderInfo(~key="modified", ~title="Modified", ~showSort=true)
   | Currency => Table.makeHeaderInfo(~key="currency", ~title="Currency")
   | CustomerId => Table.makeHeaderInfo(~key="customer_id", ~title="Customer ID")
   | Description => Table.makeHeaderInfo(~key="description", ~title="Description")


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Enabled Sorting for Modified Column in Orders Table:
Added sorting capability to the Modified column in the payments/orders list by enabling ~showSort=true.

- Updated the table header key from modified_at to modified to align with the frontend sorting enum key used for table sorting.
Although the backend column remains modified_at, sorting operates using the enum key (modified). This change ensures correct mapping between frontend sorting parameters and backend sorting logic.

## Motivation and Context

Previously, the Modified column did not support sorting, making it difficult for users to organize payments based on their latest updates.

Additionally, the table header used the backend column name (modified_at) instead of the frontend sorting enum key (modified). This mismatch prevented sorting from functioning correctly.

By aligning the header key with the sorting enum and enabling sorting, users can now efficiently sort payments by modification time.

## How did you test it?

<!-- Add your testing details and screenshots/videos here -->
- Tested payment list with sort_on: Modified and sort_by: Desc
<img width="1266" height="1300" alt="Screenshot 2026-02-19 at 4 20 14 PM" src="https://github.com/user-attachments/assets/bc4599a3-9888-4c4d-b669-cd27bab04c20" />

- Tested payment list with sort_on: Modified and sort_by: Asc
<img width="1300" height="1250" alt="Screenshot 2026-02-19 at 4 21 24 PM" src="https://github.com/user-attachments/assets/908939b3-0836-42fb-8bf3-c815dc265b5a" />



## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
