### PR TITLE
fix: reconcile stale table columns with new defaults

### DIFF
--- a/cypress/e2e/3-operations/paymentOperations.cy.js
+++ b/cypress/e2e/3-operations/paymentOperations.cy.js
@@ -434,6 +434,55 @@ describe("Payment Operations", () => {
     });
   });
 
+  it("should auto-restore newly added mandatory columns from stale local storage", () => {
+    const staleOrdersColumns = [
+      "Payment ID",
+      "Connector",
+      "Profile Id",
+      "Amount",
+      "Payment Status",
+      "Payment Method",
+      "Payment Method Type",
+      "Card Network",
+      "Connector Transaction ID",
+      "Merchant Order Reference Id",
+      "Description",
+      "Metadata",
+      "Created",
+    ];
+
+    let merchant_id;
+    homePage.merchantID
+      .eq(0)
+      .invoke("text")
+      .then((text) => {
+        merchant_id = text;
+        cy.createDummyConnectorAPI(merchant_id, "stripe_test_1");
+        cy.createPaymentAPI(merchant_id);
+      });
+
+    cy.window().then((win) => {
+      win.localStorage.setItem(
+        "tableColumnsOrder",
+        JSON.stringify({
+          orders: staleOrdersColumns.join(","),
+        }),
+      );
+    });
+
+    homePage.operations.click();
+    homePage.paymentOperations.click();
+
+    cy.get(`[data-table-heading="Modified"]`).should("exist");
+
+    cy.window().then((win) => {
+      const tableColumnsOrder = JSON.parse(
+        win.localStorage.getItem("tableColumnsOrder"),
+      );
+      expect(tableColumnsOrder.orders.split(",")).to.include("Modified");
+    });
+  });
+
   // Search bar
   it("should display correct payment when searched with payment ID", () => {
     let merchant_id;

--- a/src/components/DynamicTableUtils.res
+++ b/src/components/DynamicTableUtils.res
@@ -303,7 +303,24 @@ module ChooseColumns = {
       }
     }
 
-    let colTypeArray = retrieveColumnValueFromLocalStorage(title)->Belt.Array.keepMap(getHeadingCol)
+    let dedupeColumns = columns =>
+      columns->Array.reduce([], (acc, column) =>
+        acc->Array.includes(column) ? acc : acc->Array.concat([column])
+      )
+
+    let storedColumnLabels = retrieveColumnValueFromLocalStorage(title)
+    let storedColumnTypeArray =
+      storedColumnLabels
+      ->Belt.Array.keepMap(getHeadingCol)
+      ->dedupeColumns
+
+    let reconciledColumnTypeArray =
+      defaultColumns->Array.reduce(storedColumnTypeArray, (acc, column) =>
+        acc->Array.includes(column) ? acc : acc->Array.concat([column])
+      )
+
+    let reconciledColumnLabels =
+      reconciledColumnTypeArray->Array.map(column => getHeading(column).title)
 
     let setColumns = React.useCallback(fn => {
       setVisibleColumns(fn)
@@ -311,8 +328,12 @@ module ChooseColumns = {
     }, [setVisibleColumns])
 
     React.useEffect(() => {
-      if !{colTypeArray->Array.length === 0} {
-        setColumns(_ => colTypeArray)
+      if !{storedColumnTypeArray->Array.length === 0} {
+        setColumns(_ => reconciledColumnTypeArray)
+
+        if reconciledColumnLabels->Array.toString !== storedColumnLabels->Array.toString {
+          setColumnValueInLocalStorage(reconciledColumnLabels, title)
+        }
       }
       None
     }, [])


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
