### PR TITLE
fix: default to no threeds in sdk checkout

### DIFF
--- a/src/screens/SDKPayment/SDKProvider/SDKProvider.res
+++ b/src/screens/SDKPayment/SDKProvider/SDKProvider.res
@@ -15,7 +15,7 @@ let defaultValue = {
   setPaymentResult: _ => (),
   showSetupFutureUsage: false,
   setShowSetupFutureUsage: _ => (),
-  sendAuthType: true,
+  sendAuthType: false,
   setSendAuthType: _ => (),
   errorMessage: "",
   setErrorMessage: _ => (),
@@ -48,7 +48,7 @@ let make = (~children) => {
   let (paymentStatus, setPaymentStatus) = React.useState(_ => INCOMPLETE)
   let (clientSecretStatus, setClientSecretStatus) = React.useState(_ => IntialPreview)
   let (showSetupFutureUsage, setShowSetupFutureUsage) = React.useState(_ => false)
-  let (sendAuthType, setSendAuthType) = React.useState(_ => true)
+  let (sendAuthType, setSendAuthType) = React.useState(_ => false)
   let {profileId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
 
   let (paymentResult, setPaymentResult) = React.useState(_ => JSON.Encode.null)

--- a/src/screens/SDKPayment/SDKUtils/SDKPaymentUtils.res
+++ b/src/screens/SDKPayment/SDKUtils/SDKPaymentUtils.res
@@ -79,7 +79,7 @@ let labels = ["Above", "Floating"]
 
 let initialValueForForm = (
   ~showSetupFutureUsage=false,
-  ~sendAuthType=true,
+  ~sendAuthType=false,
   ~customCustomerId="hyperswitch_sdk_demo_id",
   ~profileId,
 ): SDKPaymentTypes.paymentType => {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Fix for issue #4300 

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
- Navigate to Dashboard → SDK Payment
- The authentication type should default to Select Authentication type . 
- Click on Show Preview -> The API response should have authentication_type as null

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
