### PR TITLE
fix: entity-based initial selection for roles page

### DIFF
--- a/src/screens/UserManagement/UserRevamp/ListRoles.res
+++ b/src/screens/UserManagement/UserRevamp/ListRoles.res
@@ -15,21 +15,21 @@ let make = () => {
     setUserModuleEntity,
   ) = React.useState(_ => #Default)
 
-  let getRolesAvailable = async (userModuleEntity: UserManagementTypes.userModuleTypes) => {
+  let getRolesAvailable = async (selectedEntity: UserManagementTypes.userModuleTypes) => {
     setScreenStateRoles(_ => PageLoaderWrapper.Loading)
     try {
       let userDataURL = getURL(
         ~entityName=V1(USER_MANAGEMENT),
         ~methodType=Get,
         ~userRoleTypes=ROLE_LIST,
-        ~queryParameters=userModuleEntity == #Default
+        ~queryParameters=selectedEntity == #Default
           ? None
-          : Some(`entity_type=${(userModuleEntity :> string)->String.toLowerCase}`),
+          : Some(`entity_type=${(selectedEntity :> string)->String.toLowerCase}`),
       )
       let res = await fetchDetails(userDataURL)
       let rolesData = res->LogicUtils.getArrayDataFromJson(itemToObjMapperForRoles)
       setRolesAvailableData(_ => rolesData->Array.map(Nullable.make))
-      setUserModuleEntity(_ => userModuleEntity)
+      setUserModuleEntity(_ => selectedEntity)
       setScreenStateRoles(_ => PageLoaderWrapper.Success)
     } catch {
     | _ => setScreenStateRoles(_ => PageLoaderWrapper.Error(""))

--- a/src/screens/UserManagement/UserRevamp/ListRolesV2.res
+++ b/src/screens/UserManagement/UserRevamp/ListRolesV2.res
@@ -25,7 +25,7 @@ let make = () => {
     setUserModuleEntity,
   ) = React.useState(_ => initialRolesEntity)
 
-  let getRolesAvailable = async (userModuleEntity: UserManagementTypes.userModuleTypes) => {
+  let getRolesAvailable = async (selectedEntity: UserManagementTypes.userModuleTypes) => {
     setScreenStateRoles(_ => PageLoaderWrapper.Loading)
     try {
       let userDataURL = getURL(
@@ -33,7 +33,7 @@ let make = () => {
         ~methodType=Get,
         ~userRoleTypes=ROLE_LIST,
         ~queryParameters=Some(
-          `groups=true&entity_type=${(userModuleEntity :> string)->String.toLowerCase}`,
+          `groups=true&entity_type=${(selectedEntity :> string)->String.toLowerCase}`,
         ),
       )
       let res = await fetchDetails(userDataURL)
@@ -42,7 +42,7 @@ let make = () => {
       let processedMatrixData = processRolesData(rolesDataRaw)
       setMatrixData(_ => processedMatrixData)
       setFilteredRoles(_ => processedMatrixData.roles)
-      setUserModuleEntity(_ => userModuleEntity)
+      setUserModuleEntity(_ => selectedEntity)
       setScreenStateRoles(_ => PageLoaderWrapper.Success)
     } catch {
     | _ => setScreenStateRoles(_ => PageLoaderWrapper.Error(""))


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Roles V2 was previously tied to a default/hardcoded flow, which caused confusion and inconsistent behavior across entity types (especially for profile users).  
This change aligns the Roles tab behavior with expected user entity context.


https://github.com/user-attachments/assets/2c0f36c9-2719-4d7a-824c-23702adb22b9



## Motivation and Context

bugfix for profile level users.

## How did you test it?

- Verified Roles tab loads with correct default entity:
  - Profile user -> Profile
  - Non-profile user -> Merchant
- Verified API request contains `groups=true&entity_type=<selected_entity>`.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
