### PR TITLE
fix(config-pmt): display connector label and MCA ID in Configure PMT table

### DIFF
--- a/src/screens/ConfigurePMTs/PaymentMethodConfigTypes.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodConfigTypes.res
@@ -3,6 +3,7 @@ type paymentMethodConfiguration = {
   payment_method_types_index: int,
   merchant_connector_id: string,
   connector_name: string,
+  connector_label: string,
   profile_id: string,
   payment_method: string,
   payment_method_type: string,

--- a/src/screens/ConfigurePMTs/PaymentMethodConfigUtils.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodConfigUtils.res
@@ -126,6 +126,7 @@ let mapPaymentMethodTypeValues = (
   payment_method_types_index: pmtIndex,
   merchant_connector_id: connectorPayload.id,
   connector_name: connectorPayload.connector_name,
+  connector_label: connectorPayload.connector_label,
   profile_id: connectorPayload.profile_id,
   payment_method: paymentMethod,
   payment_method_type: paymentMethodType.payment_method_subtype,

--- a/src/screens/ConfigurePMTs/PaymentMethodEntity.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodEntity.res
@@ -1,6 +1,8 @@
 open PaymentMethodConfigTypes
 type colType =
   | Processor
+  | ConnectorLabel
+  | MCAID
   | PaymentMethodType
   | PaymentMethod
   | CardNetwork
@@ -9,6 +11,8 @@ type colType =
 
 let defaultColumns = [
   Processor,
+  ConnectorLabel,
+  MCAID,
   PaymentMethodType,
   PaymentMethod,
   CountriesAllowed,
@@ -19,6 +23,8 @@ let defaultColumns = [
 let getHeading = colType => {
   switch colType {
   | Processor => Table.makeHeaderInfo(~key="connector_name", ~title="Processor")
+  | ConnectorLabel => Table.makeHeaderInfo(~key="connector_label", ~title="Connector Label")
+  | MCAID => Table.makeHeaderInfo(~key="merchant_connector_id", ~title="MCA ID")
   | PaymentMethod => Table.makeHeaderInfo(~key="payment_method", ~title="Payment Method")
   | PaymentMethodType =>
     Table.makeHeaderInfo(~key="payment_method_type", ~title="Payment Method Type")
@@ -40,6 +46,20 @@ let getCell = (~setReferesh) => {
       Table.CustomCell(
         <PaymentMethodConfig
           paymentMethodConfig config={paymentMethodConfig.connector_name} setReferesh
+        />,
+        "",
+      )
+    | ConnectorLabel =>
+      Table.CustomCell(
+        <PaymentMethodConfig
+          paymentMethodConfig config={paymentMethodConfig.connector_label} setReferesh
+        />,
+        "",
+      )
+    | MCAID =>
+      Table.CustomCell(
+        <PaymentMethodConfig
+          paymentMethodConfig config={paymentMethodConfig.merchant_connector_id} setReferesh
         />,
         "",
       )


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR adds display of connector label and MCA ID in the Configure Payment Method Types (PMT) table.

**Changes made:**
1. Added `connector_label` field to `paymentMethodConfiguration` type in PaymentMethodConfigTypes.res
2. Added mapping for `connector_label` in `mapPaymentMethodTypeValues` function in PaymentMethodConfigUtils.res
3. Added `ConnectorLabel` and `MCAID` column types to the table entity with proper cell rendering in PaymentMethodEntity.res

## Motivation and Context

Fixes #4331

When multiple instances of the same connector exist with different IDs and labels, it was hard to know which PMT belongs to which connector. This change displays both the connector label and MCA ID in the Configure PMT table, making it easier to distinguish between different connector instances.

## How did you test it?

Verified that the columns are properly defined and the data structure supports the connector_label field. The changes follow the existing pattern used for other columns in the same table.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
