### PR TITLE
fix(global-search): correct dispute redirect path from search results

### DIFF
--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBarUtils.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBarUtils.res
@@ -189,7 +189,7 @@ let getElements = (hits, section) => {
 
       {
         texts: [disId, amount, status]->Array.map(JSON.Encode.string),
-        redirect_link: `/${disId}/${profileId}/${merchantId}/${orgId}`->JSON.Encode.string,
+        redirect_link: `/disputes/${disId}/${profileId}/${merchantId}/${orgId}`->JSON.Encode.string,
       }
     })
   | Payouts =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed dispute navigation from global search results by adding the missing `/disputes` prefix to the redirect link in `GlobalSearchBarUtils.res`.

**Changed file**: `src/screens/Analytics/GlobalSearch/GlobalSearchBarUtils.res` (line 192)

**Before**:
```rescript
redirect_link: `/${disId}/${profileId}/${merchantId}/${orgId}`
```

**After**:
```rescript
redirect_link: `/disputes/${disId}/${profileId}/${merchantId}/${orgId}`
```

This aligns dispute handling with other entities (payments, refunds, payouts) which already include their entity prefix in the redirect link.

## Motivation and Context

Fixes #3895

When clicking on a dispute result from the global search, navigation was failing because the redirect link was missing the `/disputes` entity prefix. The route contract expects paths in the format `/disputes/{id}/{profile}/{merchant}/{org}`, but the code was generating `/{id}/{profile}/{merchant}/{org}`.

All other entities in the same file (payments, refunds, payouts) correctly include their entity prefix - this fix brings disputes in line with the established pattern.

## How did you test it?

- ✅ Ran `npm run re:build` - ReScript compilation successful (983ms)
- ✅ Code review - verified the fix matches the expected route pattern
- ✅ Static analysis - confirmed other entities (payments/refunds/payouts) remain unchanged
- ⏸️  Manual E2E testing required (backend was unavailable during development):
  1. Perform global search with a dispute ID
  2. Click on the dispute result row
  3. Verify navigation to `/disputes/{id}/{profile}/{merchant}/{org}`
  4. Verify dispute detail page renders correctly

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible