### PR TITLE
fix: add empty array fallback in payment analytics itemToObjMapper

### DIFF
--- a/src/screens/Analytics/PaymentsAnalytics/PaymentAnalyticsEntity.res
+++ b/src/screens/Analytics/PaymentsAnalytics/PaymentAnalyticsEntity.res
@@ -279,7 +279,8 @@ let itemToObjMapper = json => {
     if isStatusGrouped {
       [{...singleStateInitialValue, authorised_uncaptured_payments: 0}]
     } else {
-      queryData->Array.map(singleStateItemToObjMapper)
+      let arr = queryData->Array.map(singleStateItemToObjMapper)
+      arr->Array.length > 0 ? arr : [singleStateInitialValue]
     }
   }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

In `itemToObjMapper` within `PaymentAnalyticsEntity.res`, when the API returns an empty `queryData` array (no payments in the selected date range) and the response is not status-grouped, the mapper returned an empty array directly. This caused the Payments Analytics page to render a blank/broken state instead of gracefully showing zeros via the initial value.

This fix extracts the mapped result into `arr` and returns `[singleStateInitialValue]` as a fallback when `arr` is empty — consistent with how the `authorisedCount > 0` and `isStatusGrouped` branches already behave.


Current:
<img width="1149" height="627" alt="Screenshot 2026-03-03 at 5 15 14 PM" src="https://github.com/user-attachments/assets/f084946c-5f8b-45b6-9f8c-e758026298a7" />

Expected:
<img width="1151" height="600" alt="Screenshot 2026-03-03 at 5 15 04 PM" src="https://github.com/user-attachments/assets/0f7caf3e-110e-4a89-b8fa-7fc27fe79a1d" />



## Motivation and Context

On the Payments Analytics page, when no payments exist for the selected date range, `queryData` is empty. The existing code passed the empty array downstream, leaving the single-stat tiles (Success Rate, Overall Payments, etc.) in a blank/broken state instead of showing `0` / default values.

## How did you test it?

- ✅ Ran `npm run re:build` — ReScript compilation successful
- ✅ Code review — verified `arr` fallback is consistent with the other branches in `itemToObjMapper`
- ⏸️ Manual E2E testing steps:
  1. Open the Payments Analytics page with a date range that has payment data → stats render correctly
  2. Select a date range with no payment data → page shows `0` / default values instead of a blank screen
  3. Verify the `authorisedCount > 0` and `isStatusGrouped` paths are unaffected

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible