### PR TITLE
fix: prevent filter dropdown from closing on Select All checkbox icon click

### DIFF
--- a/src/components/FilterSelectBox.res
+++ b/src/components/FilterSelectBox.res
@@ -713,7 +713,10 @@ module BaseSelect = {
               condition={filteredOptions->Array.length > 1 &&
                 filteredOptions->Array.find(item => item.value === "Loading...")->Option.isNone}>
               <div
-                onClick={selectAll(noOfSelected === 0)}
+                onClick={ev => {
+                  ev->ReactEvent.Mouse.stopPropagation
+                  selectAll(noOfSelected === 0)(ev)
+                }}
                 className={`flex px-3 py-2 border-b-2 gap-3 text-jp-2-gray-300 items-center text-fs-14 font-medium cursor-pointer`}>
                 <CheckBoxIcon
                   isSelected={noOfSelected !== 0}
@@ -725,7 +728,10 @@ module BaseSelect = {
             </RenderIf>
           } else {
             <div
-              onClick={selectAll(noOfSelected !== options->Array.length)}
+              onClick={ev => {
+                ev->ReactEvent.Mouse.stopPropagation
+                selectAll(noOfSelected !== options->Array.length)(ev)
+              }}
               className={`flex ${isHorizontal
                   ? "flex-col"
                   : "flex-row"} justify-between pr-4 pl-5 pt-6 pb-1 text-base font-semibold ${font.textColor.primaryNormal} cursor-pointer`}>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Added `stopPropagation` to the Select All / Clear All row `onClick` handlers in `FilterSelectBox.BaseSelect` (both desktop and mobile views).

When clicking directly on the checkbox **icon** in the Select All row, the Lottie animation re-renders the SVG on state change, causing the original click target DOM node to be removed. The `OutsideClick` hook (which fires after a 50ms delay via `setTimeout`) then checks `element.contains(clickTarget)` — since the target no longer exists in the DOM, it returns `false`, misidentifying the click as an outside click and closing the dropdown.

Clicking the **text** "Select All" didn't have this issue because text nodes are preserved across re-renders.

The fix calls `ev->ReactEvent.Mouse.stopPropagation` before invoking `selectAll`, preventing the native click event from bubbling to the `window`-level `OutsideClick` listener. The dropdown now only closes when the user clicks "Apply" or clicks outside the dropdown.

## Motivation and Context

Fixes #4031 #4099 — Clicking on the checkbox icon for "Select All" was closing the dropdown, while clicking the text kept it open. Both should behave identically: keep the dropdown open.

## How did you test it?

https://github.com/user-attachments/assets/c4867c1e-4097-41c7-83d0-d62ba1cf3917


- Ran `npm run re:build` — compiles cleanly with 0 errors
- Manual verification of the fix logic: `stopPropagation` on the parent div ensures clicks anywhere in the row (icon or text) trigger `selectAll` while preventing the event from reaching the `OutsideClick` window listener

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible