### PR TITLE
fix: connectorlistforlive not being parsed from env

### DIFF
--- a/src/server/config.mjs
+++ b/src/server/config.mjs
@@ -43,6 +43,17 @@ function checkEnvValues(env, tomlConfig) {
   return [];
 }
 
+// Update connector list config using environment variables
+function updateConnectorListWithEnv(connectorListConfig, domain) {
+  domain = domain || "default";
+  const result = {};
+  for (const key in connectorListConfig) {
+    const envVar = process.env[`${domain}__connector_list_for_live__${key}`];
+    result[key] = checkEnvValues(envVar, connectorListConfig[key]);
+  }
+  return result;
+}
+
 function processConfigList(configList, body, domain, listType) {
   const result = {};
   for (const key in configList) {
@@ -56,7 +67,6 @@ function processConfigList(configList, body, domain, listType) {
       process.env[
         `${domain}__merchant_config__${listType}__${key}__profile_ids`
       ];
-
     const orgId = checkEnvValues(envOrgIds, configList[key].org_ids).find(
       (id) => body.org_id === id,
     );
@@ -142,6 +152,13 @@ const configHandler = async (
       merchantConfig = updateConfigWithEnv(config.default, domain, "theme");
     } else {
       merchantConfig = updateConfigWithEnv(merchantConfig, "default", "");
+    }
+
+    if (merchantConfig && merchantConfig["connector_list_for_live"]) {
+      merchantConfig["connector_list_for_live"] = updateConnectorListWithEnv(
+        merchantConfig["connector_list_for_live"],
+        domain,
+      );
     }
     if (merchantConfig && merchantConfig["merchant_config"]) {
       delete merchantConfig["merchant_config"];


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
The connectorListforlive was not being from process.env as it was being parsed correctly.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
