### PR TITLE
feat: add tooltip bindings from Blend Design System

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.1.5",
     "@headlessui/react": "2.2.9",
+    "@juspay/blend-design-system": "0.0.35",
     "@iarna/toml": "^2.2.5",
     "@juspay-tech/hyper-js": "^2.0.4",
     "@juspay-tech/react-hyper-js": "^1.2.4",

--- a/src/libraries/BlendDesignSystem.res
+++ b/src/libraries/BlendDesignSystem.res
@@ -1,0 +1,35 @@
+// Blend Design System - ReScript Bindings
+// https://blend.juspay.design/docs/components/tooltip/
+
+module Tooltip = {
+  type tooltipSide = [#TOP | #RIGHT | #LEFT | #BOTTOM]
+  type tooltipAlign = [#START | #END | #CENTER]
+  type tooltipSize = [#SMALL | #LARGE]
+  type tooltipSlotDirection = [#LEFT | #RIGHT]
+
+  @module("@juspay/blend-design-system") @react.component
+  external make: (
+    ~children: React.element,
+    ~content: React.element=?,
+    ~side: tooltipSide=?,
+    ~align: tooltipAlign=?,
+    ~showArrow: bool=?,
+    ~size: tooltipSize=?,
+    ~slot: React.element=?,
+    ~slotDirection: tooltipSlotDirection=?,
+    ~delayDuration: int=?,
+    ~offset: int=?,
+    ~open_: bool=?,
+    ~maxWidth: string=?,
+    ~fullWidth: bool=?,
+    ~disableInteractive: bool=?,
+  ) => React.element = "Tooltip"
+}
+
+// Re-export types for convenience
+module TooltipTypes = {
+  type side = Tooltip.tooltipSide
+  type align = Tooltip.tooltipAlign
+  type size = Tooltip.tooltipSize
+  type slotDirection = Tooltip.tooltipSlotDirection
+}


### PR DESCRIPTION
## Summary
Add ReScript bindings for the Tooltip component from @juspay/blend-design-system.

## Changes
- Add @juspay/blend-design-system dependency (v0.0.35)
- Create ReScript bindings in src/libraries/BlendDesignSystem.res
- Expose Tooltip component with all props

Closes #4336