### PR TITLE
fix: correct landing page for Intelligent Routing on merchant switch

### DIFF
--- a/src/IntelligentRouting/IntelligentRoutingApp/IntelligentRoutingApp.res
+++ b/src/IntelligentRouting/IntelligentRoutingApp/IntelligentRoutingApp.res
@@ -7,7 +7,7 @@ let make = () => {
     | list{"v2", "dynamic-routing"} => <IntelligentRoutingHome />
     | list{"v2", "dynamic-routing", "home"} => <IntelligentRoutingConfiguration />
     | list{"v2", "dynamic-routing", "dashboard"} => <IntelligentRoutingAnalytics />
-    | _ => <EmptyPage path="/v2/dynamic-routing/home" />
+    | _ => <EmptyPage path="/v2/dynamic-routing" />
     }
   }
 }

--- a/src/entryPoints/ProductUtils.res
+++ b/src/entryPoints/ProductUtils.res
@@ -115,9 +115,9 @@ let getProductUrl = (~productType: ProductTypes.productTypes, ~isLiveMode) => {
     } else {
       appendDashboardPath(~url="v2/recovery/overview")
     }
+  | DynamicRouting => appendDashboardPath(~url=`v2/${productType->getProductRouteName}`)
   | Vault
   | CostObservability
-  | DynamicRouting
   | Orchestration(V2) =>
     appendDashboardPath(~url=`v2/${productType->getProductRouteName}/home`)
   | OnBoarding(_) => ""


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When a user switches to the **Intelligent Routing** product via the merchant selection modal ("Select Merchant"), they were incorrectly landing on `/v2/dynamic-routing/home` (rendering `IntelligentRoutingConfiguration`) instead of `/v2/dynamic-routing` (rendering `IntelligentRoutingHome`).

Two fixes applied:

1. **`IntelligentRoutingApp.res`** — Changed the `_ =>` catch-all fallback path from `/v2/dynamic-routing/home` to `/v2/dynamic-routing`. During a product switch, the URL is not automatically updated, so any unrecognised path hits this fallback. Previously it redirected to `/home` which loaded the configuration screen instead of the home screen.

2. **`ProductUtils.res`** — Moved `DynamicRouting` out of the grouped `Vault | CostObservability | Orchestration(V2)` case (which appends `/home` to the route) and gave it its own explicit case returning `v2/dynamic-routing`. This ensures `getProductUrl` (used in `UnauthorizedPage` and `DefaultHomeUtils`) also returns the correct URL for Intelligent Routing.

## Motivation and Context

The `IntelligentRoutingHome` component is the intended entry point for the Intelligent Routing product. `IntelligentRoutingConfiguration` is a deeper screen that should only be reached by navigating to `/v2/dynamic-routing/home` explicitly, not on initial product load.

## How did you test it?

Manually verified that switching to the Intelligent Routing product via the merchant selection modal lands on `IntelligentRoutingHome` at `/v2/dynamic-routing`.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible