### PR TITLE
fix: generate reports url bug fix

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -85,9 +85,9 @@ let getV2Url = (
   | REVENUE_RECOVERY_REPORT =>
     switch transactionEntity {
     | #Tenant
-    | #Organization => `/v2/analytics/org/report/payments`
-    | #Merchant => `/v2/analytics/merchant/report/payments`
-    | #Profile => `/v2/analytics/profile/report/payments`
+    | #Organization => `v2/analytics/org/report/payments`
+    | #Merchant => `v2/analytics/merchant/report/payments`
+    | #Profile => `v2/analytics/profile/report/payments`
     }
   | V2_ATTEMPTS_LIST =>
     switch methodType {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
fix for revenue recpvery generate report feature 
<img width="502" height="41" alt="image" src="https://github.com/user-attachments/assets/6db15ab4-9745-4bc5-acee-828e92468889" />

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
Go to reveue recovery invoices page , click on generete report and it should create a report without fail 
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
