### PR TITLE
perf: Add Cache-Control headers to config/theme API endpoints

### DIFF
--- a/src/server/config.mjs
+++ b/src/server/config.mjs
@@ -168,6 +168,7 @@ const configHandler = async (
     res.writeHead(200, {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "max-age=300, must-revalidate",
     });
     res.end(JSON.stringify(merchantConfig));
   } catch (error) {
@@ -211,6 +212,7 @@ const merchantConfigHandler = async (
     res.writeHead(200, {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "max-age=300, must-revalidate",
     });
     res.end(JSON.stringify(data));
   } catch (error) {

--- a/src/server/theme.mjs
+++ b/src/server/theme.mjs
@@ -36,6 +36,7 @@ const themeConfigHandler = async (
     res.writeHead(200, {
       "Content-Type": "application/json",
       "Access-Control-Allow-Origin": "*",
+      "Cache-Control": "max-age=300, must-revalidate",
     });
     res.end(config);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add `Cache-Control: max-age=300, must-revalidate` header to the config and theme API endpoint responses
- Enables browser-side caching for 5 minutes, reducing redundant requests for rarely-changing configuration data
- Applied to `configHandler`, `merchantConfigHandler`, and `themeConfigHandler` response headers

## Test plan
- [ ] Verify config endpoint returns `Cache-Control: max-age=300, must-revalidate` header
- [ ] Verify theme endpoint returns `Cache-Control: max-age=300, must-revalidate` header
- [ ] Verify merchant config endpoint returns `Cache-Control: max-age=300, must-revalidate` header
- [ ] Confirm browser caches responses and does not re-fetch within 5 minutes
- [ ] Confirm stale responses trigger revalidation after 5 minutes

Closes #4554