### PR TITLE
perf: Lazy-load product app modules in HyperSwitchApp

### DIFF
--- a/src/Hypersense/HypersenseApp/HypersenseAppLazy.res
+++ b/src/Hypersense/HypersenseApp/HypersenseAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./HypersenseApp.res.js"))

--- a/src/IntelligentRouting/IntelligentRoutingApp/IntelligentRoutingAppLazy.res
+++ b/src/IntelligentRouting/IntelligentRoutingApp/IntelligentRoutingAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./IntelligentRoutingApp.res.js"))

--- a/src/Orchestration/OrchestrationAppLazy.res
+++ b/src/Orchestration/OrchestrationAppLazy.res
@@ -1,0 +1,7 @@
+open LazyUtils
+
+type props = {
+  setScreenState: (PageLoaderWrapper.viewType => PageLoaderWrapper.viewType) => unit,
+}
+
+let make: props => React.element = reactLazy(() => import_("./OrchestrationApp.res.js"))

--- a/src/OrchestrationV2/OrchestrationV2AppLazy.res
+++ b/src/OrchestrationV2/OrchestrationV2AppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./OrchestrationV2App.res.js"))

--- a/src/Recon/ReconApp/ReconAppLazy.res
+++ b/src/Recon/ReconApp/ReconAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./ReconApp.res.js"))

--- a/src/ReconEngine/ReconEngineApp/ReconEngineAppLazy.res
+++ b/src/ReconEngine/ReconEngineApp/ReconEngineAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./ReconEngineApp.res.js"))

--- a/src/RevenueRecovery/RevenueRecoveryApp/RevenueRecoveryAppLazy.res
+++ b/src/RevenueRecovery/RevenueRecoveryApp/RevenueRecoveryAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./RevenueRecoveryApp.res.js"))

--- a/src/Vault/VaultApp/VaultAppLazy.res
+++ b/src/Vault/VaultApp/VaultAppLazy.res
@@ -1,0 +1,5 @@
+open LazyUtils
+
+type props = {}
+
+let make: props => React.element = reactLazy(() => import_("./VaultApp.res.js"))

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -242,21 +242,45 @@ let make = () => {
                         | (OnBoarding(_), _) => <DefaultOnboardingPage />
                         /* RECON V1 PRODUCT */
 
-                        | (Recon(V1), _) => <ReconEngineApp />
+                        | (Recon(V1), _) =>
+                          <ReactSuspenseWrapper>
+                            <ReconEngineAppLazy />
+                          </ReactSuspenseWrapper>
 
                         /* RECON V2 PRODUCT */
 
-                        | (Recon(V2), _) => <ReconApp />
+                        | (Recon(V2), _) =>
+                          <ReactSuspenseWrapper>
+                            <ReconAppLazy />
+                          </ReactSuspenseWrapper>
 
                         /* RECOVERY PRODUCT */
-                        | (Recovery, _) => <RevenueRecoveryApp />
+                        | (Recovery, _) =>
+                          <ReactSuspenseWrapper>
+                            <RevenueRecoveryAppLazy />
+                          </ReactSuspenseWrapper>
                         /* VAULT PRODUCT */
-                        | (Vault, _) => <VaultApp />
+                        | (Vault, _) =>
+                          <ReactSuspenseWrapper>
+                            <VaultAppLazy />
+                          </ReactSuspenseWrapper>
                         /* HYPERSENSE PRODUCT */
-                        | (CostObservability, _) => <HypersenseApp />
-                        | (DynamicRouting, _) => <IntelligentRoutingApp />
-                        | (Orchestration(V2), _) => <OrchestrationV2App />
-                        | (Orchestration(V1), _) => <OrchestrationApp setScreenState />
+                        | (CostObservability, _) =>
+                          <ReactSuspenseWrapper>
+                            <HypersenseAppLazy />
+                          </ReactSuspenseWrapper>
+                        | (DynamicRouting, _) =>
+                          <ReactSuspenseWrapper>
+                            <IntelligentRoutingAppLazy />
+                          </ReactSuspenseWrapper>
+                        | (Orchestration(V2), _) =>
+                          <ReactSuspenseWrapper>
+                            <OrchestrationV2AppLazy />
+                          </ReactSuspenseWrapper>
+                        | (Orchestration(V1), _) =>
+                          <ReactSuspenseWrapper>
+                            <OrchestrationAppLazy setScreenState />
+                          </ReactSuspenseWrapper>
                         | (UnknownProduct, _) => React.null
                         }}
                       </ErrorBoundary>


### PR DESCRIPTION
## Summary
- Replace eager imports of 8 product app modules with `React.lazy` wrappers to reduce initial bundle size
- Affected modules: `ReconApp`, `ReconEngineApp`, `VaultApp`, `HypersenseApp`, `IntelligentRoutingApp`, `OrchestrationV2App`, `OrchestrationApp`, `RevenueRecoveryApp`
- Each lazy component is wrapped in `ReactSuspenseWrapper` for a loading fallback, following the existing codebase pattern (e.g., `DragNDropDemoLazy`, `Lottie`, `MonacoEditor`)

Closes #4555

## Test plan
- [ ] Verify each product app loads correctly when navigated to (no regressions)
- [ ] Confirm the loading fallback appears briefly while the lazy chunk loads
- [ ] Check that the initial JS bundle size is reduced (product app code is now code-split)
- [ ] Test error boundary behavior when a lazy chunk fails to load