### PR TITLE
feat: Add loading on manage users 

### DIFF
--- a/src/screens/UserManagement/UserRevamp/ManageUserModal.res
+++ b/src/screens/UserManagement/UserRevamp/ManageUserModal.res
@@ -6,7 +6,7 @@ let itemsContainerCss = "flex flex-col items-start w-full md:w-auto"
 
 module ChangeRoleSection = {
   @react.component
-  let make = (~defaultRole, ~options) => {
+  let make = (~defaultRole, ~options, ~setScreenState) => {
     open APIUtils
     open LogicUtils
     let getURL = useGetURL()
@@ -34,6 +34,7 @@ module ChangeRoleSection = {
 
     let updateRole = async () => {
       try {
+        setScreenState(_ => PageLoaderWrapper.Loading)
         let url = getURL(~entityName=V1(USERS), ~methodType=Post, ~userType={#UPDATE_ROLE})
         let body =
           [
@@ -41,10 +42,14 @@ module ChangeRoleSection = {
             ("role_id", userRole->JSON.Encode.string),
           ]->getJsonFromArrayOfJson
         let _ = await updateDetails(url, body, Post)
+        setScreenState(_ => PageLoaderWrapper.Success)
         showToast(~message="Role successfully updated!", ~toastType=ToastSuccess)
         RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/users"))
       } catch {
-      | _ => showToast(~message="Failed to update the role", ~toastType=ToastError)
+      | _ => {
+          setScreenState(_ => PageLoaderWrapper.Success)
+          showToast(~message="Failed to update the role", ~toastType=ToastError)
+        }
       }
     }
 
@@ -83,7 +88,7 @@ module ChangeRoleSection = {
 
 module ResendInviteSection = {
   @react.component
-  let make = (~invitationStatus) => {
+  let make = (~invitationStatus, ~setScreenState) => {
     open APIUtils
     open LogicUtils
     let getURL = useGetURL()
@@ -100,6 +105,7 @@ module ResendInviteSection = {
 
     let resendInvite = async () => {
       try {
+        setScreenState(_ => PageLoaderWrapper.Loading)
         let url = getURL(
           ~entityName=V1(USERS),
           ~userType=#RESEND_INVITE,
@@ -108,10 +114,13 @@ module ResendInviteSection = {
         )
         let body = [("email", userEmail->JSON.Encode.string)]->getJsonFromArrayOfJson
         let _ = await updateDetails(url, body, Post)
+        setScreenState(_ => PageLoaderWrapper.Success)
         showToast(~message="Invite resend. Please check your email.", ~toastType=ToastSuccess)
       } catch {
-      | _ =>
-        showToast(~message="Failed to send the invite. Please try again!", ~toastType=ToastError)
+      | _ => {
+          setScreenState(_ => PageLoaderWrapper.Success)
+          showToast(~message="Failed to send the invite. Please try again!", ~toastType=ToastError)
+        }
       }
     }
 
@@ -135,7 +144,7 @@ module ResendInviteSection = {
 
 module DeleteUserRole = {
   @react.component
-  let make = (~setShowModal) => {
+  let make = (~setShowModal, ~setScreenState) => {
     open APIUtils
     open LogicUtils
     let getURL = useGetURL()
@@ -151,13 +160,18 @@ module DeleteUserRole = {
 
     let deleteUser = async () => {
       try {
+        setScreenState(_ => PageLoaderWrapper.Loading)
         let url = getURL(~entityName=V1(USERS), ~methodType=Post, ~userType={#USER_DELETE})
         let body = [("email", userEmail->JSON.Encode.string)]->getJsonFromArrayOfJson
         let _ = await updateDetails(url, body, Delete)
+        setScreenState(_ => PageLoaderWrapper.Success)
         showToast(~message=`User has been successfully deleted.`, ~toastType=ToastSuccess)
         RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/users"))
       } catch {
-      | _ => showToast(~message=`Failed to delete the user.`, ~toastType=ToastError)
+      | _ => {
+          setScreenState(_ => PageLoaderWrapper.Success)
+          showToast(~message=`Failed to delete the user.`, ~toastType=ToastError)
+        }
       }
     }
 
@@ -194,17 +208,17 @@ module DeleteUserRole = {
 
 module ManageUserModalBody = {
   @react.component
-  let make = (~options, ~defaultRole, ~invitationStatus, ~setShowModal) => {
+  let make = (~options, ~defaultRole, ~invitationStatus, ~setShowModal, ~setScreenState) => {
     <div className="flex flex-col gap-16 p-2">
       <p className="text-gray-600 text-start">
         {"Perform various user-related actions such as modifying roles, removing users, or sending a new invitation."->React.string}
       </p>
       <div className="flex flex-col gap-6 ">
-        <ChangeRoleSection options defaultRole />
+        <ChangeRoleSection options defaultRole setScreenState />
         <hr />
-        <ResendInviteSection invitationStatus />
+        <ResendInviteSection invitationStatus setScreenState />
         <hr />
-        <DeleteUserRole setShowModal />
+        <DeleteUserRole setShowModal setScreenState />
       </div>
     </div>
   }
@@ -217,9 +231,11 @@ module ManageUserModal = {
     let getURL = useGetURL()
     let fetchDetails = useGetMethod()
     let (options, setOptions) = React.useState(_ => [])
+    let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
 
     let fetchListOfRoles = async () => {
       try {
+        setScreenState(_ => PageLoaderWrapper.Loading)
         let url = getURL(
           ~entityName=V1(USERS),
           ~userType=#LIST_ROLES_FOR_ROLE_UPDATE,
@@ -228,8 +244,12 @@ module ManageUserModal = {
         )
         let response = await fetchDetails(url)
         setOptions(_ => response->UserUtils.makeSelectBoxOptions)
+        setScreenState(_ => PageLoaderWrapper.Success)
       } catch {
-      | _ => setOptions(_ => [userInfoValue.roleId]->SelectBox.makeOptions)
+      | _ => {
+          setOptions(_ => [userInfoValue.roleId]->SelectBox.makeOptions)
+          setScreenState(_ => PageLoaderWrapper.Success)
+        }
       }
     }
 
@@ -244,13 +264,22 @@ module ManageUserModal = {
       modalHeadingClass=h2OptionalStyle
       setShowModal
       closeOnOutsideClick=true
-      modalClass="m-auto !bg-white md:w-2/5 w-full">
-      <ManageUserModalBody
-        options
-        defaultRole={userInfoValue.roleId}
-        invitationStatus={userInfoValue.status}
-        setShowModal
-      />
+      modalClass="m-auto !bg-white md:w-2/5 w-full min-h-96">
+      <PageLoaderWrapper
+        screenState
+        customLoader={<div className="h-full min-h-96 flex flex-col justify-center items-center">
+          <div className="animate-spin mb-1">
+            <Icon name="spinner" size=20 />
+          </div>
+        </div>}>
+        <ManageUserModalBody
+          options
+          defaultRole={userInfoValue.roleId}
+          invitationStatus={userInfoValue.status}
+          setShowModal
+          setScreenState
+        />
+      </PageLoaderWrapper>
     </Modal>
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added comprehensive loading states to the "Manage user" modal in the Team Management section. This include:
- A loader for the initial role fetching when the modal opens.
- Loading states for role updates, resending invitations, and user deletion actions to provide immediate visual feedback.

## Motivation and Context

Fixes #1335.
This change improves the user experience by showing a clear loading state while waiting for API responses during team management actions.

## How did you test it?

<img width="896" height="649" alt="image" src="https://github.com/user-attachments/assets/507220bf-077e-4112-ab0b-570a72836b42" />


- Manually verified all loading states (initial fetch, update, resend, delete) in the dashboard.
- Verified that the success/error handling correctly resets the screen state.
- Ran `npm run re:build` to ensure code correctness.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
