### PR TITLE
fix: deny vault-customers-tokens access for profile entity

### DIFF
--- a/src/container/OrchestrationVaultContainer.res
+++ b/src/container/OrchestrationVaultContainer.res
@@ -3,6 +3,7 @@ let make = () => {
   let url = RescriptReactRouter.useUrl()
   let (sampleReport, setSampleReport) = React.useState(_ => false)
   let setIsOrchestrationVault = Recoil.useSetRecoilState(HyperswitchAtom.orchestrationVaultAtom)
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
 
   React.useEffect(() => {
     setIsOrchestrationVault(_ => true)
@@ -23,7 +24,7 @@ let make = () => {
       <EntityScaffold
         entityName="Vault"
         remainingPath
-        access=Access
+        access={checkUserEntity([#Profile]) ? NoAccess : Access}
         renderList={() => <VaultCustomersAndTokens sampleReport setSampleReport />}
         renderShow={(id, _) => <VaultCustomerSummary id sampleReport />}
       />


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Restricted access to the `vault-customers-tokens` route for users with the `Profile` entity type. When a user has a `Profile` entity, the `EntityScaffold` receives `NoAccess` which renders the `<UnauthorizedPage />` instead of the vault customers and tokens list.

This follows the same pattern used elsewhere in the codebase (e.g. `MerchantAccountContainer`) where `checkUserEntity([#Profile])` is used to conditionally restrict access.

## Motivation and Context

The vault customers and tokens feature should not be accessible at the profile entity level, as it is intended for merchant-level access only.

## How did you test it?

Manually verified that profile entity users are redirected to the unauthorized page when navigating to `vault-customers-tokens`.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible