### PR TITLE
fix: sanitize search input to prevent error page on special characters

### DIFF
--- a/src/screens/HSwitchRemoteFilter.res
+++ b/src/screens/HSwitchRemoteFilter.res
@@ -102,7 +102,8 @@ module SearchBarFilter = {
     let (baseValue, setBaseValue) = React.useState(_ => "")
     let onChange = ev => {
       let value = ReactEvent.Form.target(ev)["value"]
-      setBaseValue(_ => value)
+      let filteredValue = value->String.replaceRegExp(%re("/[^a-zA-Z0-9_-]/g"), "")
+      setBaseValue(_ => filteredValue)
     }
 
     React.useEffect(() => {


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This PR fixes an issue where entering special characters or spaces in the search box caused the application to show an error page. 

Key changes:
- Added input sanitization in `SearchBarFilter`'s `onChange` handler inside `HSwitchRemoteFilter.res`.
- Used regex `/[^a-zA-Z0-9_-]/g` to strip out any characters that are not alphanumeric, underscores, or hyphens.
- This ensures that only valid ID characters are stored and subsequently sent to the API, preventing backend errors that triggered the "Something went wrong!" page.

Since `SearchBarFilter` is a shared component, this fix applies across:
- Payment Operations
- Refunds
- Disputes
- Payouts

## Motivation and Context
Fixes #3382. 
Previously, raw input (including special characters like `@#$*` or spaces) was sent directly to the API as a `payment_id`, `refund_id`, etc. The API would return an error for invalid characters, which the frontend handled by displaying a full-page error instead of failing gracefully or preventing the invalid input.

## How did you test it?
- ✅ Typed special characters (`@#$%^&*`) in the payment search box and verified they are stripped immediately.
- ✅ Typed spaces and verified they are stripped.
- ✅ Verified valid payment IDs still work correctly when pressing Enter.
- ✅ Verified the fix works across Refunds, Disputes, and Payouts search boxes.
- ✅ Ran `npm run re:build` — ReScript compilation successful.

## Where to test it?
- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist
- [x] I ran npm run re:build
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
