### PR TITLE
chore: align custom spacing config with Blend unit token scale

### DIFF
--- a/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/AnalyzeData.res
+++ b/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/AnalyzeData.res
@@ -214,7 +214,7 @@ let make = (~onNextClick, ~setReviewFields, ~setIsUpload, ~fileUInt8Array, ~setF
     None
   }, [selectedField])
 
-  <div className="w-500-px">
+  <div className="w-[500px]">
     {IntelligentRoutingHelper.stepperHeading(
       ~title="Choose Your Data Source",
       ~subTitle="Select a data source to begin your simulation",

--- a/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/IntelligentRoutingConfiguration.res
+++ b/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/IntelligentRoutingConfiguration.res
@@ -44,8 +44,8 @@ let make = () => {
       </h1>
     </>
 
-  <div className="h-774-px w-full">
-    <div className="flex flex-row h-890-px">
+  <div className="h-[774px] w-full">
+    <div className="flex flex-row h-[890px]">
       <VerticalStepIndicator
         titleElement=intelligentRoutingTitleElement sections currentStep backClick
       />

--- a/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/ReviewDataSummary.res
+++ b/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingConfiguration/ReviewDataSummary.res
@@ -84,7 +84,7 @@ let make = (~reviewFields, ~isUpload=false, ~fileUInt8Array) => {
     </div>
 
   <div>
-    <div className="w-500-px">
+    <div className="w-[500px]">
       {IntelligentRoutingHelper.stepperHeading(
         ~title="Review Data Summary",
         ~subTitle="Explore insights in the dashboard",

--- a/src/Recon/ReconScreens/ReconConfiguration/ReconConfiguration.res
+++ b/src/Recon/ReconScreens/ReconConfiguration/ReconConfiguration.res
@@ -28,14 +28,14 @@ let make = (~setShowOnBoarding, ~currentStep, ~setCurrentStep) => {
       </h1>
     </>
 
-  <div className="flex flex-col gap-10 h-774-px">
+  <div className="flex flex-col gap-10 h-[774px]">
     <div className="flex h-full mt-10">
       <div className="flex flex-col">
         <VerticalStepIndicator titleElement=reconTitleElement sections currentStep backClick />
       </div>
       <div className="mx-12 mt-16 overflow-y-auto">
         <div
-          className="absolute z-10 top-76-px left-0 w-full py-4 px-10 bg-orange-50 flex justify-between items-center">
+          className="absolute z-10 top-[76px] left-0 w-full py-4 px-10 bg-orange-50 flex justify-between items-center">
           <div className="flex gap-4 items-center">
             <Icon name="nd-information-triangle" size=24 />
             <p className="text-nd_gray-600 text-base leading-6 font-medium">
@@ -43,7 +43,7 @@ let make = (~setShowOnBoarding, ~currentStep, ~setCurrentStep) => {
             </p>
           </div>
         </div>
-        <div className="w-500-px">
+        <div className="w-[500px]">
           {switch currentStep.sectionId->getSectionVariantFromString {
           | #orderDataConnection =>
             <OrderDataConnection

--- a/src/ReconEngine/ReconEngineActivityFAB.res
+++ b/src/ReconEngine/ReconEngineActivityFAB.res
@@ -2,7 +2,7 @@
 let make = () => {
   let (showDrawer, setShowDrawer) = React.useState(_ => false)
 
-  let iconClass = showDrawer ? "right-500-px" : "right-0"
+  let iconClass = showDrawer ? "right-[500px]" : "right-0"
 
   <>
     <div

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAuditLogDrawer/ReconEngineAuditLogDrawer.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAuditLogDrawer/ReconEngineAuditLogDrawer.res
@@ -92,7 +92,7 @@ let make = (~showDrawer: bool) => {
 
   <>
     <div
-      className={`fixed right-0 top-0 h-full w-500-px bg-white shadow-2xl rounded-l-xl overflow-hidden transform transition-all duration-300 ease-in-out flex flex-col z-20 ${transitionClass}`}>
+      className={`fixed right-0 top-0 h-full w-[500px] bg-white shadow-2xl rounded-l-xl overflow-hidden transform transition-all duration-300 ease-in-out flex flex-col z-20 ${transitionClass}`}>
       <div className="flex flex-col gap-2 p-6 border-b border-nd_br_gray-150 bg-white">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesHelper.res
@@ -158,7 +158,7 @@ module TransformationHistoryActionsComponent = {
           ->Int.toString})`}
         modalHeadingClass={`text-nd_gray-800 ${heading.sm.semibold}`}
         alignModal="justify-center items-center"
-        modalClass="flex flex-col justify-start !h-400-px w-2/5 !overflow-y-scroll !bg-white dark:!bg-jp-gray-lightgray_background"
+        modalClass="flex flex-col justify-start !h-[400px] w-2/5 !overflow-y-scroll !bg-white dark:!bg-jp-gray-lightgray_background"
         childClass="relative h-full">
         <div className="h-full relative">
           <div className="absolute inset-0 overflow-scroll px-8 py-4 modal-scrollbar mb-20">

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineExceptionsVolumeColumnGraph.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineExceptionsVolumeColumnGraph.res
@@ -81,7 +81,7 @@ let make = (~ruleId: string) => {
     <PageLoaderWrapper
       screenState
       customUI={<NewAnalyticsHelper.NoData height="h-72" message="No data available" />}
-      customLoader={<Shimmer styleClass="w-full h-344-px rounded-b-xl" />}>
+      customLoader={<Shimmer styleClass="w-full h-[344px] rounded-b-xl" />}>
       <div className="w-full p-4">
         <ColumnGraph options={ColumnGraphUtils.getColumnGraphOptions(volumeData)} />
       </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineReconciledVolumeColumnGraph.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineReconciledVolumeColumnGraph.res
@@ -83,7 +83,7 @@ let make = (~ruleId: string) => {
     <PageLoaderWrapper
       screenState
       customUI={<NewAnalyticsHelper.NoData height="h-72" message="No data available" />}
-      customLoader={<Shimmer styleClass="w-full h-344-px rounded-b-xl" />}>
+      customLoader={<Shimmer styleClass="w-full h-[344px] rounded-b-xl" />}>
       <div className="w-full p-4">
         <ColumnGraph options={ColumnGraphUtils.getColumnGraphOptions(volumeData)} />
       </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineRules/ReconEngineRuleDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineRules/ReconEngineRuleDetails.res
@@ -102,7 +102,7 @@ module SearchIdentifier = {
                       deselectDisable=true
                       disableSelect=true
                       fullLength=true
-                      customButtonStyle="w-147-px h-10"
+                      customButtonStyle="w-[147px] h-10"
                     />
                   </div>
                   <div className="flex items-center mt-6">
@@ -119,7 +119,7 @@ module SearchIdentifier = {
                       deselectDisable=true
                       disableSelect=true
                       fullLength=true
-                      customButtonStyle="w-147-px h-10"
+                      customButtonStyle="w-[147px] h-10"
                     />
                   </div>
                 </div>
@@ -214,7 +214,7 @@ module MappingRules = {
                           deselectDisable=true
                           disableSelect=true
                           fullLength=true
-                          customButtonStyle="w-147-px h-10"
+                          customButtonStyle="w-[147px] h-10"
                         />
                       </div>
                       <div className="flex items-center mt-6">
@@ -231,7 +231,7 @@ module MappingRules = {
                           deselectDisable=true
                           disableSelect=true
                           fullLength=true
-                          customButtonStyle="w-147-px h-10"
+                          customButtonStyle="w-[147px] h-10"
                         />
                       </div>
                     </div>
@@ -312,7 +312,7 @@ module TriggerRules = {
             deselectDisable=true
             disableSelect=true
             fullLength=true
-            customButtonStyle="w-147-px h-10"
+            customButtonStyle="w-[147px] h-10"
           />
         </div>
         <SelectBox.BaseDropdown
@@ -413,7 +413,7 @@ module SourceTargetAccount = {
             deselectDisable=true
             disableSelect=true
             fullLength=true
-            customButtonStyle="w-147-px h-10"
+            customButtonStyle="w-[147px] h-10"
           />
           <p className={`${body.md.regular} text-nd_gray-500 mt-2 ml-1`}>
             {"Where the original transaction is recorded"->React.string}
@@ -450,7 +450,7 @@ module SourceTargetAccount = {
                   deselectDisable=true
                   disableSelect=true
                   fullLength=true
-                  customButtonStyle="w-147-px h-10"
+                  customButtonStyle="w-[147px] h-10"
                 />
                 <RenderIf condition={splitText->isNonEmptyString}>
                   <p className={`${body.md.semibold} text-nd_gray-600 my-3`}>

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
@@ -262,7 +262,7 @@ let make = (
     | (#chooseDataSource, _) =>
       <PageWrapper
         title="Choose Your Data Source" subTitle="Select a data source to begin your simulation">
-        <div className="-m-1 mb-10 flex flex-col gap-7 w-540-px">
+        <div className="-m-1 mb-10 flex flex-col gap-7 w-[540px]">
           {dataSource
           ->Array.map(dataSource => {
             switch dataSource {
@@ -333,7 +333,7 @@ let make = (
       <PageWrapper
         title="Where do you process your payments"
         subTitle="Link the payment processor you use for handling subscription transactions.">
-        <div className="-m-1 mb-10 flex flex-col gap-7 w-540-px">
+        <div className="-m-1 mb-10 flex flex-col gap-7 w-[540px]">
           <PageLoaderWrapper screenState>
             <Form onSubmit initialValues validate=validateMandatoryField>
               <SelectBox.BaseDropdown
@@ -392,7 +392,7 @@ let make = (
       </PageWrapper>
     | (#connectProcessor, #activePaymentMethods) =>
       <PageWrapper title="Payment Methods" subTitle="Configure your PaymentMethods.">
-        <div className="mb-10 flex flex-col gap-7 w-540-px">
+        <div className="mb-10 flex flex-col gap-7 w-[540px]">
           <PageLoaderWrapper screenState>
             <Form onSubmit initialValues validate=validateMandatoryField>
               <div className="flex flex-col mb-5 gap-3 ">

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
@@ -9,7 +9,7 @@ let make = (~initialValues, ~merchantId, ~onNextClick) => {
     title="Setup Subscription Webhook"
     subTitle="Configure this endpoint in the subscription management system dashboard under webhook settings for us to pick up failed payments for recovery.">
     <div className="mb-10 flex flex-col gap-7">
-      <div className="mb-10 flex flex-col gap-7 w-540-px">
+      <div className="mb-10 flex flex-col gap-7 w-[540px]">
         <ConnectorWebhookPreview
           merchantId
           connectorName=connectorInfoDict.id

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboarding.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboarding.res
@@ -42,7 +42,7 @@ let make = () => {
         RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url=defaultPath))
       }}
     />
-    <div className="flex flex-row ml-14 mt-16 w-540-px">
+    <div className="flex flex-row ml-14 mt-16 w-[540px]">
       <RecoveryOnboardingPayments
         currentStep
         setConnectorID={setPaymentConnectorID}

--- a/src/Themes/ThemeHelper.res
+++ b/src/Themes/ThemeHelper.res
@@ -232,7 +232,7 @@ module LineageFormContent = {
           />
           <div className="relative pl-8">
             <div
-              className="absolute left-4 top-0 bottom-0 h-50-px w-px border-l-2 border-dashed border-gray-300"
+              className="absolute left-4 top-0 bottom-0 h-[50px] w-px border-l-2 border-dashed border-gray-300"
             />
             <div
               className="absolute left-4 top-12 w-4 h-px border-t-2 border-dashed border-gray-300"
@@ -256,7 +256,7 @@ module LineageFormContent = {
           />
           <div className="relative pl-8">
             <div
-              className="absolute left-4 top-0 bottom-0 h-50-px w-px border-l-2 border-dashed border-gray-300"
+              className="absolute left-4 top-0 bottom-0 h-[50px] w-px border-l-2 border-dashed border-gray-300"
             />
             <div
               className="absolute left-4 top-12 w-4 h-px border-t-2 border-dashed border-gray-300"
@@ -271,7 +271,7 @@ module LineageFormContent = {
           </div>
           <div className="relative pl-16">
             <div
-              className="absolute left-12 top-0 bottom-0 h-50-px w-px border-l-2 border-dashed border-gray-300"
+              className="absolute left-12 top-0 bottom-0 h-[50px] w-px border-l-2 border-dashed border-gray-300"
             />
             <div
               className="absolute left-12 top-12 w-4 h-px border-t-2 border-dashed border-gray-300"

--- a/src/Themes/ThemeScreens/ThemeList/ThemeListHelper.res
+++ b/src/Themes/ThemeScreens/ThemeList/ThemeListHelper.res
@@ -5,7 +5,7 @@ module NoThemesFound = {
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
 
     <RenderIf condition={themeListArray->Array.length == 0}>
-      <div className="flex flex-col items-center justify-center text-center mt-300-px">
+      <div className="flex flex-col items-center justify-center text-center mt-[300px]">
         <div className="flex flex-col items-center gap-2 ">
           <p className={`${heading.sm.semibold}`}> {"No Themes Available"->React.string} </p>
           <p className={`${body.md.regular} text-nd_gray-500 mb-6`}>

--- a/src/Vault/VaultScreens/VaultCustomersAndTokens/VaultCustomersAndTokens.res
+++ b/src/Vault/VaultScreens/VaultCustomersAndTokens/VaultCustomersAndTokens.res
@@ -41,7 +41,7 @@ module NoDataFoundComponent = {
 
     <div className="mt-7">
       <div
-        className="flex bg-nd_gray-50 h-11 gap-72-px border rounded-t-lg overflow-x-auto whitespace-nowrap">
+        className="flex bg-nd_gray-50 h-11 gap-[72px] border rounded-t-lg overflow-x-auto whitespace-nowrap">
         {fieldArray
         ->Array.map(item =>
           <p className="pl-6 font-medium text-fs-13 text-nd_gray-400 p-3">

--- a/src/Vault/VaultScreens/VaultCustomersAndTokens/VaultCustomersTotalDataView.res
+++ b/src/Vault/VaultScreens/VaultCustomersAndTokens/VaultCustomersTotalDataView.res
@@ -2,7 +2,7 @@ module TotalNumbersViewCard = {
   @react.component
   let make = (~title, ~count, ~countTextCss="font-semibold text-2xl text-nd_gray-600") => {
     <div
-      className={`flex flex-col  gap-3 h-20 justify-between bg-white text-semibold border rounded-md pt-3 px-4 pb-2.5 w-306-px my-8 border-nd_gray-150`}>
+      className={`flex flex-col  gap-3 h-20 justify-between bg-white text-semibold border rounded-md pt-3 px-4 pb-2.5 w-[306px] my-8 border-nd_gray-150`}>
       <p className="font-medium text-xs text-nd_gray-400"> {title->React.string} </p>
       <RenderIf condition={!(count->LogicUtils.isEmptyString)}>
         <p className=countTextCss> {count->React.string} </p>

--- a/src/components/Button.res
+++ b/src/components/Button.res
@@ -361,9 +361,9 @@ let make = (
   let paddingClass = customPaddingClass->Option.getOr("")
 
   let customWidthClass = switch buttonSize {
-  | Large => "w-147-px"
-  | Medium => "w-145-px"
-  | Small => "w-137-px"
+  | Large => "w-[147px]"
+  | Medium => "w-[145px]"
+  | Small => "w-[137px]"
   | _ => ""
   }
 

--- a/src/entryPoints/HyperSwitchApp.res
+++ b/src/entryPoints/HyperSwitchApp.res
@@ -107,7 +107,7 @@ let make = () => {
 
   let leftCustomClass = switch activeProduct {
   | Orchestration(V1) => ""
-  | _ => "-left-180-px"
+  | _ => "-left-[180px]"
   }
 
   let showGlobalSearchBar = switch merchantDetailsTypedValue.product_type {

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -103,7 +103,7 @@ module ListBaseComp = {
       {switch user {
       | #Merchant =>
         <div
-          className={`cursor-pointer ${secondaryTextColor} hover:bg-opacity-80 flex flex-col gap-0.5 ${body.sm.semibold} w-267-px px-4 py-3`}>
+          className={`cursor-pointer ${secondaryTextColor} hover:bg-opacity-80 flex flex-col gap-0.5 ${body.sm.semibold} w-[267px] px-4 py-3`}>
           <div className="flex flex-row w-full justify-between">
             <div className="flex gap-2">
               <span className={`${secondaryTextColor} opacity-50 ${body.sm.medium}`}>

--- a/src/fragments/VerticalStepIndicator/VerticalStepIndicator.res
+++ b/src/fragments/VerticalStepIndicator/VerticalStepIndicator.res
@@ -10,7 +10,7 @@ let make = (
 
   let rows = sections->Array.length->Int.toString
   let currIndex = sections->findSectionIndex(currentStep.sectionId)
-  <div className="flex flex-col gap-y-6 h-774-px w-334-px sticky overflow-y-auto py-5">
+  <div className="flex flex-col gap-y-6 h-[774px] w-[334px] sticky overflow-y-auto py-5">
     <div className="flex items-center gap-x-3 px-6">
       <Icon
         name="nd-arrow-left"

--- a/src/screens/Connectors/BillingProcessor/BillingProcessorHelper.res
+++ b/src/screens/Connectors/BillingProcessor/BillingProcessorHelper.res
@@ -73,7 +73,7 @@ module CustomConnectorCellWithDefaultIcon = {
           </div>
           <RenderIf condition={connector.id == billing_processor_id}>
             <div
-              className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-2-px rounded-lg ${body.sm.semibold}`}>
+              className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-0.5 rounded-lg ${body.sm.semibold}`}>
               {"Default"->React.string}
             </div>
           </RenderIf>

--- a/src/screens/Connectors/BillingProcessor/BillingProcessorHome.res
+++ b/src/screens/Connectors/BillingProcessor/BillingProcessorHome.res
@@ -205,7 +205,7 @@ let make = () => {
     <>
       <RenderIf condition={connectorInfo.merchant_connector_id == billing_processor_id}>
         <div
-          className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-2-px rounded-lg ${body.md.medium}`}>
+          className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-0.5 rounded-lg ${body.md.medium}`}>
           {"Default"->React.string}
         </div>
       </RenderIf>

--- a/src/screens/Connectors/VaultProcessors/VaultProcessorsHome.res
+++ b/src/screens/Connectors/VaultProcessors/VaultProcessorsHome.res
@@ -176,7 +176,7 @@ let make = () => {
     <div className="flex gap-6 items-center">
       <RenderIf condition={connectorInfo.merchant_connector_id == vault_processor_id}>
         <div
-          className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-2-px rounded-lg ${body.md.medium}`}>
+          className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-0.5 rounded-lg ${body.md.medium}`}>
           {"Default"->React.string}
         </div>
       </RenderIf>

--- a/src/screens/Helpers/HelperComponents.res
+++ b/src/screens/Helpers/HelperComponents.res
@@ -156,7 +156,7 @@ module ConnectorCustomCell = {
         </div>
         <RenderIf condition={showDefaultTag}>
           <div
-            className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-2-px rounded-lg ${body.sm.semibold}`}>
+            className={`border border-nd_gray-200 bg-nd_gray-50 px-2 py-0.5 rounded-lg ${body.sm.semibold}`}>
             {"Default"->React.string}
           </div>
         </RenderIf>

--- a/src/screens/NewAnalytics/RoutingAnalytics/LeastCostRoutingAnalytics/LeastCostRoutingAnalyticsMetrics/LeastCostRoutingAnalyticsMetrics.res
+++ b/src/screens/NewAnalytics/RoutingAnalytics/LeastCostRoutingAnalytics/LeastCostRoutingAnalyticsMetrics/LeastCostRoutingAnalyticsMetrics.res
@@ -63,8 +63,8 @@ module LeastCostAnalyticsBasicMetricsCard = {
     <div className="grid md:grid-cols-2 gap-4">
       <PageLoaderWrapper
         screenState
-        customUI={<NewAnalyticsHelper.NoData height="h-84-px" />}
-        customLoader={<Shimmer styleClass="h-84-px w-full rounded-xl" />}>
+        customUI={<NewAnalyticsHelper.NoData height="h-[84px]" />}
+        customLoader={<Shimmer styleClass="h-[84px] w-full rounded-xl" />}>
         <div
           className="flex flex-col border rounded-xl p-4 bg-white shadow-xs border-nd_gray-200 gap-6 2xl:gap-2">
           <p className={`${body.md.medium} text-nd_gray-400`}> {"Total Savings"->React.string} </p>
@@ -76,8 +76,8 @@ module LeastCostAnalyticsBasicMetricsCard = {
       </PageLoaderWrapper>
       <PageLoaderWrapper
         screenState
-        customUI={<NewAnalyticsHelper.NoData height="h-84-px" />}
-        customLoader={<Shimmer styleClass="h-84-px w-full rounded-xl" />}>
+        customUI={<NewAnalyticsHelper.NoData height="h-[84px]" />}
+        customLoader={<Shimmer styleClass="h-[84px] w-full rounded-xl" />}>
         <div
           className="flex flex-col border rounded-xl p-4 bg-white shadow-xs border-nd_gray-200 gap-6 2xl:gap-2">
           <p className={`${body.md.medium} text-nd_gray-400`}>
@@ -160,8 +160,8 @@ module LeastCostAnalyticsRegulationMetricsCard = {
     <div className="grid md:grid-cols-2 gap-4">
       <PageLoaderWrapper
         screenState
-        customUI={<NewAnalyticsHelper.NoData height="h-84-px" />}
-        customLoader={<Shimmer styleClass="h-84-px w-full rounded-xl" />}>
+        customUI={<NewAnalyticsHelper.NoData height="h-[84px]" />}
+        customLoader={<Shimmer styleClass="h-[84px] w-full rounded-xl" />}>
         <div
           className="flex flex-col border rounded-xl p-4 bg-white shadow-xs border-nd_gray-200 gap-2">
           <p className={`${body.md.medium} text-nd_gray-400`}>
@@ -174,8 +174,8 @@ module LeastCostAnalyticsRegulationMetricsCard = {
       </PageLoaderWrapper>
       <PageLoaderWrapper
         screenState
-        customUI={<NewAnalyticsHelper.NoData height="h-84-px" />}
-        customLoader={<Shimmer styleClass="h-84-px w-full rounded-xl" />}>
+        customUI={<NewAnalyticsHelper.NoData height="h-[84px]" />}
+        customLoader={<Shimmer styleClass="h-[84px] w-full rounded-xl" />}>
         <div
           className="flex flex-col border rounded-xl p-4 bg-white shadow-xs border-nd_gray-200 gap-2">
           <p className={`${body.md.medium} text-nd_gray-400`}>

--- a/src/screens/PaymentLinkThemeConfigurator/PaymentLinkThemeConfiguratorTool.res
+++ b/src/screens/PaymentLinkThemeConfigurator/PaymentLinkThemeConfiguratorTool.res
@@ -127,7 +127,7 @@ module ConfiguratorForm = {
                 />
                 <style> {React.string(configuratorScrollbarCss)} </style>
                 <div
-                  className="flex flex-col gap-3 rounded-lg border border-nd_gray-300 p-4 h-650-px overflow-scroll configurator-scrollbar !m-0">
+                  className="flex flex-col gap-3 rounded-lg border border-nd_gray-300 p-4 h-[650px] overflow-scroll configurator-scrollbar !m-0">
                   <FieldRenderer field={makeLogoField()} fieldWrapperClass="!w-full" />
                   <FieldRenderer field={makePaymentButtonTextField()} fieldWrapperClass="!w-full" />
                   <FieldRenderer
@@ -212,7 +212,7 @@ module ConfiguratorForm = {
           </div>
           <div className="w-full">
             <div className="sticky top-4 w-full">
-              <div className="bg-nd_gray-25 rounded-lg border border-nd_gray-300 p-3.5 h-650-px">
+              <div className="bg-nd_gray-25 rounded-lg border border-nd_gray-300 p-3.5 h-[650px]">
                 <div className="flex items-center justify-between">
                   <h4 className={`text-nd_gray-600 mb-2 ${body.xl.medium}`}>
                     {"Live Preview"->React.string}
@@ -226,7 +226,7 @@ module ConfiguratorForm = {
                       </div>
                     : React.null}
                 </div>
-                <div className=" rounded-lg w-full h-590-px flex flex-col bg-white">
+                <div className=" rounded-lg w-full h-[590px] flex flex-col bg-white">
                   {switch (previewLoading, previewError, previewHtml) {
                   | (true, _, _) =>
                     <div className="flex items-center justify-center h-full w-full">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,8 +33,7 @@ module.exports = {
         400: "4",
       },
       margin: {
-        "15-px": "15px",
-        "300-px": "300px",
+        "15-px": "15px", // Blend unit[15] — not in Tailwind default scale
       },
       height: {
         "1.1-rem": "1.125rem",
@@ -59,26 +58,10 @@ module.exports = {
         "30-vh": "30vh",
         "40-vh": "40vh",
         "75-vh": "75vh",
-        "50-px": "50px",
-        "68-px": "68px",
-        "84-px": "84px",
-        "120-px": "120px",
-        "130-px": "130px",
-        "195-px": "195px",
-        "344-px": "344px",
-        "400-px": "400px",
-        "590-px": "590px",
-        "650-px": "650px",
-        "700-px": "700px",
-        "774-px": "774px",
-        "840-px": "840px",
-        "890-px": "890px",
+        "120-px": "120px", // Blend unit[120] — not in Tailwind default scale
         "12.5-rem": "12.5rem",
         onBoardingSupplier: "calc(100vh - 300px)",
         modalContentHeight: "calc(100vh - 140px)",
-      },
-      padding: {
-        "2-px": "2px",
       },
       minWidth: {
         "25-rem": "25rem",
@@ -87,17 +70,10 @@ module.exports = {
         "15-rem": "15rem",
         "25-rem": "25rem",
         "30-rem": "30rem",
-        "750-px": "750px",
-      },
-      minHeight: {
-        "500-px": "500px",
       },
       inset: {
-        "5-px": "5px",
-        "76-px": "76px",
-        "120-px": "120px",
-        "180-px": "180px",
-        "500-px": "500px",
+        "5-px": "5px", // Blend unit[5] — not in Tailwind default scale
+        "120-px": "120px", // Blend unit[120] — not in Tailwind default scale
       },
       letterSpacing: {
         compressed: "-2px",
@@ -107,8 +83,7 @@ module.exports = {
         extended: "2px",
       },
       width: {
-        "1-px": "1px",
-        "90-px": "90px",
+        "1-px": "1px", // Blend unit[1] — not in Tailwind default scale
         100: "25rem",
         133: "35rem",
         200: "58rem",
@@ -123,25 +98,10 @@ module.exports = {
         "30-rem": "30rem",
         "10.25-rem": "10.25rem",
         "89.5-per": "89.5%",
-        "104-px": "104px",
-        "137-px": "137px",
-        "145-px": "145px",
-        "147-px": "147px",
-        "267-px": "267px",
-        "298-px": "298px",
-        "334-px": "334px",
-        "499-px": "499px",
-        "540-px": "540px",
-        "500-px": "500px",
-        "1034-px": "1034px",
-        "306-px": "306px",
         modalOverlay: "calc(100vw + 7rem)",
         pageWidth11: "75rem",
         fixedPageWidth: "75.5rem",
         standardPageWidth: "67.5rem",
-      },
-      gap: {
-        "72-px": "72px",
       },
       maxWidth: {
         fixedPageWidth: "82.75rem",


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Phase 2 of the spacing standardization effort (#4646).

Removes non-Blend custom spacing/sizing entries from `tailwind.config.js` and replaces all usages with Tailwind's arbitrary-value syntax (e.g. `h-[84px]`, `w-[540px]`). Retains only entries that fill genuine gaps in Tailwind's default scale, aligned with the Blend Design System unit token scale:

**Kept (Blend-aligned, not in Tailwind default):**
- `margin "15-px"` → Blend `unit[15]`
- `inset "5-px"` → Blend `unit[5]`
- `inset/height "120-px"` → Blend `unit[120]`
- `width "1-px"` → Blend `unit[1]`

**Removed + replaced with arbitrary syntax (`[value]`):**
- Spacing: `py-2-px` → `py-0.5`, `gap-72-px`, `mt-300-px`, `top-76-px`, `-left-180-px`, `right-500-px`
- Heights: `h-50-px`, `h-84-px`, `h-344-px`, `h-400-px`, `h-590-px`, `h-650-px`, `h-774-px`, `h-890-px`
- Widths: `w-137-px`, `w-145-px`, `w-147-px`, `w-267-px`, `w-306-px`, `w-334-px`, `w-500-px`, `w-540-px`

**Dead entries removed (0 usages):** `maxHeight-750-px`, `minHeight-500-px`, `w-90-px`, `h-68-px`, `h-130-px`, `h-195-px`, `h-700-px`, `h-840-px`

## Motivation and Context

Part of spacing standardization tracked in #4646. The principle: `tailwind.config.js` custom extensions should only contain values that are in the Blend unit token scale but missing from Tailwind's default scale. Everything else either maps to an existing Tailwind class or uses arbitrary syntax.

## How did you test it?

All substitutions are value-identical — `h-[84px]` renders identically to the removed `h-84-px` custom class. Verified no stale class references remain in source files.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible