### PR TITLE
refactor: parallelize dashboard API calls in setUpDashboard

### DIFF
--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -74,10 +74,12 @@ let make = () => {
         Promise.resolve()
       }
       let userGroupACLFetch = fetchUserGroupACL()
-      let merchantResponse = await merchantDetailsFetch
-      let _ = await merchantConfigFetch
-      let _ = await merchantListFetch
-      let _ = await userGroupACLFetch
+      let (merchantResponse, _, _, _) = await Promise.all4((
+        merchantDetailsFetch,
+        merchantConfigFetch,
+        merchantListFetch,
+        userGroupACLFetch,
+      ))
       setActiveProductValue(merchantResponse.product_type)
       setShowSideBar(_ => true)
     } catch {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes #4523

In `setUpDashboard` (`HyperSwitchApp.res`), four API calls were being made sequentially:

1. `fetchMerchantAccountDetails`
2. `fetchMerchantSpecificConfig`
3. `fetchMerchantList` (non-internal users only)
4. `fetchUserGroupACL`

This change fires all four requests concurrently by storing the promises before awaiting them, then awaiting all results together. The only ordering constraint preserved is that `setActiveProductValue` is called after `merchantResponse` is resolved, which depends on `fetchMerchantAccountDetails`.

**Before:**
```rescript
let merchantResponse = await fetchMerchantAccountDetails(~version)  // 400ms
let _ = await fetchMerchantSpecificConfig()                          // +300ms
let _ = await fetchMerchantList()                                    // +500ms
let _ = await fetchUserGroupACL()                                    // +300ms
// Total: ~1500ms sequential waterfall
```

**After:**
```rescript
// All four fired concurrently
let merchantDetailsFetch = fetchMerchantAccountDetails(~version)
let merchantConfigFetch = fetchMerchantSpecificConfig()
let merchantListFetch = if !isInternalUser { fetchMerchantList() } else { Promise.resolve(()) }
let userGroupACLFetch = fetchUserGroupACL()
// Await results
let merchantResponse = await merchantDetailsFetch
let _ = await merchantConfigFetch
let _ = await merchantListFetch
let _ = await userGroupACLFetch
// Total: ~500ms (slowest single request)
```

Waterfall pattern currently-
<img width="1693" height="687" alt="Screenshot 2026-03-24 at 4 10 29 PM" src="https://github.com/user-attachments/assets/abbc9882-7d00-4d5f-9fd8-7cf67d08008d" />

With this PR changes-
<img width="1722" height="818" alt="Screenshot 2026-03-24 at 4 10 06 PM" src="https://github.com/user-attachments/assets/337793d4-5fcb-435c-b249-75e3cb6e4810" />



## Motivation and Context

Dashboard load time was slow due to a sequential API waterfall in `setUpDashboard`. These four calls were identified as having **no inter-dependencies**:

| API Call | Inputs | Depends on other calls? |
|---|---|---|
| `fetchMerchantAccountDetails` | `version` from context | No |
| `fetchMerchantSpecificConfig` | `orgId`, `merchantId`, `profileId` from context | No |
| `fetchMerchantList` | feature flags atom, context | No |
| `fetchUserGroupACL` | none | No |

Since none of these reads data written by another, they can safely be parallelised. Expected saving: **~1000–1200ms** off the dashboard setup critical path.

## How did you test it?

- Verified via Chrome DevTools → Network tab that all four requests now initiate at the same timestamp instead of in a staircase waterfall pattern.
- Verified dashboard renders correctly after the change with no regressions in merchant data, ACL, or product type selection.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible