### PR TITLE
fix: apple pay fields missing in braintree fix

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ApplePay/ApplePayIntegrationUtils.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/ApplePay/ApplePayIntegrationUtils.res
@@ -160,10 +160,14 @@ let applePayNameMapper = (
       `metadata.apple_pay_combined.${(integrationType->Option.getOr(
           #manual,
         ): applePayIntegrationType :> string)}.payment_request_data.label`
-    | _ =>
+    | `supported_networks` | `merchant_capabilities` =>
       `metadata.apple_pay_combined.${(integrationType->Option.getOr(
           #manual,
         ): applePayIntegrationType :> string)}.payment_request_data.${name}`
+    | _ =>
+      `metadata.apple_pay_combined.${(integrationType->Option.getOr(
+          #manual,
+        ): applePayIntegrationType :> string)}.session_token_data.${name}`
     }
   | _ =>
     switch name {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
apple pay fields not populating in braintree fix

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
