### PR TITLE
fix: preserve disabled state when updating connector

### DIFF
--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -2055,6 +2055,7 @@ let constructConnectorRequestBody = (wasmRequest: wasmRequest, payload: JSON.t) 
         : connectorAdditionalMerchantData->JSON.Encode.object,
     ),
     ("connector_label", dict->getString("connector_label", "")->JSON.Encode.string),
+    ("disabled", dict->getBool("disabled", false)->JSON.Encode.bool),
     ("status", dict->getString("status", "active")->JSON.Encode.string),
     (
       "pm_auth_config",

--- a/src/screens/Connectors/PaymentProcessor/ConnectorUpdateAuthCreds.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorUpdateAuthCreds.res
@@ -72,6 +72,7 @@ let make = (
       ),
       ("connector_webhook_details", connectorInfo.connector_webhook_details),
       ("connector_label", connectorInfo.connector_label->JSON.Encode.string),
+      ("disabled", connectorInfo.disabled->JSON.Encode.bool),
       ("metadata", connectorInfo.metadata),
       (
         "additional_merchant_data",
@@ -83,6 +84,7 @@ let make = (
   }, (
     connectorInfo.connector_webhook_details,
     connectorInfo.connector_label,
+    connectorInfo.disabled,
     connectorInfo.metadata,
   ))
 


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

When updating a disabled connector (via Dashboard), the `disabled` field was not being included in the API request body, causing it to be reset to `false` on the backend — effectively re-enabling the connector unintentionally.

**Changes:**

- **`ConnectorUtils.res`**: Added `("disabled", ...)` to the dict in `constructConnectorRequestBody` so the `disabled` state is included in the update request body sent during the Payment Methods step (Step 2).
- **`ConnectorUpdateAuthCreds.res`**: Added `("disabled", connectorInfo.disabled->JSON.Encode.bool)` to the `initialValues` dict and its dependency tuple, so the `disabled` state is preserved when updating auth credentials from the Preview screen.

## Motivation and Context

Fixes #4046

When an existing disabled connector was updated, the connector's `disabled` flag was automatically changed to `false`, re-enabling the connector. This happened because the `disabled` field was missing from the request body constructed during connector updates. The backend would then default it to `false`, overriding the existing `disabled: true` state.

## How did you test it?

Tested manually:
1. Disabled a connector via the Enable/Disable toggle
2. Updated a field on the connector (e.g., auth credentials or payment methods)
3. Verified the connector remained disabled after the update

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible