### PR TITLE
feat: add product multi-select with chip UI and toggle

### DIFF
--- a/src/screens/Home/ProdIntent/ProdIntentForm.res
+++ b/src/screens/Home/ProdIntent/ProdIntentForm.res
@@ -28,6 +28,17 @@ let make = (~isFromMilestoneCard=false) => {
       let hideHeader = valueForProdIntent->getBool(IsCompleted->getStringFromVariant, false)
       if !hideHeader {
         valueForProdIntent->Dict.set(POCemail->getStringFromVariant, email->JSON.Encode.string)
+        // Pre-select orchestration if no products were previously selected
+        let existingProducts = valueForProdIntent->LogicUtils.getStrArrayFromDict(
+          SelectedProducts->getStringFromVariant,
+          [],
+        )
+        if existingProducts->Array.length === 0 {
+          valueForProdIntent->Dict.set(
+            SelectedProducts->getStringFromVariant,
+            ["orchestration"]->Array.map(JSON.Encode.string)->JSON.Encode.array,
+          )
+        }
       }
       setIsProdIntentCompleted(_ => Some(hideHeader))
       setInitialValues(_ => valueForProdIntent)

--- a/src/screens/Home/ProdIntent/ProdIntentHelper.res
+++ b/src/screens/Home/ProdIntent/ProdIntentHelper.res
@@ -1,3 +1,111 @@
+let productOptions = [
+  ("orchestration", "Orchestration"),
+  ("recon", "Reconciliation"),
+  ("dynamic_routing", "Intelligent Routing"),
+  ("recovery", "Revenue Recovery"),
+  ("cost_observability", "Cost Observability"),
+]
+
+module ProductSelector = {
+  @react.component
+  let make = () => {
+    let form = ReactFinalForm.useForm()
+    let fieldInput = ReactFinalForm.useField("selected_products").input
+    let selectedProducts =
+      fieldInput.value->LogicUtils.getStrArrayFromJson
+
+    let allSelected = selectedProducts->Array.length === productOptions->Array.length
+
+    let updateProducts = updated => {
+      form.change(
+        "selected_products",
+        updated->Array.map(JSON.Encode.string)->JSON.Encode.array,
+      )
+    }
+
+    let toggleProduct = product => {
+      let updated = if selectedProducts->Array.includes(product) {
+        selectedProducts->Array.filter(p => p !== product)
+      } else {
+        selectedProducts->Array.concat([product])
+      }
+      updateProducts(updated)
+    }
+
+    let toggleAll = () => {
+      let updated = if allSelected {
+        []
+      } else {
+        productOptions->Array.map(((value, _)) => value)
+      }
+      updateProducts(updated)
+    }
+
+    let unselectedProducts =
+      productOptions->Array.filter(((value, _)) => !(selectedProducts->Array.includes(value)))
+
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-gray-700">
+          {"Request production access for:"->React.string}
+        </p>
+        <label className="inline-flex items-center gap-2 cursor-pointer">
+          <div className="relative">
+            <input
+              type_="checkbox"
+              className="sr-only peer"
+              checked={allSelected}
+              onChange={_ => toggleAll()}
+            />
+            <div
+              className="w-9 h-5 bg-gray-200 rounded-full peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-full"
+            />
+          </div>
+          <span className="text-sm text-gray-600"> {"All products"->React.string} </span>
+        </label>
+      </div>
+      <div
+        className="flex flex-wrap gap-2 min-h-10 p-3 rounded-lg bg-gray-50 border border-gray-200">
+        {if selectedProducts->Array.length > 0 {
+          productOptions
+          ->Array.filter(((value, _)) => selectedProducts->Array.includes(value))
+          ->Array.map(((value, label)) =>
+            <button
+              key={value}
+              type_="button"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm bg-white border border-gray-300 text-gray-700 cursor-pointer hover:bg-gray-50"
+              onClick={_ => toggleProduct(value)}>
+              {label->React.string}
+              <Icon name="times" size=10 />
+            </button>
+          )
+          ->React.array
+        } else {
+          <span className="text-sm text-gray-400 py-1.5">
+            {"Select at least one product"->React.string}
+          </span>
+        }}
+      </div>
+      <RenderIf condition={unselectedProducts->Array.length > 0}>
+        <div className="flex flex-wrap gap-2">
+          {unselectedProducts
+          ->Array.map(((value, label)) =>
+            <button
+              key={value}
+              type_="button"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm border border-gray-200 text-gray-600 cursor-pointer hover:border-gray-300 hover:bg-gray-50"
+              onClick={_ => toggleProduct(value)}>
+              <span className="text-gray-400"> {"+"->React.string} </span>
+              {label->React.string}
+            </button>
+          )
+          ->React.array}
+        </div>
+      </RenderIf>
+    </div>
+  }
+}
+
 module CountryField = {
   @react.component
   let make = (~fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -10,18 +10,10 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
-  let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
-
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
       let bodyValues = values->getBody->JSON.Encode.object
-      bodyValues
-      ->LogicUtils.getDictFromJsonObject
-      ->Dict.set(
-        "product_type",
-        activeProduct->ProductUtils.getProductStringName->JSON.Encode.string,
-      )
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
       showToast(
@@ -39,9 +31,6 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   }
 
   let onSubmit = (values, _) => {
-    values
-    ->LogicUtils.getDictFromJsonObject
-    ->Dict.set("product_type", activeProduct->ProductUtils.getProductStringName->JSON.Encode.string)
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
@@ -70,9 +59,13 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
               <div className="flex flex-col gap-12 w-full">
+                <div className="px-5">
+                  <ProdIntentHelper.ProductSelector />
+                </div>
                 <FormRenderer.DesktopRow>
                   <div className="flex flex-col gap-5">
                     {formFields
+                    ->Array.filter(col => col !== SelectedProducts)
                     ->Array.mapWithIndex((column, index) =>
                       <FormRenderer.FieldRenderer
                         key={index->Int.toString}

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -7,6 +7,7 @@ type prodFormColumnType =
   | Country
   | Website
   | POCName
+  | SelectedProducts
 
 let getStringFromVariant = key => {
   switch key {
@@ -16,6 +17,7 @@ let getStringFromVariant = key => {
   | Country => "business_location"
   | Website => "business_website"
   | POCName => "poc_name"
+  | SelectedProducts => "selected_products"
   }
 }
 
@@ -86,6 +88,12 @@ let validateEmptyValue = (key, errors) => {
       key->getStringFromVariant,
       "Please enter a Point of Contact Name"->JSON.Encode.string,
     )
+  | SelectedProducts =>
+    Dict.set(
+      errors,
+      key->getStringFromVariant,
+      "Please select at least one product"->JSON.Encode.string,
+    )
   | _ => ()
   }
 }
@@ -100,7 +108,7 @@ let getFormField = columnType => {
   }
 }
 
-let formFields = [BusinessName, Country, Website, POCName, POCemail]
+let formFields = [SelectedProducts, BusinessName, Country, Website, POCName, POCemail]
 
 let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
 
@@ -130,9 +138,16 @@ let validateForm = (values, ~fieldsToValidate: array<prodFormColumnType>) => {
   let valuesDict = values->getDictFromJsonObject
 
   fieldsToValidate->Array.forEach(key => {
-    let value = LogicUtils.getString(valuesDict, key->getStringFromVariant, "")
-
-    value->String.length < 1 ? key->validateEmptyValue(errors) : key->validateCustom(errors, value)
+    switch key {
+    | SelectedProducts =>
+      let products = LogicUtils.getStrArrayFromDict(valuesDict, key->getStringFromVariant, [])
+      if products->Array.length < 1 {
+        key->validateEmptyValue(errors)
+      }
+    | _ =>
+      let value = LogicUtils.getString(valuesDict, key->getStringFromVariant, "")
+      value->String.length < 1 ? key->validateEmptyValue(errors) : key->validateCustom(errors, value)
+    }
   })
 
   errors->JSON.Encode.object
@@ -177,5 +192,14 @@ let getBody = (values: JSON.t) => {
     "business_country_name",
     valuesDict->getOptionString("business_country_name"),
   )
+
+  let selectedProducts = valuesDict->getStrArrayFromDict(SelectedProducts->getStringFromVariant, [])
+  if selectedProducts->Array.length > 0 {
+    prodOnboardingpayload->Dict.set(
+      SelectedProducts->getStringFromVariant,
+      selectedProducts->Array.map(JSON.Encode.string)->JSON.Encode.array,
+    )
+  }
+
   prodOnboardingpayload
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR adds a chip-based product multi-select to the production access form, allowing users to request production access for multiple products in a single submission.

**Changes made:**

- **`ProdIntentHelper.res`** — New `ProductSelector` component with:
  - Selected products displayed as chips with × remove button inside a gray container
  - Unselected products shown as `+ Label` add buttons below the container
  - "All products" toggle switch (CSS-only `peer-checked` pattern) to select/deselect all at once
  - Form state managed via `ReactFinalForm.useForm().change()` writing a JSON string array to `selected_products`

- **`ProdVerifyModalUtils.res`** — Added `SelectedProducts` variant to `prodFormColumnType`, with:
  - Key mapping: `SelectedProducts => "selected_products"`
  - Array-based validation: requires at least one product selected
  - `getBody` serializes `selected_products` as a JSON array (`["orchestration", "recon", ...]`)
  - Added to `formFields` for validation

- **`ProdVerifyModal.res`** — Renders `<ProdIntentHelper.ProductSelector />` above the form fields. Removed `product_type` injection from both `updateProdDetails` and `onSubmit` (and the `activeProduct` context import)

- **`ProdIntentForm.res`** — Pre-selects `["orchestration"]` when the form opens fresh (no prior submission). Preserves any previously saved selection.

**Before:**
- Form injected `product_type` from the active product context (single product)
- No product selection UI

**After:**
- Users see a chip-based multi-select at the top of the form
- Orchestration pre-selected by default
- `selected_products` array sent in payload instead of `product_type`

## Motivation and Context

Part of the unified production access form initiative (#4600). Users should be able to request production access for multiple products in a single form submission rather than submitting separate requests per product.

Closes #4603

## How did you test it?

- Verified Orchestration is pre-selected when opening the form fresh
- Verified clicking `+ Label` buttons adds products as chips inside the container
- Verified clicking × on chips removes them
- Verified "All products" toggle selects and deselects all products
- Verified form submission fails with validation error when no products selected
- Verified `selected_products` is sent as a JSON array in the API payload
- Verified `product_type` is no longer injected from `activeProduct`

## Checklist

- [x] I formatted the code `cargo +nightly fmt --all`
- [x] I addressed lints thrown by `cargo clippy`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible