### PR TITLE
fix: cost observability explore button redirect to fixed URL

### DIFF
--- a/src/Hypersense/HypersenseScreens/HypersenseHome.res
+++ b/src/Hypersense/HypersenseScreens/HypersenseHome.res
@@ -1,25 +1,8 @@
 @react.component
 let make = () => {
-  open APIUtils
-  open LogicUtils
   open PageUtils
 
-  let getURL = useGetURL()
-  let fetchDetails = useGetMethod()
   let mixpanelEvent = MixpanelHook.useSendEvent()
-
-  let onExploreClick = async () => {
-    let hypersenseTokenUrl = getURL(
-      ~entityName=V1(HYPERSENSE),
-      ~methodType=Get,
-      ~hypersenseType=#TOKEN,
-    )
-    let res = await fetchDetails(hypersenseTokenUrl)
-    let token = res->getDictFromJsonObject->getString("token", "")
-    mixpanelEvent(~eventName="cost_observability-redirect")
-    let url = `${Window.env.hypersenseUrl}?auth_token=${token}`
-    url->Window._open
-  }
 
   <div className="flex flex-1 flex-col gap-14 items-center justify-center w-full h-screen">
     <object
@@ -41,7 +24,8 @@ let make = () => {
         text="Explore Cost Observability"
         onClick={_ => {
           mixpanelEvent(~eventName="cost_observability_explore")
-          onExploreClick()->ignore
+          mixpanelEvent(~eventName="cost_observability-redirect")
+          "https://eu.hyperswitch.io/cost-observability/home"->Window._open
         }}
         customTextPaddingClass="pr-0"
         rightIcon={CustomIcon(<Icon name="nd-angle-right" size=16 className="cursor-pointer" />)}


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The "Explore Cost Observability" button on the Cost Observability (Hypersense) home page now opens `https://eu.hyperswitch.io/cost-observability/home` directly in a new tab. Legacy logic that fetched an auth token and redirected with `?auth_token=...` has been removed.

## Motivation and Context

Cost Observability is a modular product; the redirect target is now a fixed URL and no longer requires token-based auth from the control center. Simplifying the flow avoids unnecessary API calls and keeps the button behavior aligned with the current product setup.

## How did you test it?

Manual verification: click "Explore Cost Observability" and confirm the correct URL opens in a new tab. Existing mixpanel events (`cost_observability_explore`, `cost_observability-redirect`) are unchanged.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

Made with [Cursor](https://cursor.com)