### PR TITLE
perf: Enable CssMinimizerPlugin in production build

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -31,8 +31,8 @@ const mergeProd = () => {
             },
           }),
           // For webpack@5 you can use the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), uncomment the next line
-          // `...`,
-          // new CssMinimizerPlugin(),
+          `...`,
+          new CssMinimizerPlugin(),
         ],
       },
     },


### PR DESCRIPTION
## Summary
- Uncomment `CssMinimizerPlugin` and the `...` spread syntax in the `optimization.minimizer` array of `webpack.prod.js`
- This enables CSS minification alongside Terser in production builds, reducing CSS bundle size

Closes #4550

## Test plan
- [ ] Verify production build completes successfully (`npm run build`)
- [ ] Confirm CSS output files are minified (smaller size compared to before)
- [ ] Ensure JS minification via Terser still works as expected