### PR TITLE
fix: patch @juspay/blend-design-system for React 18 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "re:start": "rescript -w",
     "re:format": "rescript format -all",
     "test:start": "cross-env default__endpoints__api_url=http://localhost:8080 default__features__email=true node dist/server/server.js",
-    "postinstall": "git config core.hooksPath .githooks && chmod +x .githooks/commit-msg",
+    "postinstall": "git config core.hooksPath .githooks && chmod +x .githooks/commit-msg && patch-package",
     "cy:open": "sh cypress/start_hyperswitch.sh && cypress open",
     "cy:run": "sh cypress/start_hyperswitch.sh && cypress run",
     "local:cy:open": "cypress open",
@@ -53,6 +53,7 @@
     "monaco-editor-webpack-plugin": "^7.0.1",
     "nyc": "^15.1.0",
     "otplib": "^12.0.1",
+    "patch-package": "^8.0.1",
     "postcss": "^8.3.6",
     "postcss-loader": "^4.1.0",
     "prettier": "^3.1.0",
@@ -71,6 +72,7 @@
     "@iarna/toml": "^2.2.5",
     "@juspay-tech/hyper-js": "^2.0.4",
     "@juspay-tech/react-hyper-js": "^1.2.4",
+    "@juspay/blend-design-system": "^0.0.36",
     "@monaco-editor/react": "^4.4.5",
     "@rescript/core": "^0.6.0",
     "@rescript/react": "^0.12.0",
@@ -102,8 +104,7 @@
     "react-window": "^1.8.8",
     "recoil": "^0.1.2",
     "rescript-webapi": "0.10.0",
-    "tailwindcss": "^3.0.0",
-    "@juspay/blend-design-system": "0.0.36-beta.2"
+    "tailwindcss": "^3.0.0"
   },
   "packageManager": "yarn@3.2.1"
 }

--- a/patches/@juspay+blend-design-system+0.0.36.patch
+++ b/patches/@juspay+blend-design-system+0.0.36.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/@juspay/blend-design-system/dist/main.js b/node_modules/@juspay/blend-design-system/dist/main.js
+index 85cb20e..46fbe41 100644
+--- a/node_modules/@juspay/blend-design-system/dist/main.js
++++ b/node_modules/@juspay/blend-design-system/dist/main.js
+@@ -26427,7 +26427,7 @@ function Nae() {
+       implementation: h
+     };
+   }
+-  var s = e.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
++  var s = e.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE || e.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+   function o(l, c) {
+     if (l === "font") return "";
+     if (typeof c == "string")
+@@ -26594,7 +26594,7 @@ See https://react.dev/link/invalid-hook-call for tips about how to debug and fix
+       },
+       p: 0,
+       findDOMNode: null
+-    }, c = Symbol.for("react.portal"), h = o.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
++    }, c = Symbol.for("react.portal"), h = o.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE || o.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+     typeof Map == "function" && Map.prototype != null && typeof Map.prototype.forEach == "function" && typeof Set == "function" && Set.prototype != null && typeof Set.prototype.clear == "function" && typeof Set.prototype.forEach == "function" || console.error(
+       "React depends on Map and Set built-in types. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills"
+     ), Oa.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = l, Oa.createPortal = function(u, g) {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Upgrades `@juspay/blend-design-system` from `0.0.36-beta.2` → `0.0.36` stable
- Adds a `patch-package` fix to make Blend compatible with React 18
- Adds `patch-package` as a dev dependency with `postinstall` hook to auto-apply the patch after every `npm install`

**Patch details:**

Blend's bundled ReactDOM was built against React 19 and uses `__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE`. This property does not exist in React 18, so the patch adds a fallback to React 18's equivalent:

```diff
- var s = e.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+ var s = e.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE || e.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;

- h = o.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+ h = o.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE || o.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
```

## Motivation and Context

Fixes #4514

Without this fix, any Blend component that opens a Popover/dropdown (DateRangePicker, SingleSelect, MultiSelect, Menu) crashes immediately on click with:

```
TypeError: Cannot read properties of undefined (reading 'T')
  at Oa.flushSync (blend-design-system/dist/main.js)
```

Upstream issue filed on Blend repo: https://github.com/juspay/blend-design-system/issues/1282

> ⚠️ Delete `patches/@juspay+blend-design-system+0.0.36.patch` and remove `&& patch-package` from `postinstall` when upgrading to React 19.

## How did you test it?

Tested manually — clicking the Blend DateRangePicker component no longer crashes after the patch is applied.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible