### PR TITLE
fix: show seconds when milliseconds are absent in DateCell

### DIFF
--- a/src/components/TableUtils.res
+++ b/src/components/TableUtils.res
@@ -476,11 +476,7 @@ module DateCell = {
     }
   }
 
-  let removeSecondAndMilliseconds = format =>
-    format
-    ->String.replace(":ss.SSS", "")
-    ->String.replace(":ss", "")
-    ->String.replace(".SSS", "")
+  let removeMilliseconds = format => format->String.replace(".SSS", "")
 
   @react.component
   let make = (
@@ -501,7 +497,7 @@ module DateCell = {
       : dateFormat
     let millisecondsPart = getMillisecondsPart(timestamp)
     let showMilliseconds = millisecondsPart != "000"
-    let dateFormat = showMilliseconds ? dateFormat : dateFormat->removeSecondAndMilliseconds
+    let dateFormat = showMilliseconds ? dateFormat : dateFormat->removeMilliseconds
 
     let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZoneInFloat()
     let getFormattedDate = dateStr => {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

In `DateCell`, when a timestamp has no sub-second precision (milliseconds = "000"), the previous `removeSecondAndMilliseconds` function was replacing `:ss.SSS` as a single unit — stripping **both** seconds and milliseconds from the format string `"MMM DD, YYYY hh:mm:ss.SSS A"`, resulting in `"MMM DD, YYYY hh:mm A"`.

This caused two regressions introduced by #4308:
- **Dispute details** (`connector_created_at`, `connector_updated_at`, `created_at`): string timestamps without sub-second precision showed times without seconds (e.g., `12:43 PM` instead of `12:43:07 PM`)
- **Payouts in global search** (`created_at`): unix timestamps in seconds always produce `.000Z` milliseconds → seconds were always stripped

<img width="1532" height="993" alt="Screenshot 2026-03-27 at 4 00 45 PM" src="https://github.com/user-attachments/assets/bd988144-f53d-416b-addc-06b2c4f5bcc2" />
<img width="1548" height="966" alt="Screenshot 2026-03-27 at 4 35 05 PM" src="https://github.com/user-attachments/assets/ec641d6a-9402-4446-be37-9975311ddd6e" />

**Fix**: Renamed to `removeMilliseconds` and simplified to only replace `.SSS` with `""`, keeping seconds intact in the display format.

Before: `"MMM DD, YYYY hh:mm:ss.SSS A"` → `"MMM DD, YYYY hh:mm A"` ❌  
After: `"MMM DD, YYYY hh:mm:ss.SSS A"` → `"MMM DD, YYYY hh:mm:ss A"` ✓  
With ms: `"MMM DD, YYYY hh:mm:ss.SSS A"` → unchanged ✓

## Motivation and Context

Fixes juspay/hyperswitch-cloud#15234 (comment by reviewer noting milliseconds/seconds missing in Dispute details and Payouts global search).

## How did you test it?

Manually verified the logic: the `removeMilliseconds` function now only strips `.SSS` from the format, leaving `:ss` intact. Seconds are always shown; milliseconds are shown only when non-zero.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible