### PR TITLE
fix: close mobile sidebar when navigating to profile from user menu

### DIFF
--- a/src/screens/Sidebar/Sidebar.res
+++ b/src/screens/Sidebar/Sidebar.res
@@ -1022,6 +1022,9 @@ let make = (
                           <MenuOption
                             onClick={_ => {
                               panelProps["close"]()
+                              if isMobileView {
+                                setIsSidebarExpanded(_ => false)
+                              }
                               RescriptReactRouter.replace(
                                 GlobalVars.appendDashboardPath(~url="/account-settings/profile"),
                               )


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

On mobile view, when the user opens the sidebar and clicks on the email at the bottom to open the user menu popover, then clicks **Profile**, the URL correctly navigates to `/account-settings/profile` but the sidebar remains open — overlaying the profile page content.

This fix adds a call to `setIsSidebarExpanded(_ => false)` inside the Profile click handler, guarded by an `isMobileView` check, so the sidebar is automatically dismissed after navigation on mobile. Desktop behavior is unchanged.

## Motivation and Context

Fixes #3713

On mobile, the sidebar occupies the full viewport width. After clicking Profile, the sidebar stayed open because the click handler only closed the Popover panel (`panelProps["close"]()`) and triggered the router navigation, but never collapsed the sidebar. Adding `setIsSidebarExpanded(_ => false)` (already available in the component scope via `SidebarProvider`) resolves this.

## How did you test it?

- ✅ Ran `npm run re:build` — ReScript compilation successful
- ✅ Code review — verified `isMobileView` and `setIsSidebarExpanded` are in scope at the fix point
- ✅ Verified desktop users are unaffected (`isMobileView` guard ensures sidebar state is only changed on mobile)
- ⏸️ Manual E2E testing steps:
  1. Open the app on a mobile viewport (or DevTools mobile emulation)
  2. Tap the hamburger / open the sidebar
  3. Tap the email at the bottom of the sidebar
  4. Tap **Profile** in the popover menu
  5. Verify the sidebar closes and the Profile page content is visible

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible