### PR TITLE
refactor: optimize getGroupAccessJson to use Map-based O(1) lookup

### DIFF
--- a/src/utils/Mappers/GroupACLMapper.res
+++ b/src/utils/Mappers/GroupACLMapper.res
@@ -91,36 +91,37 @@ let defaultValueForGroupAccessJson = {
   themeManage: NoAccess,
 }
 
-let getAccessValue = (~groupAccess: groupAccessType, ~groupACL) =>
-  groupACL->Array.find(ele => ele == groupAccess)->Option.isSome ? Access : NoAccess
-
-// TODO: Refactor to not call function for every group
-let getGroupAccessJson = groupACL => {
-  operationsView: getAccessValue(~groupAccess=OperationsView, ~groupACL),
-  operationsManage: getAccessValue(~groupAccess=OperationsManage, ~groupACL),
-  connectorsView: getAccessValue(~groupAccess=ConnectorsView, ~groupACL),
-  connectorsManage: getAccessValue(~groupAccess=ConnectorsManage, ~groupACL),
-  workflowsView: getAccessValue(~groupAccess=WorkflowsView, ~groupACL),
-  workflowsManage: getAccessValue(~groupAccess=WorkflowsManage, ~groupACL),
-  analyticsView: getAccessValue(~groupAccess=AnalyticsView, ~groupACL),
-  usersView: getAccessValue(~groupAccess=UsersView, ~groupACL),
-  usersManage: getAccessValue(~groupAccess=UsersManage, ~groupACL),
-  merchantDetailsView: getAccessValue(~groupAccess=MerchantDetailsView, ~groupACL),
-  merchantDetailsManage: getAccessValue(~groupAccess=MerchantDetailsManage, ~groupACL),
-  organizationManage: getAccessValue(~groupAccess=OrganizationManage, ~groupACL),
-  accountView: getAccessValue(~groupAccess=AccountView, ~groupACL),
-  accountManage: getAccessValue(~groupAccess=AccountManage, ~groupACL),
-  themeView: getAccessValue(~groupAccess=ThemeView, ~groupACL),
-  themeManage: getAccessValue(~groupAccess=ThemeManage, ~groupACL),
-}
-
 let convertValueToMapGroup = arrayValue => {
   let userGroupACLMap: Map.t<groupAccessType, authorization> = Map.make()
   arrayValue->Array.forEach(value => userGroupACLMap->Map.set(value, Access))
   userGroupACLMap
 }
+
 let convertValueToMapResources = arrayValue => {
   let resourceACLMap: Map.t<resourceAccessType, authorization> = Map.make()
   arrayValue->Array.forEach(value => resourceACLMap->Map.set(value, Access))
   resourceACLMap
+}
+
+let getGroupAccessJson = groupACL => {
+  let accessMap = convertValueToMapGroup(groupACL)
+  let getAccess = key => accessMap->Map.get(key)->Option.isSome ? Access : NoAccess
+  {
+    operationsView: getAccess(OperationsView),
+    operationsManage: getAccess(OperationsManage),
+    connectorsView: getAccess(ConnectorsView),
+    connectorsManage: getAccess(ConnectorsManage),
+    workflowsView: getAccess(WorkflowsView),
+    workflowsManage: getAccess(WorkflowsManage),
+    analyticsView: getAccess(AnalyticsView),
+    usersView: getAccess(UsersView),
+    usersManage: getAccess(UsersManage),
+    merchantDetailsView: getAccess(MerchantDetailsView),
+    merchantDetailsManage: getAccess(MerchantDetailsManage),
+    organizationManage: getAccess(OrganizationManage),
+    accountView: getAccess(AccountView),
+    accountManage: getAccess(AccountManage),
+    themeView: getAccess(ThemeView),
+    themeManage: getAccess(ThemeManage),
+  }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR resolves the existing `TODO` comment in `GroupACLMapper.res` by refactoring `getGroupAccessJson` to avoid redundant linear scans of the ACL array.

**Changes made:**
- Removed the standalone `getAccessValue` helper (which performed an `Array.find` per field call)
- Reordered `getGroupAccessJson` to appear after the existing `convertValueToMapGroup` utility
- `getGroupAccessJson` now builds a `Map` once via `convertValueToMapGroup`, then uses `Map.get` (O(1)) for each of the 16 field lookups

**Before (inefficient):**
```rescript
let getAccessValue = (~groupAccess: groupAccessType, ~groupACL) =>
  groupACL->Array.find(ele => ele == groupAccess)->Option.isSome ? Access : NoAccess

// TODO: Refactor to not call function for every group
let getGroupAccessJson = groupACL => {
  operationsView: getAccessValue(~groupAccess=OperationsView, ~groupACL),
  // ... 15 more Array.find calls (O(n) each)
}
```

**After (optimised):**
```rescript
let getGroupAccessJson = groupACL => {
  let accessMap = convertValueToMapGroup(groupACL)   // single O(n) pass
  let getAccess = key => accessMap->Map.get(key)->Option.isSome ? Access : NoAccess
  {
    operationsView: getAccess(OperationsView),        // O(1) lookup
    // ... 15 more O(1) Map.get calls
  }
}
```

## Motivation and Context

Closes #4511

The original implementation iterated over the full `groupACL` array **once per field** (16 fields × O(n) = **O(16n)**). By building a `Map` in a single O(n) pass upfront and reusing it for all lookups, total complexity becomes **O(n + 16)** — essentially O(n). This also removes the need for the intermediate `getAccessValue` helper and resolves the TODO comment left in the code.

## How did you test it?

- Ran `npm run re:build` — build succeeded with no errors
- Ran `npm run re:format` — all files are properly formatted
- Verified that `getGroupAccessJson` produces the same ACL mapping output as before

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible