### PR TITLE
fix(ui): handle empty string case in CopyTextCustomComp

### DIFF
--- a/src/screens/Transaction/Disputes/DisputesEntity.res
+++ b/src/screens/Transaction/Disputes/DisputesEntity.res
@@ -111,12 +111,16 @@ let getCell = (disputesData, colType, merchantId, orgId, ~profileId=""): Table.c
       "",
     )
   | AttemptId =>
-    CustomCell(
-      <HelperComponents.CopyTextCustomComp
-        customTextCss="w-36 truncate whitespace-nowrap" displayValue=Some(disputesData.attempt_id)
-      />,
-      "",
-    )
+    if disputesData.attempt_id->isNonEmptyString {
+      CustomCell(
+        <HelperComponents.CopyTextCustomComp
+          customTextCss="w-36 truncate whitespace-nowrap" displayValue=Some(disputesData.attempt_id)
+        />,
+        "",
+      )
+    } else {
+      Text("NA")
+    }
   | Amount => Text(amountValue(disputesData.amount, disputesData.currency))
   | Currency => Text(disputesData.currency)
   | DisputeStatus =>

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -84,7 +84,18 @@ let getAttemptCell = (attempt: attempts, attemptColType: attemptColType): Table.
   | PaymentMethodType => Text(attempt.payment_method_type)
   | AttemptId => DisplayCopyCell(attempt.attempt_id)
   | ErrorMessage => Text(attempt.error_message)
-  | ConnectorTransactionID => DisplayCopyCell(attempt.connector_transaction_id)
+  | ConnectorTransactionID =>
+    if attempt.connector_transaction_id->isNonEmptyString {
+      CustomCell(
+        <HelperComponents.CopyTextCustomComp
+          customTextCss="w-36 truncate whitespace-nowrap"
+          displayValue=Some(attempt.connector_transaction_id)
+        />,
+        "",
+      )
+    } else {
+      Text("NA")
+    }
   | CaptureMethod => Text(attempt.capture_method)
   | AuthenticationType => Text(attempt.authentication_type)
   | CancellationReason => Text(attempt.cancellation_reason)
@@ -594,13 +605,17 @@ let getCellForSummary = (order, summaryColType): Table.cell => {
   | ProductName => Text(order.product_name->Option.getOr(""))
   | ErrorMessage => Text(order.error.error_message)
   | ConnectorTransactionID =>
-    CustomCell(
-      <HelperComponents.CopyTextCustomComp
-        customTextCss="w-36 truncate whitespace-nowrap"
-        displayValue=Some(order.connector_payment_id)
-      />,
-      "",
-    )
+    if order.connector_payment_id->isNonEmptyString {
+      CustomCell(
+        <HelperComponents.CopyTextCustomComp
+          customTextCss="w-36 truncate whitespace-nowrap"
+          displayValue=Some(order.connector_payment_id)
+        />,
+        "",
+      )
+    } else {
+      Text("NA")
+    }
   }
 }
 
@@ -791,13 +806,17 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
   | ErrorCode => Text(order.error.error_code)
   | ErrorMessage => EllipsisText(order.error.error_message, "w-40")
   | ConnectorTransactionID =>
-    CustomCell(
-      <CopyTextCustomComp
-        customTextCss="w-36 truncate whitespace-nowrap"
-        displayValue=Some(order.connector_payment_id)
-      />,
-      "",
-    )
+    if order.connector_payment_id->isNonEmptyString {
+      CustomCell(
+        <CopyTextCustomComp
+          customTextCss="w-36 truncate whitespace-nowrap"
+          displayValue=Some(order.connector_payment_id)
+        />,
+        "",
+      )
+    } else {
+      Text("NA")
+    }
   | ProfileId => Text(order.profile_id)
   | Refunds =>
     Text(


### PR DESCRIPTION
## Description
Addresses issue #3582 - Added empty string handling for fields rendered via CopyTextCustomComp to display 'NA' instead of an empty copy button.

## Changes
**OrderEntity.res:**
- Added empty string check for connector_transaction_id in three places:
  - Line ~87 (getCell function for main table)
  - Line ~607 (attemptCellDetails function)
  - Line ~808 (second getCell for attempt details)

**DisputesEntity.res:**
- Added empty string check for attempt_id field

## Pattern Used
This follows the existing implementation in PayoutsEntity.res (lines 584-594) which correctly handles empty strings.

## Related Issue
Fixes #3582

## Testing
- Verified the pattern matches the reference implementation
- All changes follow the same empty string handling approach