### PR TITLE
fix: send null for cleared connector metadata so API clears optional fields

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/ConnectorUpdateAuthCreds.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorUpdateAuthCreds.res
@@ -86,6 +86,23 @@ let make = (
     connectorInfo.metadata,
   ))
 
+  let prepareValuesForSubmit = values => {
+    let valuesDict = values->getDictFromJsonObject
+    switch valuesDict->Dict.get("metadata") {
+    | Some(metadataJson) =>
+      let metadataDict = metadataJson->getDictFromJsonObject
+      metadataDict->Dict.toArray->Array.forEach(((key, value)) => {
+        switch value->JSON.Decode.string {
+        | Some(str) if str === "" => metadataDict->Dict.set(key, JSON.Encode.null)
+        | _ => ()
+        }
+      })
+      valuesDict->Dict.set("metadata", metadataDict->JSON.Encode.object)
+    | None => ()
+    }
+    valuesDict->JSON.Encode.object
+  }
+
   let onSubmit = async (values, _) => {
     try {
       let url = getURL(
@@ -93,7 +110,7 @@ let make = (
         ~methodType=Post,
         ~id=Some(connectorInfo.merchant_connector_id),
       )
-      let _ = await updateAPIHook(url, values, Post)
+      let _ = await updateAPIHook(url, prepareValuesForSubmit(values), Post)
       switch getConnectorDetails {
       | Some(fun) => fun()->ignore
       | _ => ()


### PR DESCRIPTION
## Summary

Fixes #4014

Optional connector metadata (e.g. **Purpose of Payment** for WorldpayWPG payout) could be changed but not removed. After deselecting the value, the previous value still persisted because the form sent an empty string and the API did not clear the field.

## Approach

In `ConnectorUpdateAuthCreds.res`, before submitting the connector update request, any metadata field whose value is an empty string is converted to `null`. The API then receives an explicit `null` and clears the field.

- Added `prepareValuesForSubmit(values)` which:
  - Reads the `metadata` object from form values
  - For each key, if the value is `""`, sets it to `JSON.Encode.null`
  - Returns the modified values for the API call
- `onSubmit` now calls `updateAPIHook(url, prepareValuesForSubmit(values), Post)` instead of passing raw `values`

## File changed

- `src/screens/Connectors/PaymentProcessor/ConnectorUpdateAuthCreds.res`

## Test plan

- [ ] Configure WorldpayWPG payout with "Purpose of Payment" = e.g. "Account management"
- [ ] Update connector, deselect "Purpose of Payment" (clear the field), Submit
- [ ] Confirm metadata no longer contains the previous value (reload or re-open connector)

Made with [Cursor](https://cursor.com)