### PR TITLE
feat : Org level custom role

### DIFF
--- a/src/screens/UserManagement/UserRevamp/CreateCustomRole.res
+++ b/src/screens/UserManagement/UserRevamp/CreateCustomRole.res
@@ -42,7 +42,7 @@ module NewCustomRoleInputFields = {
     <div className="flex justify-between">
       <div className="flex flex-col gap-4 w-full">
         <FormRenderer.FieldRenderer
-          field={userRole->roleScope}
+          field={roleScope(userRole, #Merchant)}
           fieldWrapperClass="w-4/5"
           labelClass="!text-black !text-base !-ml-[0.5px]"
         />

--- a/src/screens/UserManagement/UserRevamp/CreateCustomRoleUtils.res
+++ b/src/screens/UserManagement/UserRevamp/CreateCustomRoleUtils.res
@@ -11,7 +11,7 @@ let updateScope = (scopes, action, targetScope: groupScopeType) => {
 
 let getInitialValuesForForm = (entityType: UserInfoTypes.entity) =>
   [
-    ("role_scope", "merchant"->JSON.Encode.string),
+    ("role_scope", (entityType :> string)->String.toLowerCase->JSON.Encode.string),
     ("role_name", ""->JSON.Encode.string),
     ("entity_type", (entityType :> string)->String.toLowerCase->JSON.Encode.string),
   ]->Dict.fromArray

--- a/src/screens/UserManagement/UserRevamp/CreateCustomRoleV2.res
+++ b/src/screens/UserManagement/UserRevamp/CreateCustomRoleV2.res
@@ -89,7 +89,7 @@ module RenderPermissionModule = {
 module NewCustomRoleInputFields = {
   open CommonAuthHooks
   @react.component
-  let make = (~onEntityTypeChange) => {
+  let make = (~onEntityTypeChange, ~currentEntityType: UserInfoTypes.entity) => {
     let {userRole} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
     <div className="flex flex-col gap-4">
@@ -99,7 +99,7 @@ module NewCustomRoleInputFields = {
           field=createCustomRole fieldWrapperClass="w-3/5" labelClass="!text-black !-ml-[0.5px]"
         />
         <FormRenderer.FieldRenderer
-          field={userRole->roleScope}
+          field={roleScope(userRole, currentEntityType)}
           fieldWrapperClass="w-fit"
           labelClass="!text-black !-ml-[0.5px]"
         />
@@ -259,7 +259,7 @@ let make = () => {
           validate={values => validateCustomRoleForm(values, ~permissionModules, ~isV2=true)}
           onSubmit
           formClass="flex flex-col gap-8">
-          <NewCustomRoleInputFields onEntityTypeChange=handleEntityTypeChange />
+          <NewCustomRoleInputFields onEntityTypeChange=handleEntityTypeChange currentEntityType />
           <div className="flex flex-col gap-6">
             <div className={`${body.md.semibold} text-nd_gray-700`}>
               {"Select Permission Level"->React.string}

--- a/src/screens/UserManagement/UserRevamp/UserManagementUtils.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementUtils.res
@@ -11,8 +11,14 @@ let createCustomRole = FormRenderer.makeFieldInfo(
   ~isRequired=true,
 )
 
-let roleScope = userRole => {
-  let roleScopeArray = ["Merchant", "Organization"]->Array.map(item => {
+let roleScope = (userRole, entityType: UserInfoTypes.entity) => {
+  let validScopes = switch entityType {
+  | #Organization => ["Organization"]
+  | #Merchant => ["Organization", "Merchant"]
+  | #Profile => ["Organization", "Merchant", "Profile"]
+  | _ => ["Organization", "Merchant"]
+  }
+  let roleScopeArray = validScopes->Array.map(item => {
     let option: SelectBox.dropdownOption = {
       label: item,
       value: item->String.toLowerCase,
@@ -34,7 +40,7 @@ let roleScope = userRole => {
 }
 
 let entityTypeField = (~onEntityTypeChange: option<entity => unit>=?, ~userHasAccess) => {
-  let entityTypeVariants: array<UserInfoTypes.entity> = [#Merchant, #Profile]
+  let entityTypeVariants: array<UserInfoTypes.entity> = [#Organization, #Merchant, #Profile]
   let entityTypeArray = entityTypeVariants->Array.map(entityVariant => {
     let entityString = (entityVariant :> string)->String.toLowerCase
     let option: SelectBox.dropdownOption = {

--- a/src/utils/RouteUtils.res
+++ b/src/utils/RouteUtils.res
@@ -8,7 +8,6 @@ open UserInfoTypes
  *   RouteUtils.getPath(~path="/payments", version)
  *   RouteUtils.getPath(~path=`/payments/${paymentId}`, version)
  */
-
 let v2Prefix = "/v2/orchestration"
 
 let getPath = (~path: string, version: version) =>


### PR DESCRIPTION
## Type of Change

  - [ ] Bugfix
  - [x] New feature
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description

  - Add `#Organization` to the entity type dropdown in the V2 custom role creation form (`UserManagementUtils.res`)
  - Add `"Profile"` to the role scope (Role Visibility) dropdown
  - Make role scope options dynamic based on selected entity type — valid scopes filter to only those >= the selected entity level:
    - Organization → `[Organization]`
    - Merchant → `[Organization, Merchant]`
    - Profile → `[Organization, Merchant, Profile]`
  - Default `role_scope` initial value now matches the selected `entity_type` instead of being hardcoded to `"merchant"`

  ## Motivation and Context

  Previously, the entity type dropdown was missing `Organization` and the scope dropdown was missing `Profile`, blocking users from creating
  org-level or profile-scoped custom roles from the UI even though the backend fully supports both. Additionally, the scope dropdown did not
  update when entity type changed, making it possible to submit invalid combinations.

  Fixes #4524

  ## How did you test it?

  Tested manually:
  - `Organization` appears in the entity type dropdown
  - Selecting `Organization` entity type filters scope dropdown to only show `Organization`
  - Selecting `Merchant` entity type shows `[Organization, Merchant]` in scope dropdown
  - Selecting `Profile` entity type shows `[Organization, Merchant, Profile]` in scope dropdown
  - Default scope auto-selects to match the chosen entity type on form load/reset
  - `yarn re:start` compiles with no errors

  ## Where to test it?

  - [x] INTEG
  - [ ] SANDBOX
  - [ ] PROD

  ## Checklist

  - [x] I ran `npm run re:build`
  - [x] I reviewed submitted code
  - [ ] I added unit tests for my changes where possible