### PR TITLE
feat: add custom dashboard builder UI with My Dashboards tab in Insights

### DIFF
--- a/src/Orchestration/OrchestrationApp.res
+++ b/src/Orchestration/OrchestrationApp.res
@@ -66,7 +66,8 @@ let make = (~setScreenState) => {
     | list{"new-analytics"}
     | list{"new-analytics", "payment"}
     | list{"new-analytics", "refund"}
-    | list{"new-analytics", "smart-retry"} =>
+    | list{"new-analytics", "smart-retry"}
+    | list{"new-analytics", "dashboards"} =>
       <AccessControl
         isEnabled={featureFlagDetails.newAnalytics &&
         isFeatureEnabledForDenyListMerchant(merchantSpecificConfig.newAnalytics)}

--- a/src/container/InsightsAnalyticsContainer.res
+++ b/src/container/InsightsAnalyticsContainer.res
@@ -6,7 +6,7 @@ let make = () => {
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
   let url = RescriptReactRouter.useUrl()
-  let {newAnalyticsSmartRetries, newAnalyticsRefunds} =
+  let {newAnalyticsSmartRetries, newAnalyticsRefunds, customDashboards} =
     HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateExistingKeys, updateFilterAsync} = React.useContext(FilterContext.filterContext)
   let (tabIndex, setTabIndex) = React.useState(_ => url->getPageIndex)
@@ -106,6 +106,13 @@ let make = () => {
     tabs->Array.push({
       title: "Refunds",
       renderContent: () => <InsightsRefundsAnalytics />,
+    })
+  }
+
+  if customDashboards {
+    tabs->Array.push({
+      title: "My Dashboards",
+      renderContent: () => <CustomDashboardTab />,
     })
   }
 

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -77,6 +77,7 @@ type featureFlag = {
   devVault: bool,
   networkTokenization: bool,
   devBlendEnabled: bool,
+  customDashboards: bool,
 }
 
 let featureFlagType = (featureFlags: JSON.t) => {
@@ -156,6 +157,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     paymentSettingsRevamped: dict->getBool("payment_settings_revamped", false),
     networkTokenization: dict->getBool("network_tokenization", false),
     devBlendEnabled: dict->getBool("dev_blend_enabled", false),
+    customDashboards: dict->getBool("custom_dashboards", false),
   }
 }
 

--- a/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
@@ -1,0 +1,153 @@
+@react.component
+let make = (~onClose, ~onSuccess) => {
+  open LogicUtils
+  open APIUtils
+  let getURL = useGetURL()
+  let updateDetails = useUpdateMethod()
+  let showToast = ToastState.useShowToast()
+  let (name, setName) = React.useState(_ => "")
+  let (description, setDescription) = React.useState(_ => "")
+  let (selectedTemplate, setSelectedTemplate) = React.useState(_ => 0)
+  let (isSubmitting, setIsSubmitting) = React.useState(_ => false)
+
+  let handleCreate = async () => {
+    if name->String.trim->isNonEmptyString {
+      try {
+        setIsSubmitting(_ => true)
+        let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+        let template = CustomDashboardConstants.templates->Array.get(selectedTemplate)
+        let widgets = switch template {
+        | Some(t) => t.widgets
+        | None => []
+        }
+        let data = Dict.make()
+        data->Dict.set("dashboard_name", name->String.trim->JSON.Encode.string)
+        if description->String.trim->isNonEmptyString {
+          data->Dict.set("description", description->String.trim->JSON.Encode.string)
+        }
+        if widgets->Array.length > 0 {
+          data->Dict.set("widgets", widgets->Identity.genericTypeToJson)
+        }
+        let body = CustomDashboardUtils.buildOperationBody(
+          ~operationType="Create",
+          ~data=data->JSON.Encode.object,
+        )
+        let _ = await updateDetails(url, body, Post)
+        let newDashboard: CustomDashboardTypes.dashboard = {
+          dashboardName: name->String.trim,
+          description: description->String.trim->isNonEmptyString
+            ? Some(description->String.trim)
+            : None,
+          isDefault: false,
+          widgets,
+          createdAt: Date.make()->Date.toISOString,
+          updatedAt: Date.make()->Date.toISOString,
+        }
+        showToast(~message="Dashboard created", ~toastType=ToastSuccess)
+        onSuccess(newDashboard)
+      } catch {
+      | _ =>
+        showToast(~message="Failed to create dashboard", ~toastType=ToastError)
+        setIsSubmitting(_ => false)
+      }
+    }
+  }
+
+  <div
+    className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+    onClick={evt => {
+      evt->JsxEvent.Mouse.stopPropagation
+      onClose()
+    }}>
+    <div
+      className="bg-white dark:bg-jp-gray-lightgray_background rounded-lg shadow-xl w-full max-w-lg mx-4"
+      onClick={evt => evt->JsxEvent.Mouse.stopPropagation}>
+      <div className="flex items-center justify-between p-5 border-b">
+        <p className="text-lg font-semibold text-jp-gray-900 dark:text-white">
+          {React.string("Create New Dashboard")}
+        </p>
+        <button
+          className="p-1 rounded hover:bg-gray-100 dark:hover:bg-jp-gray-lightgray_background"
+          onClick={_ => onClose()}>
+          <Icon name="close" size=16 />
+        </button>
+      </div>
+      <div className="p-5 flex flex-col gap-5">
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-jp-gray-900 dark:text-white">
+            {React.string("Dashboard Name *")}
+          </label>
+          <input
+            type_="text"
+            value={name}
+            onChange={evt => {
+              let val = ReactEvent.Form.target(evt)["value"]
+              setName(_ => val)
+            }}
+            placeholder="My Payment Overview"
+            className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-jp-gray-lightgray_background dark:text-white"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-jp-gray-900 dark:text-white">
+            {React.string("Description (optional)")}
+          </label>
+          <textarea
+            value={description}
+            onChange={evt => {
+              let val = ReactEvent.Form.target(evt)["value"]
+              setDescription(_ => val)
+            }}
+            placeholder="Daily payment monitoring dashboard"
+            rows=2
+            className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-jp-gray-lightgray_background dark:text-white resize-none"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium text-jp-gray-900 dark:text-white">
+            {React.string("Start from")}
+          </label>
+          <div className="flex flex-col gap-2">
+            {CustomDashboardConstants.templates
+            ->Array.mapWithIndex((template, index) =>
+              <label
+                key={index->Int.toString}
+                className={`flex items-center gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${selectedTemplate ===
+                    index
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                    : "hover:bg-gray-50 dark:hover:bg-jp-gray-lightgray_background"}`}>
+                <input
+                  type_="radio"
+                  name="template"
+                  checked={selectedTemplate === index}
+                  onChange={_ => setSelectedTemplate(_ => index)}
+                  className="text-blue-600"
+                />
+                <div>
+                  <p className="text-sm font-medium text-jp-gray-900 dark:text-white">
+                    {React.string(template.label)}
+                  </p>
+                  <p className="text-xs text-grey-text">
+                    {React.string(template.description)}
+                  </p>
+                </div>
+              </label>
+            )
+            ->React.array}
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center justify-end gap-3 p-5 border-t">
+        <Button text="Cancel" buttonType={Secondary} onClick={_ => onClose()} />
+        <Button
+          text="Create"
+          buttonType={Primary}
+          onClick={_ => handleCreate()->ignore}
+          buttonState={isSubmitting || name->String.trim->String.length === 0
+            ? Disabled
+            : Normal}
+        />
+      </div>
+    </div>
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
@@ -24,10 +24,10 @@ let make = (~onClose, ~onSuccess) => {
             widgetId: `${Date.now()->Float.toString}-${Math.random()->Float.toString}`,
           })
         )
-        
+
         let data = Dict.make()
         data->Dict.set("dashboard_name", trimmedName->JSON.Encode.string)
-        
+
         let trimmedDesc = description->String.trim
         if trimmedDesc->isNonEmptyString {
           data->Dict.set("description", trimmedDesc->JSON.Encode.string)
@@ -35,13 +35,13 @@ let make = (~onClose, ~onSuccess) => {
         if widgets->Array.length > 0 {
           data->Dict.set("widgets", widgets->CustomDashboardUtils.serializeWidgets)
         }
-        
+
         let body = CustomDashboardUtils.buildOperationBody(
           ~operationType="Create",
           ~data=data->JSON.Encode.object,
         )
         let _ = await updateDetails(url, body, Post)
-        
+
         let now = Date.make()->Date.toISOString
         let newDashboard: CustomDashboardTypes.dashboard = {
           dashboardName: trimmedName,
@@ -136,9 +136,7 @@ let make = (~onClose, ~onSuccess) => {
                   <p className="text-sm font-medium text-jp-gray-900 dark:text-white">
                     {React.string(template.label)}
                   </p>
-                  <p className="text-xs text-grey-text">
-                    {React.string(template.description)}
-                  </p>
+                  <p className="text-xs text-grey-text"> {React.string(template.description)} </p>
                 </div>
               </label>
             )
@@ -152,9 +150,7 @@ let make = (~onClose, ~onSuccess) => {
           text="Create"
           buttonType={Primary}
           onClick={_ => handleCreate()->ignore}
-          buttonState={isSubmitting || name->String.trim->String.length === 0
-            ? Disabled
-            : Normal}
+          buttonState={isSubmitting || name->String.trim->String.length === 0 ? Disabled : Normal}
         />
       </div>
     </div>

--- a/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CreateDashboardModal/CreateDashboardModal.res
@@ -11,44 +11,53 @@ let make = (~onClose, ~onSuccess) => {
   let (isSubmitting, setIsSubmitting) = React.useState(_ => false)
 
   let handleCreate = async () => {
-    if name->String.trim->isNonEmptyString {
+    let trimmedName = name->String.trim
+    if trimmedName->isNonEmptyString {
       try {
         setIsSubmitting(_ => true)
         let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
         let template = CustomDashboardConstants.templates->Array.get(selectedTemplate)
-        let widgets = switch template {
-        | Some(t) => t.widgets
-        | None => []
-        }
+        // Generate unique widget IDs to prevent collision across dashboards
+        let widgets = template->Option.mapOr([], t =>
+          t.widgets->Array.map(w => {
+            ...w,
+            widgetId: `${Date.now()->Float.toString}-${Math.random()->Float.toString}`,
+          })
+        )
+        
         let data = Dict.make()
-        data->Dict.set("dashboard_name", name->String.trim->JSON.Encode.string)
-        if description->String.trim->isNonEmptyString {
-          data->Dict.set("description", description->String.trim->JSON.Encode.string)
+        data->Dict.set("dashboard_name", trimmedName->JSON.Encode.string)
+        
+        let trimmedDesc = description->String.trim
+        if trimmedDesc->isNonEmptyString {
+          data->Dict.set("description", trimmedDesc->JSON.Encode.string)
         }
         if widgets->Array.length > 0 {
-          data->Dict.set("widgets", widgets->Identity.genericTypeToJson)
+          data->Dict.set("widgets", widgets->CustomDashboardUtils.serializeWidgets)
         }
+        
         let body = CustomDashboardUtils.buildOperationBody(
           ~operationType="Create",
           ~data=data->JSON.Encode.object,
         )
         let _ = await updateDetails(url, body, Post)
+        
+        let now = Date.make()->Date.toISOString
         let newDashboard: CustomDashboardTypes.dashboard = {
-          dashboardName: name->String.trim,
-          description: description->String.trim->isNonEmptyString
-            ? Some(description->String.trim)
-            : None,
+          dashboardName: trimmedName,
+          description: trimmedDesc->isNonEmptyString ? Some(trimmedDesc) : None,
           isDefault: false,
           widgets,
-          createdAt: Date.make()->Date.toISOString,
-          updatedAt: Date.make()->Date.toISOString,
+          createdAt: now,
+          updatedAt: now,
         }
         showToast(~message="Dashboard created", ~toastType=ToastSuccess)
         onSuccess(newDashboard)
       } catch {
-      | _ =>
-        showToast(~message="Failed to create dashboard", ~toastType=ToastError)
-        setIsSubmitting(_ => false)
+      | _ => {
+          showToast(~message="Failed to create dashboard", ~toastType=ToastError)
+          setIsSubmitting(_ => false)
+        }
       }
     }
   }

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardConstants.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardConstants.res
@@ -14,7 +14,7 @@ let paymentOverviewTemplate: array<widget> = [
     position: {x: 0, y: 0, w: 6, h: 4},
     config: {
       domain: Payments,
-      metrics: ["sessionized_payments_success_rate"],
+      metrics: ["sessionized_payment_success_rate"],
       groupBy: [],
       filters: JSON.Encode.object(Dict.make()),
       granularity: Some("G_ONEDAY"),
@@ -28,7 +28,7 @@ let paymentOverviewTemplate: array<widget> = [
     position: {x: 6, y: 0, w: 6, h: 4},
     config: {
       domain: Payments,
-      metrics: ["sessionized_payment_intent_count"],
+      metrics: ["sessionized_payment_count"],
       groupBy: ["payment_method"],
       filters: JSON.Encode.object(Dict.make()),
       granularity: None,
@@ -59,7 +59,7 @@ let connectorComparisonTemplate: array<widget> = [
     position: {x: 0, y: 0, w: 12, h: 4},
     config: {
       domain: Payments,
-      metrics: ["sessionized_payments_success_rate"],
+      metrics: ["sessionized_payment_success_rate"],
       groupBy: ["connector"],
       filters: JSON.Encode.object(Dict.make()),
       granularity: Some("G_ONEDAY"),
@@ -73,7 +73,7 @@ let connectorComparisonTemplate: array<widget> = [
     position: {x: 0, y: 4, w: 6, h: 4},
     config: {
       domain: Payments,
-      metrics: ["sessionized_payment_intent_count"],
+      metrics: ["sessionized_payment_count"],
       groupBy: ["connector"],
       filters: JSON.Encode.object(Dict.make()),
       granularity: None,

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardConstants.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardConstants.res
@@ -1,0 +1,103 @@
+open CustomDashboardTypes
+
+let maxDashboards = 10
+let maxWidgetsPerDashboard = 20
+
+let defaultWidgetPosition: widgetPosition = {x: 0, y: 0, w: 12, h: 4}
+let halfWidgetPosition: widgetPosition = {x: 0, y: 0, w: 6, h: 4}
+
+let paymentOverviewTemplate: array<widget> = [
+  {
+    widgetId: "template-1",
+    widgetName: "Payment Success Rate",
+    chartType: LineChart,
+    position: {x: 0, y: 0, w: 6, h: 4},
+    config: {
+      domain: Payments,
+      metrics: ["sessionized_payments_success_rate"],
+      groupBy: [],
+      filters: JSON.Encode.object(Dict.make()),
+      granularity: Some("G_ONEDAY"),
+      timeRangePreset: Some("last_30_days"),
+    },
+  },
+  {
+    widgetId: "template-2",
+    widgetName: "Payment Method Distribution",
+    chartType: PieChart,
+    position: {x: 6, y: 0, w: 6, h: 4},
+    config: {
+      domain: Payments,
+      metrics: ["sessionized_payment_intent_count"],
+      groupBy: ["payment_method"],
+      filters: JSON.Encode.object(Dict.make()),
+      granularity: None,
+      timeRangePreset: Some("last_7_days"),
+    },
+  },
+  {
+    widgetId: "template-3",
+    widgetName: "Payments Processed",
+    chartType: LineChart,
+    position: {x: 0, y: 4, w: 12, h: 4},
+    config: {
+      domain: Payments,
+      metrics: ["sessionized_payment_processed_amount"],
+      groupBy: [],
+      filters: JSON.Encode.object(Dict.make()),
+      granularity: Some("G_ONEDAY"),
+      timeRangePreset: Some("last_30_days"),
+    },
+  },
+]
+
+let connectorComparisonTemplate: array<widget> = [
+  {
+    widgetId: "template-1",
+    widgetName: "Success Rate by Connector",
+    chartType: LineChart,
+    position: {x: 0, y: 0, w: 12, h: 4},
+    config: {
+      domain: Payments,
+      metrics: ["sessionized_payments_success_rate"],
+      groupBy: ["connector"],
+      filters: JSON.Encode.object(Dict.make()),
+      granularity: Some("G_ONEDAY"),
+      timeRangePreset: Some("last_30_days"),
+    },
+  },
+  {
+    widgetId: "template-2",
+    widgetName: "Volume by Connector",
+    chartType: BarChart,
+    position: {x: 0, y: 4, w: 6, h: 4},
+    config: {
+      domain: Payments,
+      metrics: ["sessionized_payment_intent_count"],
+      groupBy: ["connector"],
+      filters: JSON.Encode.object(Dict.make()),
+      granularity: None,
+      timeRangePreset: Some("last_30_days"),
+    },
+  },
+]
+
+type templateOption = {
+  label: string,
+  description: string,
+  widgets: array<widget>,
+}
+
+let templates: array<templateOption> = [
+  {label: "Empty Dashboard", description: "Start from scratch", widgets: []},
+  {
+    label: "Payment Overview",
+    description: "Success rate, volume, distribution",
+    widgets: paymentOverviewTemplate,
+  },
+  {
+    label: "Connector Comparison",
+    description: "Compare PSP performance",
+    widgets: connectorComparisonTemplate,
+  },
+]

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTab.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTab.res
@@ -1,13 +1,22 @@
+// Global styles for transparent Highcharts backgrounds (injected once)
+let chartStyles = `
+  .chart-bg-gradient .highcharts-background { fill: transparent !important; }
+  .chart-bg-gradient .highcharts-plot-background { fill: transparent !important; }
+`
+
 @react.component
 let make = () => {
   let (subView, setSubView) = React.useState(_ => CustomDashboardTypes.DashboardListView)
 
-  switch subView {
-  | DashboardListView =>
-    <DashboardList
-      onOpenDashboard={dashboard => setSubView(_ => DashboardCanvasView(dashboard))}
-    />
-  | DashboardCanvasView(dashboard) =>
-    <DashboardCanvas dashboard onBack={() => setSubView(_ => DashboardListView)} />
-  }
+  <>
+    <style> {React.string(chartStyles)} </style>
+    {switch subView {
+    | DashboardListView =>
+      <DashboardList
+        onOpenDashboard={dashboard => setSubView(_ => DashboardCanvasView(dashboard))}
+      />
+    | DashboardCanvasView(dashboard) =>
+      <DashboardCanvas dashboard onBack={() => setSubView(_ => DashboardListView)} />
+    }}
+  </>
 }

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTab.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTab.res
@@ -1,0 +1,13 @@
+@react.component
+let make = () => {
+  let (subView, setSubView) = React.useState(_ => CustomDashboardTypes.DashboardListView)
+
+  switch subView {
+  | DashboardListView =>
+    <DashboardList
+      onOpenDashboard={dashboard => setSubView(_ => DashboardCanvasView(dashboard))}
+    />
+  | DashboardCanvasView(dashboard) =>
+    <DashboardCanvas dashboard onBack={() => setSubView(_ => DashboardListView)} />
+  }
+}

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTypes.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTypes.res
@@ -1,0 +1,53 @@
+type chartType =
+  | @as("line_chart") LineChart
+  | @as("bar_chart") BarChart
+  | @as("column_chart") ColumnChart
+  | @as("pie_chart") PieChart
+  | @as("stacked_bar_chart") StackedBarChart
+  | @as("sankey_chart") SankeyChart
+  | @as("funnel_chart") FunnelChart
+
+type analyticsDomain =
+  | @as("payments") Payments
+  | @as("refunds") Refunds
+  | @as("disputes") Disputes
+  | @as("auth_events") AuthEvents
+  | @as("smart_retries") SmartRetries
+  | @as("routing") Routing
+
+type widgetPosition = {
+  x: int,
+  y: int,
+  w: int,
+  h: int,
+}
+
+type widgetConfig = {
+  domain: analyticsDomain,
+  metrics: array<string>,
+  @as("group_by") groupBy: array<string>,
+  filters: JSON.t,
+  granularity: option<string>,
+  @as("time_range_preset") timeRangePreset: option<string>,
+}
+
+type widget = {
+  @as("widget_id") widgetId: string,
+  @as("widget_name") widgetName: string,
+  @as("chart_type") chartType: chartType,
+  position: widgetPosition,
+  config: widgetConfig,
+}
+
+type dashboard = {
+  @as("dashboard_name") dashboardName: string,
+  description: option<string>,
+  @as("is_default") isDefault: bool,
+  widgets: array<widget>,
+  @as("created_at") createdAt: string,
+  @as("updated_at") updatedAt: string,
+}
+
+type dashboardViewMode = View | Edit
+
+type subView = DashboardListView | DashboardCanvasView(dashboard)

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTypes.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardTypes.res
@@ -6,6 +6,9 @@ type chartType =
   | @as("stacked_bar_chart") StackedBarChart
   | @as("sankey_chart") SankeyChart
   | @as("funnel_chart") FunnelChart
+  | @as("table") Table
+  | @as("stat_number") StatNumber
+  | @as("gauge") Gauge
 
 type analyticsDomain =
   | @as("payments") Payments

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
@@ -1,93 +1,153 @@
 open LogicUtils
 
+let parseWidget = (widgetJson: JSON.t): option<CustomDashboardTypes.widget> => {
+  try {
+    let wDict = widgetJson->getDictFromJsonObject
+    let configDict = wDict->getDictfromDict("config")
+    let posDict = wDict->getDictfromDict("position")
+
+    let domain = configDict->getString("domain", "payments")
+    let chartType = wDict->getString("chart_type", "line_chart")
+
+    Some({
+      widgetId: wDict->getString("widget_id", ""),
+      widgetName: wDict->getString("widget_name", ""),
+      chartType: switch chartType {
+      | "bar_chart" => BarChart
+      | "column_chart" => ColumnChart
+      | "pie_chart" => PieChart
+      | "stacked_bar_chart" => StackedBarChart
+      | "sankey_chart" => SankeyChart
+      | "funnel_chart" => FunnelChart
+      | "table" => Table
+      | "stat_number" => StatNumber
+      | "gauge" => Gauge
+      | _ => LineChart
+      },
+      position: {
+        x: posDict->getInt("x", 0),
+        y: posDict->getInt("y", 0),
+        w: posDict->getInt("w", 12),
+        h: posDict->getInt("h", 4),
+      },
+      config: {
+        domain: switch domain {
+        | "refunds" => Refunds
+        | "disputes" => Disputes
+        | "auth_events" => AuthEvents
+        | "smart_retries" => SmartRetries
+        | "routing" => Routing
+        | _ => Payments
+        },
+        metrics: configDict->getStrArrayFromDict("metrics", []),
+        groupBy: configDict->getStrArrayFromDict("group_by", []),
+        filters: configDict->getJsonObjectFromDict("filters"),
+        granularity: configDict->getOptionString("granularity"),
+        timeRangePreset: configDict->getOptionString("time_range_preset"),
+      },
+    })
+  } catch {
+  | _ => None
+  }
+}
+
 let parseDashboard = (json: JSON.t): option<CustomDashboardTypes.dashboard> => {
   try {
     let dict = json->getDictFromJsonObject
     let widgetsJson = dict->getArrayFromDict("widgets", [])
-    let widgets = widgetsJson->Array.filterMap(widgetJson => {
-      try {
-        let wDict = widgetJson->getDictFromJsonObject
-        let configDict = wDict->getDictfromDict("config")
-        let posDict = wDict->getDictfromDict("position")
-        let config: CustomDashboardTypes.widgetConfig = {
-          domain: configDict->getString("domain", "payments")->Obj.magic,
-          metrics: configDict->getStrArrayFromDict("metrics", []),
-          groupBy: configDict->getStrArrayFromDict("group_by", []),
-          filters: configDict->getJsonObjectFromDict("filters"),
-          granularity: configDict->getOptionString("granularity"),
-          timeRangePreset: configDict->getOptionString("time_range_preset"),
-        }
-        let position: CustomDashboardTypes.widgetPosition = {
-          x: posDict->getInt("x", 0),
-          y: posDict->getInt("y", 0),
-          w: posDict->getInt("w", 12),
-          h: posDict->getInt("h", 4),
-        }
-        Some(
-          (
-            {
-              widgetId: wDict->getString("widget_id", ""),
-              widgetName: wDict->getString("widget_name", ""),
-              chartType: wDict->getString("chart_type", "line_chart")->Obj.magic,
-              position,
-              config,
-            }: CustomDashboardTypes.widget
-          ),
-        )
-      } catch {
-      | _ => None
-      }
+
+    let widgets =
+      widgetsJson
+      ->Array.filterMap(parseWidget)
+      ->Array.toSorted((a, b) => float(a.position.y - b.position.y))
+
+    Some({
+      dashboardName: dict->getString("dashboard_name", ""),
+      description: dict->getOptionString("description"),
+      isDefault: dict->getBool("is_default", false),
+      widgets,
+      createdAt: dict->getString("created_at", ""),
+      updatedAt: dict->getString("updated_at", ""),
     })
-    // Sort widgets by y position so saved order is preserved
-    let sortedWidgets = widgets->Array.toSorted((a, b) => {
-      let ay = (a: CustomDashboardTypes.widget).position.y
-      let by = (b: CustomDashboardTypes.widget).position.y
-      if ay < by {
-        -1.0
-      } else if ay > by {
-        1.0
-      } else {
-        0.0
-      }
-    })
-    Some(
-      (
-        {
-          dashboardName: dict->getString("dashboard_name", ""),
-          description: dict->getOptionString("description"),
-          isDefault: dict->getBool("is_default", false),
-          widgets: sortedWidgets,
-          createdAt: dict->getString("created_at", ""),
-          updatedAt: dict->getString("updated_at", ""),
-        }: CustomDashboardTypes.dashboard
-      ),
-    )
   } catch {
   | _ => None
   }
 }
 
 let parseDashboards = (response: JSON.t): array<CustomDashboardTypes.dashboard> => {
-  // Response is [ { "CustomDashboards": [...] } ] — an array wrapping one object
-  let firstItem =
-    response
-    ->getArrayFromJson([])
-    ->Array.get(0)
-    ->Option.getOr(JSON.Encode.object(Dict.make()))
-  firstItem
-  ->getDictFromJsonObject
-  ->getArrayFromDict("CustomDashboards", [])
-  ->Array.filterMap(parseDashboard)
+  response
+  ->getArrayFromJson([])
+  ->Array.get(0)
+  ->Option.flatMap(json => {
+    json
+    ->getDictFromJsonObject
+    ->getArrayFromDict("CustomDashboards", [])
+    ->Array.filterMap(parseDashboard)
+    ->Some
+  })
+  ->Option.getOr([])
+}
+
+// Explicit widget serializer — avoids Identity.genericTypeToJson unsafe cast
+let serializeWidget = (widget: CustomDashboardTypes.widget): JSON.t => {
+  let config = Dict.fromArray([
+    (
+      "domain",
+      (switch widget.config.domain {
+      | Payments | SmartRetries => "payments"
+      | Routing => "routing"
+      | Refunds => "refunds"
+      | Disputes => "disputes"
+      | AuthEvents => "auth_events"
+      })->JSON.Encode.string,
+    ),
+    ("metrics", widget.config.metrics->Array.map(JSON.Encode.string)->JSON.Encode.array),
+    ("group_by", widget.config.groupBy->Array.map(JSON.Encode.string)->JSON.Encode.array),
+    ("filters", widget.config.filters),
+    (
+      "granularity",
+      switch widget.config.granularity {
+      | Some(g) => g->JSON.Encode.string
+      | None => JSON.Encode.null
+      },
+    ),
+    (
+      "time_range_preset",
+      switch widget.config.timeRangePreset {
+      | Some(t) => t->JSON.Encode.string
+      | None => JSON.Encode.null
+      },
+    ),
+  ])
+  let position = Dict.fromArray([
+    ("x", widget.position.x->JSON.Encode.int),
+    ("y", widget.position.y->JSON.Encode.int),
+    ("w", widget.position.w->JSON.Encode.int),
+    ("h", widget.position.h->JSON.Encode.int),
+  ])
+  Dict.fromArray([
+    ("widget_id", widget.widgetId->JSON.Encode.string),
+    ("widget_name", widget.widgetName->JSON.Encode.string),
+    ("chart_type", (widget.chartType :> string)->JSON.Encode.string),
+    ("position", position->JSON.Encode.object),
+    ("config", config->JSON.Encode.object),
+  ])->JSON.Encode.object
+}
+
+let serializeWidgets = (widgets: array<CustomDashboardTypes.widget>): JSON.t => {
+  widgets->Array.map(serializeWidget)->JSON.Encode.array
 }
 
 let buildOperationBody = (~operationType: string, ~data: JSON.t): JSON.t => {
-  let inner = Dict.make()
-  inner->Dict.set("type", operationType->JSON.Encode.string)
-  inner->Dict.set("data", data)
-
-  let outer = Dict.make()
-  outer->Dict.set("CustomDashboards", inner->JSON.Encode.object)
-  outer->JSON.Encode.object
+  Dict.fromArray([
+    (
+      "CustomDashboards",
+      Dict.fromArray([
+        ("type", operationType->JSON.Encode.string),
+        ("data", data),
+      ])->JSON.Encode.object,
+    ),
+  ])->JSON.Encode.object
 }
 
 let getChartTypeLabel = (chartType: CustomDashboardTypes.chartType) => {
@@ -99,6 +159,9 @@ let getChartTypeLabel = (chartType: CustomDashboardTypes.chartType) => {
   | StackedBarChart => "Stacked Bar"
   | SankeyChart => "Sankey"
   | FunnelChart => "Funnel"
+  | Table => "Table"
+  | StatNumber => "Number"
+  | Gauge => "Gauge"
   }
 }
 
@@ -113,14 +176,20 @@ let getDomainLabel = (domain: CustomDashboardTypes.analyticsDomain) => {
   }
 }
 
-let getDomainApiEntity = (domain: CustomDashboardTypes.analyticsDomain) => {
+let getDomainApiEntity = (
+  domain: CustomDashboardTypes.analyticsDomain,
+  ~metrics: array<string>=[],
+) => {
   open APIUtilsTypes
+
+  let hasPaymentIntentMetric = metrics->Array.some(WidgetConfiguratorUtils.isPaymentIntentMetric)
+
   switch domain {
-  | Payments | SmartRetries => V1(ANALYTICS_PAYMENTS_V2)
+  | Payments | SmartRetries | Routing =>
+    hasPaymentIntentMetric ? V1(ANALYTICS_PAYMENTS_V2) : V1(ANALYTICS_PAYMENTS)
   | Refunds => V1(ANALYTICS_REFUNDS)
   | Disputes => V1(ANALYTICS_DISPUTES)
-  | AuthEvents => V1(ANALYTICS_AUTHENTICATION)
-  | Routing => V1(ANALYTICS_PAYMENTS_V2)
+  | AuthEvents => V1(ANALYTICS_AUTHENTICATION_V2)
   }
 }
 
@@ -138,14 +207,64 @@ let formatUpdatedAt = (updatedAt: string) => {
     let now = Date.make()->Date.toString->DayJs.getDayJsForString
     let updated = updatedAt->DayJs.getDayJsForString
     let diffMinutes = now.diff(updated.toString(), "minute")
-    if diffMinutes < 60 {
-      `${diffMinutes->Int.toString} min ago`
-    } else if diffMinutes < 1440 {
-      `${(diffMinutes / 60)->Int.toString} hours ago`
-    } else {
-      `${(diffMinutes / 1440)->Int.toString} days ago`
+
+    switch diffMinutes {
+    | m if m < 60 => `${m->Int.toString} min ago`
+    | m if m < 1440 => `${(m / 60)->Int.toString} hours ago`
+    | m => `${(m / 1440)->Int.toString} days ago`
     }
   } else {
     ""
   }
+}
+
+// Convert a metric string to its polyvariant safely (replaces Obj.magic)
+let stringToMetric = (metricStr: string): option<InsightsTypes.metrics> => {
+  switch metricStr {
+  // Payment metrics - map to available polyvariants
+  | "sessionized_payment_success_rate"
+  | "sessionized_connector_success_rate" =>
+    Some(#sessionized_payments_success_rate)
+  | "sessionized_payment_processed_amount" => Some(#sessionized_payment_processed_amount)
+  | "sessionized_payment_count"
+  | "payment_count"
+  | "sessionized_payment_intent_count"
+  | "sessionized_payment_success_count"
+  | "sessionized_avg_ticket_size"
+  | "sessionized_retries_count" =>
+    Some(#sessionized_payment_intent_count)
+  | "payment_success_rate" => Some(#payment_success_rate)
+  | "sessionized_smart_retried_amount" => Some(#sessionized_smart_retried_amount)
+  // Refund metrics
+  | "sessionized_refund_processed_amount" => Some(#sessionized_refund_processed_amount)
+  | "sessionized_refund_count" => Some(#sessionized_refund_count)
+  | "sessionized_refund_success_count" => Some(#sessionized_refund_success_count)
+  | "sessionized_refund_success_rate" => Some(#sessionized_refund_success_rate)
+  | "sessionized_refund_error_message" => Some(#sessionized_refund_error_message)
+  | "sessionized_refund_reason" => Some(#sessionized_refund_reason)
+  | "refund_processed_amount" => Some(#refund_processed_amount)
+  // Dispute metrics
+  | "dispute_status_metric" => Some(#dispute_status_metric)
+  | "payments_distribution" => Some(#payments_distribution)
+  | "failure_reasons" => Some(#failure_reasons)
+  // Auth metrics
+  | "authentication_count" => Some(#authentication_count)
+  | "authentication_attempt_count" => Some(#authentication_attempt_count)
+  | "authentication_success_count" => Some(#authentication_success_count)
+  | "challenge_flow_count" => Some(#challenge_flow_count)
+  | "frictionless_flow_count" => Some(#frictionless_flow_count)
+  | "frictionless_success_count" => Some(#frictionless_success_count)
+  | "challenge_attempt_count" => Some(#challenge_attempt_count)
+  | "challenge_success_count" => Some(#challenge_success_count)
+  | "authentication_funnel" => Some(#authentication_funnel)
+  | "authentication_error_message" => Some(#authentication_error_message)
+  | "authentication_exemption_approved_count" => Some(#authentication_exemption_approved_count)
+  | "authentication_exemption_requested_count" => Some(#authentication_exemption_requested_count)
+  | _ => None
+  }
+}
+
+// Convert array of metric strings to polyvariants, filtering invalid ones
+let metricsStringsToPolyvariants = (metricStrings: array<string>): array<InsightsTypes.metrics> => {
+  metricStrings->Array.filterMap(stringToMetric)
 }

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
@@ -93,13 +93,13 @@ let serializeWidget = (widget: CustomDashboardTypes.widget): JSON.t => {
   let config = Dict.fromArray([
     (
       "domain",
-      (switch widget.config.domain {
+      switch widget.config.domain {
       | Payments | SmartRetries => "payments"
       | Routing => "routing"
       | Refunds => "refunds"
       | Disputes => "disputes"
       | AuthEvents => "auth_events"
-      })->JSON.Encode.string,
+      }->JSON.Encode.string,
     ),
     ("metrics", widget.config.metrics->Array.map(JSON.Encode.string)->JSON.Encode.array),
     ("group_by", widget.config.groupBy->Array.map(JSON.Encode.string)->JSON.Encode.array),

--- a/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/CustomDashboardUtils.res
@@ -1,0 +1,151 @@
+open LogicUtils
+
+let parseDashboard = (json: JSON.t): option<CustomDashboardTypes.dashboard> => {
+  try {
+    let dict = json->getDictFromJsonObject
+    let widgetsJson = dict->getArrayFromDict("widgets", [])
+    let widgets = widgetsJson->Array.filterMap(widgetJson => {
+      try {
+        let wDict = widgetJson->getDictFromJsonObject
+        let configDict = wDict->getDictfromDict("config")
+        let posDict = wDict->getDictfromDict("position")
+        let config: CustomDashboardTypes.widgetConfig = {
+          domain: configDict->getString("domain", "payments")->Obj.magic,
+          metrics: configDict->getStrArrayFromDict("metrics", []),
+          groupBy: configDict->getStrArrayFromDict("group_by", []),
+          filters: configDict->getJsonObjectFromDict("filters"),
+          granularity: configDict->getOptionString("granularity"),
+          timeRangePreset: configDict->getOptionString("time_range_preset"),
+        }
+        let position: CustomDashboardTypes.widgetPosition = {
+          x: posDict->getInt("x", 0),
+          y: posDict->getInt("y", 0),
+          w: posDict->getInt("w", 12),
+          h: posDict->getInt("h", 4),
+        }
+        Some(
+          (
+            {
+              widgetId: wDict->getString("widget_id", ""),
+              widgetName: wDict->getString("widget_name", ""),
+              chartType: wDict->getString("chart_type", "line_chart")->Obj.magic,
+              position,
+              config,
+            }: CustomDashboardTypes.widget
+          ),
+        )
+      } catch {
+      | _ => None
+      }
+    })
+    // Sort widgets by y position so saved order is preserved
+    let sortedWidgets = widgets->Array.toSorted((a, b) => {
+      let ay = (a: CustomDashboardTypes.widget).position.y
+      let by = (b: CustomDashboardTypes.widget).position.y
+      if ay < by {
+        -1.0
+      } else if ay > by {
+        1.0
+      } else {
+        0.0
+      }
+    })
+    Some(
+      (
+        {
+          dashboardName: dict->getString("dashboard_name", ""),
+          description: dict->getOptionString("description"),
+          isDefault: dict->getBool("is_default", false),
+          widgets: sortedWidgets,
+          createdAt: dict->getString("created_at", ""),
+          updatedAt: dict->getString("updated_at", ""),
+        }: CustomDashboardTypes.dashboard
+      ),
+    )
+  } catch {
+  | _ => None
+  }
+}
+
+let parseDashboards = (response: JSON.t): array<CustomDashboardTypes.dashboard> => {
+  // Response is [ { "CustomDashboards": [...] } ] — an array wrapping one object
+  let firstItem =
+    response
+    ->getArrayFromJson([])
+    ->Array.get(0)
+    ->Option.getOr(JSON.Encode.object(Dict.make()))
+  firstItem
+  ->getDictFromJsonObject
+  ->getArrayFromDict("CustomDashboards", [])
+  ->Array.filterMap(parseDashboard)
+}
+
+let buildOperationBody = (~operationType: string, ~data: JSON.t): JSON.t => {
+  let inner = Dict.make()
+  inner->Dict.set("type", operationType->JSON.Encode.string)
+  inner->Dict.set("data", data)
+
+  let outer = Dict.make()
+  outer->Dict.set("CustomDashboards", inner->JSON.Encode.object)
+  outer->JSON.Encode.object
+}
+
+let getChartTypeLabel = (chartType: CustomDashboardTypes.chartType) => {
+  switch chartType {
+  | LineChart => "Line Chart"
+  | BarChart => "Bar Chart"
+  | ColumnChart => "Column Chart"
+  | PieChart => "Pie Chart"
+  | StackedBarChart => "Stacked Bar"
+  | SankeyChart => "Sankey"
+  | FunnelChart => "Funnel"
+  }
+}
+
+let getDomainLabel = (domain: CustomDashboardTypes.analyticsDomain) => {
+  switch domain {
+  | Payments => "Payments"
+  | Refunds => "Refunds"
+  | Disputes => "Disputes"
+  | AuthEvents => "Authentication"
+  | SmartRetries => "Smart Retries"
+  | Routing => "Routing"
+  }
+}
+
+let getDomainApiEntity = (domain: CustomDashboardTypes.analyticsDomain) => {
+  open APIUtilsTypes
+  switch domain {
+  | Payments | SmartRetries => V1(ANALYTICS_PAYMENTS_V2)
+  | Refunds => V1(ANALYTICS_REFUNDS)
+  | Disputes => V1(ANALYTICS_DISPUTES)
+  | AuthEvents => V1(ANALYTICS_AUTHENTICATION)
+  | Routing => V1(ANALYTICS_PAYMENTS_V2)
+  }
+}
+
+let getDomainString = (domain: CustomDashboardTypes.analyticsDomain) => {
+  switch domain {
+  | Payments | SmartRetries | Routing => "payments"
+  | Refunds => "refunds"
+  | Disputes => "disputes"
+  | AuthEvents => "auth_events"
+  }
+}
+
+let formatUpdatedAt = (updatedAt: string) => {
+  if updatedAt->isNonEmptyString {
+    let now = Date.make()->Date.toString->DayJs.getDayJsForString
+    let updated = updatedAt->DayJs.getDayJsForString
+    let diffMinutes = now.diff(updated.toString(), "minute")
+    if diffMinutes < 60 {
+      `${diffMinutes->Int.toString} min ago`
+    } else if diffMinutes < 1440 {
+      `${(diffMinutes / 60)->Int.toString} hours ago`
+    } else {
+      `${(diffMinutes / 1440)->Int.toString} days ago`
+    }
+  } else {
+    ""
+  }
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
@@ -1,14 +1,20 @@
 let reorder = (list, startIndex, endIndex) => {
-  let arr = Array.copy(list)
-  let removed = Js.Array.removeCountInPlace(~pos=startIndex, ~count=1, arr)
-  arr->Array.splice(~start=endIndex, ~remove=0, ~insert=removed)
-  arr
+  switch (list[startIndex], startIndex === endIndex) {
+  | (None, _) | (_, true) => list
+  | (Some(item), false) => {
+      let without = list->Array.filterWithIndex((_, i) => i !== startIndex)
+      let before = without->Array.slice(~start=0, ~end=endIndex)
+      let after = without->Array.slice(~start=endIndex, ~end=without->Array.length)
+      before->Array.concat([item])->Array.concat(after)
+    }
+  }
 }
 
 @react.component
 let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
   open APIUtils
   let getURL = useGetURL()
+  let fetchDetails = useGetMethod()
   let updateDetails = useUpdateMethod()
   let showToast = ToastState.useShowToast()
   let (viewMode, setViewMode) = React.useState(_ => CustomDashboardTypes.View)
@@ -18,12 +24,34 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
     (): option<CustomDashboardTypes.widget> => None,
   )
 
+  // Refetch dashboard widgets from API to get fresh data after add/edit/remove
+  let refetchWidgets = async () => {
+    try {
+      let url = getURL(
+        ~entityName=V1(USERS),
+        ~userType=#USER_DATA,
+        ~methodType=Get,
+        ~queryParameters=Some("keys=CustomDashboards"),
+      )
+      let response = await fetchDetails(url)
+      let dashboards = CustomDashboardUtils.parseDashboards(response)
+      let updated = dashboards->Array.find(d => d.dashboardName === dashboard.dashboardName)
+      switch updated {
+      | Some(d) => setWidgets(_ => d.widgets)
+      | None => ()
+      }
+    } catch {
+    | _ => showToast(~message="Failed to refresh widgets", ~toastType=ToastError)
+    }
+  }
+
   let handleRemoveWidget = async (widgetId: string) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let data = Dict.make()
-      data->Dict.set("dashboard_name", dashboard.dashboardName->JSON.Encode.string)
-      data->Dict.set("widget_id", widgetId->JSON.Encode.string)
+      let data = Dict.fromArray([
+        ("dashboard_name", dashboard.dashboardName->JSON.Encode.string),
+        ("widget_id", widgetId->JSON.Encode.string),
+      ])
       let body = CustomDashboardUtils.buildOperationBody(
         ~operationType="RemoveWidget",
         ~data=data->JSON.Encode.object,
@@ -39,29 +67,30 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
   let handleSave = async () => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let layoutData =
-        widgets->Array.mapWithIndex((widget, index) => {
-          let entry = Dict.make()
-          entry->Dict.set("widget_id", widget.widgetId->JSON.Encode.string)
-          let position = Dict.make()
-          position->Dict.set("x", 0->JSON.Encode.int)
-          position->Dict.set("y", (index * widget.position.h)->JSON.Encode.int)
-          position->Dict.set("w", widget.position.w->JSON.Encode.int)
-          position->Dict.set("h", widget.position.h->JSON.Encode.int)
-          entry->Dict.set("position", position->JSON.Encode.object)
-          entry->JSON.Encode.object
-        })
-      let data = Dict.make()
-      data->Dict.set("dashboard_name", dashboard.dashboardName->JSON.Encode.string)
-      data->Dict.set("layout", layoutData->JSON.Encode.array)
+      let layoutData = widgets->Array.map(widget => {
+        let pos = widget.position
+        let position = Dict.fromArray([
+          ("x", pos.x->JSON.Encode.int),
+          ("y", pos.y->JSON.Encode.int),
+          ("w", pos.w->JSON.Encode.int),
+          ("h", pos.h->JSON.Encode.int),
+        ])
+        Dict.fromArray([
+          ("widget_id", widget.widgetId->JSON.Encode.string),
+          ("position", position->JSON.Encode.object),
+        ])->JSON.Encode.object
+      })
+      let data = Dict.fromArray([
+        ("dashboard_name", dashboard.dashboardName->JSON.Encode.string),
+        ("layout", layoutData->JSON.Encode.array),
+      ])
       let body = CustomDashboardUtils.buildOperationBody(
         ~operationType="UpdateLayout",
         ~data=data->JSON.Encode.object,
       )
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard saved", ~toastType=ToastSuccess)
-      // Go back to list so it re-fetches fresh data from API
-      onBack()
+      setViewMode(_ => View)
     } catch {
     | _ => showToast(~message="Failed to save layout", ~toastType=ToastError)
     }
@@ -73,8 +102,16 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
   }
 
   let openAddWidget = () => {
-    setEditingWidget(_ => None)
-    setShowConfigurator(_ => true)
+    // FIX: Enforce widget limit before opening configurator
+    if widgets->Array.length >= CustomDashboardConstants.maxWidgetsPerDashboard {
+      showToast(
+        ~message=`Maximum ${CustomDashboardConstants.maxWidgetsPerDashboard->Int.toString} widgets allowed per dashboard`,
+        ~toastType=ToastWarning,
+      )
+    } else {
+      setEditingWidget(_ => None)
+      setShowConfigurator(_ => true)
+    }
   }
 
   let openEditWidget = (widget: CustomDashboardTypes.widget) => {
@@ -85,7 +122,7 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
   let handleConfiguratorSuccess = () => {
     setShowConfigurator(_ => false)
     setEditingWidget(_ => None)
-    onBack()
+    refetchWidgets()->ignore
   }
 
   let isEditMode = viewMode === Edit
@@ -181,8 +218,8 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
       } else {
         <div className="dashboard-grid grid grid-cols-12 gap-4">
           {widgets
-          ->Array.mapWithIndex((widget, index) =>
-            <div key={index->Int.toString} className={getColSpanClass(widget.position.w)}>
+          ->Array.map(widget =>
+            <div key={widget.widgetId} className={getColSpanClass(widget.position.w)}>
               <WidgetCard widget isEditMode=false />
             </div>
           )

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
@@ -20,8 +20,8 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
   let (viewMode, setViewMode) = React.useState(_ => CustomDashboardTypes.View)
   let (widgets, setWidgets) = React.useState(_ => dashboard.widgets)
   let (showConfigurator, setShowConfigurator) = React.useState(_ => false)
-  let (editingWidget, setEditingWidget) = React.useState(
-    (): option<CustomDashboardTypes.widget> => None,
+  let (editingWidget, setEditingWidget) = React.useState((): option<CustomDashboardTypes.widget> =>
+    None
   )
 
   // Refetch dashboard widgets from API to get fresh data after add/edit/remove
@@ -185,7 +185,9 @@ let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
           <ReactBeautifulDND.Droppable droppableId="dashboard-widgets" direction="vertical">
             {(droppableProvided, _snapshot) =>
               React.cloneElement(
-                <div ref={droppableProvided["innerRef"]} className="dashboard-grid grid grid-cols-12 gap-4">
+                <div
+                  ref={droppableProvided["innerRef"]}
+                  className="dashboard-grid grid grid-cols-12 gap-4">
                   {widgets
                   ->Array.mapWithIndex((widget, index) =>
                     <ReactBeautifulDND.Draggable

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardCanvas.res
@@ -1,0 +1,257 @@
+let reorder = (list, startIndex, endIndex) => {
+  let arr = Array.copy(list)
+  let removed = Js.Array.removeCountInPlace(~pos=startIndex, ~count=1, arr)
+  arr->Array.splice(~start=endIndex, ~remove=0, ~insert=removed)
+  arr
+}
+
+@react.component
+let make = (~dashboard: CustomDashboardTypes.dashboard, ~onBack) => {
+  open APIUtils
+  let getURL = useGetURL()
+  let updateDetails = useUpdateMethod()
+  let showToast = ToastState.useShowToast()
+  let (viewMode, setViewMode) = React.useState(_ => CustomDashboardTypes.View)
+  let (widgets, setWidgets) = React.useState(_ => dashboard.widgets)
+  let (showConfigurator, setShowConfigurator) = React.useState(_ => false)
+  let (editingWidget, setEditingWidget) = React.useState(
+    (): option<CustomDashboardTypes.widget> => None,
+  )
+
+  let handleRemoveWidget = async (widgetId: string) => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      let data = Dict.make()
+      data->Dict.set("dashboard_name", dashboard.dashboardName->JSON.Encode.string)
+      data->Dict.set("widget_id", widgetId->JSON.Encode.string)
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="RemoveWidget",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      setWidgets(prev => prev->Array.filter(w => w.widgetId !== widgetId))
+      showToast(~message="Widget removed", ~toastType=ToastSuccess)
+    } catch {
+    | _ => showToast(~message="Failed to remove widget", ~toastType=ToastError)
+    }
+  }
+
+  let handleSave = async () => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      let layoutData =
+        widgets->Array.mapWithIndex((widget, index) => {
+          let entry = Dict.make()
+          entry->Dict.set("widget_id", widget.widgetId->JSON.Encode.string)
+          let position = Dict.make()
+          position->Dict.set("x", 0->JSON.Encode.int)
+          position->Dict.set("y", (index * widget.position.h)->JSON.Encode.int)
+          position->Dict.set("w", widget.position.w->JSON.Encode.int)
+          position->Dict.set("h", widget.position.h->JSON.Encode.int)
+          entry->Dict.set("position", position->JSON.Encode.object)
+          entry->JSON.Encode.object
+        })
+      let data = Dict.make()
+      data->Dict.set("dashboard_name", dashboard.dashboardName->JSON.Encode.string)
+      data->Dict.set("layout", layoutData->JSON.Encode.array)
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="UpdateLayout",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      showToast(~message="Dashboard saved", ~toastType=ToastSuccess)
+      // Go back to list so it re-fetches fresh data from API
+      onBack()
+    } catch {
+    | _ => showToast(~message="Failed to save layout", ~toastType=ToastError)
+    }
+  }
+
+  let handleCancel = () => {
+    setWidgets(_ => dashboard.widgets)
+    setViewMode(_ => View)
+  }
+
+  let openAddWidget = () => {
+    setEditingWidget(_ => None)
+    setShowConfigurator(_ => true)
+  }
+
+  let openEditWidget = (widget: CustomDashboardTypes.widget) => {
+    setEditingWidget(_ => Some(widget))
+    setShowConfigurator(_ => true)
+  }
+
+  let handleConfiguratorSuccess = () => {
+    setShowConfigurator(_ => false)
+    setEditingWidget(_ => None)
+    onBack()
+  }
+
+  let isEditMode = viewMode === Edit
+
+  // All 12 literal classes so Tailwind won't purge any
+  let getColSpanClass = (w: int) => {
+    switch w {
+    | 1 => "col-span-1"
+    | 2 => "col-span-2"
+    | 3 => "col-span-3"
+    | 4 => "col-span-4"
+    | 5 => "col-span-5"
+    | 6 => "col-span-6"
+    | 7 => "col-span-7"
+    | 8 => "col-span-8"
+    | 9 => "col-span-9"
+    | 10 => "col-span-10"
+    | 11 => "col-span-11"
+    | _ => "col-span-12"
+    }
+  }
+
+  let updateWidgetSize = (widgetId: string, ~w: int, ~h: int) => {
+    setWidgets(prev =>
+      prev->Array.map(widget =>
+        if widget.widgetId === widgetId {
+          {
+            ...widget,
+            position: {
+              ...widget.position,
+              w,
+              h,
+            },
+          }
+        } else {
+          widget
+        }
+      )
+    )
+  }
+
+  let onDragEnd = result => {
+    let dest = Nullable.toOption(result["destination"])
+    switch dest {
+    | Some(destination) => {
+        let sourceIndex = result["source"]["index"]
+        let destIndex = destination["index"]
+        if sourceIndex !== destIndex {
+          setWidgets(prev => reorder(prev, sourceIndex, destIndex))
+        }
+      }
+    | None => ()
+    }
+  }
+
+  let renderWidgetGrid = () => {
+    if widgets->Array.length > 0 {
+      if isEditMode {
+        <ReactBeautifulDND.DragDropContext onDragEnd>
+          <ReactBeautifulDND.Droppable droppableId="dashboard-widgets" direction="vertical">
+            {(droppableProvided, _snapshot) =>
+              React.cloneElement(
+                <div ref={droppableProvided["innerRef"]} className="dashboard-grid grid grid-cols-12 gap-4">
+                  {widgets
+                  ->Array.mapWithIndex((widget, index) =>
+                    <ReactBeautifulDND.Draggable
+                      key={widget.widgetId} draggableId={widget.widgetId} index>
+                      {(draggableProvided, _dragSnapshot) =>
+                        React.cloneElement(
+                          <div
+                            ref={draggableProvided["innerRef"]}
+                            className={getColSpanClass(widget.position.w)}>
+                            <WidgetCard
+                              widget
+                              isEditMode=true
+                              onEdit={() => openEditWidget(widget)}
+                              onRemove={() => handleRemoveWidget(widget.widgetId)->ignore}
+                              onResize={(~w, ~h) => updateWidgetSize(widget.widgetId, ~w, ~h)}
+                              dragHandleProps={draggableProvided["dragHandleProps"]}
+                            />
+                          </div>,
+                          draggableProvided["draggableProps"],
+                        )}
+                    </ReactBeautifulDND.Draggable>
+                  )
+                  ->React.array}
+                  {droppableProvided["placeholder"]}
+                </div>,
+                droppableProvided["droppableProps"],
+              )}
+          </ReactBeautifulDND.Droppable>
+        </ReactBeautifulDND.DragDropContext>
+      } else {
+        <div className="dashboard-grid grid grid-cols-12 gap-4">
+          {widgets
+          ->Array.mapWithIndex((widget, index) =>
+            <div key={index->Int.toString} className={getColSpanClass(widget.position.w)}>
+              <WidgetCard widget isEditMode=false />
+            </div>
+          )
+          ->React.array}
+        </div>
+      }
+    } else {
+      <div
+        className="flex flex-col items-center justify-center py-16 border-2 border-dashed rounded-lg text-grey-text cursor-pointer hover:bg-gray-50 transition-colors"
+        onClick={_ =>
+          if isEditMode {
+            openAddWidget()
+          }}>
+        <Icon name="nd-plus" size=24 className="text-gray-400 mb-2" />
+        <p className="text-lg font-medium"> {React.string("No widgets yet")} </p>
+        <p className="text-sm mt-1">
+          {React.string(
+            isEditMode
+              ? "Click here or use + Add Widget to get started"
+              : "Click Edit and add widgets to build your dashboard",
+          )}
+        </p>
+      </div>
+    }
+  }
+
+  <div className="mt-5 flex flex-col gap-4">
+    <DashboardToolbar
+      dashboardName={dashboard.dashboardName}
+      viewMode
+      onBack
+      onEdit={() => setViewMode(_ => Edit)}
+      onSave={() => handleSave()->ignore}
+      onCancel={handleCancel}
+      onAddWidget={openAddWidget}
+    />
+    {if isEditMode {
+      <p className="text-xs text-gray-400">
+        {React.string("Drag widgets to reorder \u2022 Click size buttons to resize")}
+      </p>
+    } else {
+      React.null
+    }}
+    {renderWidgetGrid()}
+    {if isEditMode && widgets->Array.length > 0 {
+      <div
+        className="border-2 border-dashed border-gray-300 rounded-lg bg-gray-50 dark:bg-gray-800 flex flex-col items-center justify-center py-10 cursor-pointer hover:bg-gray-100 hover:border-blue-300 transition-colors"
+        onClick={_ => openAddWidget()}>
+        <Icon name="nd-plus" size=20 className="text-gray-400" />
+        <span className="text-sm text-gray-400 mt-2"> {React.string("Add Widget")} </span>
+        <span className="text-xs text-gray-300 mt-0.5">
+          {React.string("Click to add a new chart")}
+        </span>
+      </div>
+    } else {
+      React.null
+    }}
+    {if showConfigurator {
+      <WidgetConfigurator
+        dashboardName={dashboard.dashboardName}
+        editingWidget
+        onClose={() => {
+          setShowConfigurator(_ => false)
+          setEditingWidget(_ => None)
+        }}
+        onSuccess={handleConfiguratorSuccess}
+      />
+    } else {
+      React.null
+    }}
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardToolbar.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/DashboardToolbar.res
@@ -1,0 +1,48 @@
+@react.component
+let make = (
+  ~dashboardName,
+  ~viewMode: CustomDashboardTypes.dashboardViewMode,
+  ~onBack,
+  ~onEdit,
+  ~onSave,
+  ~onCancel,
+  ~onAddWidget,
+) => {
+  <div className="flex items-center justify-between">
+    <div className="flex items-center gap-3">
+      <button
+        className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700"
+        onClick={_ => onBack()}>
+        <Icon name="arrow-left" size=14 />
+        {React.string(
+          switch viewMode {
+          | View => "Back to My Dashboards"
+          | Edit => "Back"
+          },
+        )}
+      </button>
+      <span className="text-grey-text"> {React.string("|")} </span>
+      <p className="text-xl font-semibold text-jp-gray-900 dark:text-white">
+        {React.string(dashboardName)}
+        {switch viewMode {
+        | Edit =>
+          <span className="text-sm font-normal text-grey-text ml-2">
+            {React.string("(Editing)")}
+          </span>
+        | View => React.null
+        }}
+      </p>
+    </div>
+    <div className="flex items-center gap-2">
+      {switch viewMode {
+      | View => <Button text="Edit" buttonType={Secondary} onClick={_ => onEdit()} />
+      | Edit =>
+        <>
+          <Button text="+ Add Widget" buttonType={Primary} onClick={_ => onAddWidget()} />
+          <Button text="Save" buttonType={Primary} onClick={_ => onSave()} />
+          <Button text="Cancel" buttonType={Secondary} onClick={_ => onCancel()} />
+        </>
+      }}
+    </div>
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
@@ -101,11 +101,25 @@ let attachResizeHandlers: (
     container.appendChild(makeHandle('r-right','ew-resize','x'));
     container.appendChild(makeHandle('r-bottom','ns-resize','y'));
     container.appendChild(makeHandle('r-corner','nwse-resize','xy'));
+
+    // Store abort function for cleanup during mid-drag unmount
+    container.__abortResize = function() {
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      container.style.outline = '';
+      container.style.outlineOffset = '';
+      container.style.transition = '';
+    };
   }
 `)
 
 let cleanupResizeHandlers: Dom.element => unit = %raw(`
   function(container) {
+    // Abort any in-flight drag to prevent memory leak
+    if (container.__abortResize) {
+      container.__abortResize();
+      container.__abortResize = null;
+    }
     container.querySelectorAll('.resize-handle').forEach(function(el) { el.remove() });
     container.style.outline = '';
     container.style.width = '';
@@ -128,12 +142,13 @@ let make = (
   let cardRef = React.useRef(Nullable.null)
   let heightPx = widget.position.h * 80
 
-  // In edit mode use fixed height; in view mode use minHeight so content can expand
-  let cardStyle = if isEditMode {
-    ReactDOM.Style.make(~height=`${heightPx->Int.toString}px`, ~overflow="hidden", ())
-  } else {
-    ReactDOM.Style.make(~minHeight=`${heightPx->Int.toString}px`, ())
-  }
+  // Edit mode uses fixed height for resize stability; view mode allows content expansion
+  let cardStyle = ReactDOM.Style.make(
+    ~height=isEditMode ? `${heightPx->Int.toString}px` : "auto",
+    ~minHeight=isEditMode ? "auto" : `${heightPx->Int.toString}px`,
+    ~overflow=isEditMode ? "hidden" : "visible",
+    (),
+  )
 
   // Attach resize handles — re-runs when widget size changes (after resize end)
   React.useEffect(() => {
@@ -201,10 +216,18 @@ let make = (
             </button>
           </div>
         } else {
+          // View mode: no toggle buttons (removed as not useful)
           React.null
         }}
       </div>
-      <div className="px-2 pb-4 overflow-hidden">
+      // Chart area with light blue background (matching mockup design)
+      // [class*="highcharts-background"] makes Highcharts SVG background transparent
+      <div
+        className="mx-4 mb-4 rounded-lg overflow-hidden chart-bg-gradient"
+        style={ReactDOM.Style.make(
+          ~background="linear-gradient(180deg, #eff6ff 0%, #f0f9ff 40%, #ffffff 100%)",
+          (),
+        )}>
         <GenericChartRenderer widget />
       </div>
     </div>

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
@@ -1,9 +1,4 @@
-let attachResizeHandlers: (
-  Dom.element,
-  int,
-  int,
-  (int, int) => unit,
-) => unit = %raw(`
+let attachResizeHandlers: (Dom.element, int, int, (int, int) => unit) => unit = %raw(`
   function(container, currentW, currentH, onResizeEnd) {
     container.querySelectorAll('.resize-handle').forEach(function(el) { el.remove() });
 

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardCanvas/WidgetCard.res
@@ -1,0 +1,212 @@
+let attachResizeHandlers: (
+  Dom.element,
+  int,
+  int,
+  (int, int) => unit,
+) => unit = %raw(`
+  function(container, currentW, currentH, onResizeEnd) {
+    container.querySelectorAll('.resize-handle').forEach(function(el) { el.remove() });
+
+    function getGridEl() {
+      var node = container.parentElement;
+      for (var i = 0; i < 8 && node; i++) {
+        if (node.classList && node.classList.contains('dashboard-grid')) return node;
+        node = node.parentElement;
+      }
+      return null;
+    }
+
+    var MIN_W = 2, MAX_W = 12, MIN_H = 2, MAX_H = 10, H_UNIT = 80;
+
+    function makeHandle(cls, cursor, axis) {
+      var el = document.createElement('div');
+      el.className = 'resize-handle ' + cls;
+      el.style.cssText = 'position:absolute;z-index:10;cursor:' + cursor + ';';
+      if (axis === 'x') { el.style.top='0';el.style.right='-4px';el.style.width='8px';el.style.height='100%'; }
+      else if (axis === 'y') { el.style.bottom='-4px';el.style.left='0';el.style.height='8px';el.style.width='100%'; }
+      else { el.style.bottom='-4px';el.style.right='-4px';el.style.width='18px';el.style.height='18px'; }
+
+      el.addEventListener('mouseenter', function() { el.style.background='rgba(59,130,246,0.3)'; });
+      el.addEventListener('mouseleave', function() { el.style.background='transparent'; });
+
+      el.addEventListener('mousedown', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        var startX = e.clientX, startY = e.clientY;
+        var gridEl = getGridEl();
+        var gridW = gridEl ? gridEl.getBoundingClientRect().width : 1200;
+        var oneCol = gridW / 12;
+
+        // Source of truth: state values passed in
+        var w = currentW, h = currentH;
+        var wPx = oneCol * w, hPx = h * H_UNIT;
+        var minWPx = oneCol * MIN_W, maxWPx = oneCol * MAX_W;
+        var minHPx = MIN_H * H_UNIT, maxHPx = MAX_H * H_UNIT;
+
+        // Snap container to state dimensions at drag start
+        container.style.height = hPx + 'px';
+        container.style.minHeight = '0px';
+        container.style.overflow = 'hidden';
+        container.style.outline = '2px solid #3b82f6';
+        container.style.outlineOffset = '2px';
+        container.style.transition = 'none';
+        document.body.style.cursor = cursor;
+        document.body.style.userSelect = 'none';
+
+        var label = container.querySelector('.size-label');
+
+        function onMove(ev) {
+          var dx = ev.clientX - startX, dy = ev.clientY - startY;
+          if (axis === 'x' || axis === 'xy') {
+            var newWPx = Math.max(minWPx, Math.min(maxWPx, wPx + dx));
+            container.style.width = newWPx + 'px';
+            w = Math.max(MIN_W, Math.min(MAX_W, Math.round(newWPx / oneCol)));
+          }
+          if (axis === 'y' || axis === 'xy') {
+            var newHPx = Math.max(minHPx, Math.min(maxHPx, hPx + dy));
+            container.style.height = newHPx + 'px';
+            h = Math.max(MIN_H, Math.min(MAX_H, Math.round(newHPx / H_UNIT)));
+          }
+          if (label) {
+            label.textContent = w + '/12 \u00d7 ' + h + 'h';
+            label.style.color = '#2563eb';
+            label.style.fontWeight = '600';
+          }
+        }
+
+        function onUp() {
+          document.removeEventListener('mousemove', onMove);
+          document.removeEventListener('mouseup', onUp);
+          document.body.style.cursor = '';
+          document.body.style.userSelect = '';
+          container.style.outline = '';
+          container.style.outlineOffset = '';
+          container.style.overflow = '';
+          container.style.transition = '';
+          // Keep height set until React re-renders with new value
+          container.style.height = (h * H_UNIT) + 'px';
+          container.style.minHeight = (h * H_UNIT) + 'px';
+          container.style.width = '';
+          if (label) { label.style.color = ''; label.style.fontWeight = ''; }
+          onResizeEnd(w, h);
+        }
+
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+      });
+      return el;
+    }
+
+    container.style.position = 'relative';
+    container.appendChild(makeHandle('r-right','ew-resize','x'));
+    container.appendChild(makeHandle('r-bottom','ns-resize','y'));
+    container.appendChild(makeHandle('r-corner','nwse-resize','xy'));
+  }
+`)
+
+let cleanupResizeHandlers: Dom.element => unit = %raw(`
+  function(container) {
+    container.querySelectorAll('.resize-handle').forEach(function(el) { el.remove() });
+    container.style.outline = '';
+    container.style.width = '';
+    container.style.height = '';
+    container.style.minHeight = '';
+    container.style.overflow = '';
+  }
+`)
+
+@react.component
+let make = (
+  ~widget: CustomDashboardTypes.widget,
+  ~isEditMode,
+  ~onEdit=() => (),
+  ~onRemove=() => (),
+  ~onResize=(~w as _: int, ~h as _: int) => (),
+  ~dragHandleProps=?,
+) => {
+  let borderClass = isEditMode ? "border-2 border-dashed border-blue-300 rounded-lg" : ""
+  let cardRef = React.useRef(Nullable.null)
+  let heightPx = widget.position.h * 80
+
+  // In edit mode use fixed height; in view mode use minHeight so content can expand
+  let cardStyle = if isEditMode {
+    ReactDOM.Style.make(~height=`${heightPx->Int.toString}px`, ~overflow="hidden", ())
+  } else {
+    ReactDOM.Style.make(~minHeight=`${heightPx->Int.toString}px`, ())
+  }
+
+  // Attach resize handles — re-runs when widget size changes (after resize end)
+  React.useEffect(() => {
+    switch cardRef.current->Nullable.toOption {
+    | Some(el) =>
+      if isEditMode {
+        let cb = (w, h) => onResize(~w, ~h)
+        attachResizeHandlers(el, widget.position.w, widget.position.h, cb)
+        Some(() => cleanupResizeHandlers(el))
+      } else {
+        cleanupResizeHandlers(el)
+        None
+      }
+    | None => None
+    }
+  }, (isEditMode, widget.position.w, widget.position.h))
+
+  <InsightsHelper.Card>
+    <div ref={cardRef->ReactDOM.Ref.domRef} className={borderClass} style={cardStyle}>
+      <div className="flex items-center justify-between px-4 pt-3 pb-1">
+        <div className="flex items-center gap-2">
+          {if isEditMode {
+            switch dragHandleProps {
+            | Some(props) =>
+              React.cloneElement(
+                <span className="cursor-grab text-gray-400 text-lg select-none">
+                  {React.string({`\u2630`})}
+                </span>,
+                props,
+              )
+            | None =>
+              <span className="cursor-grab text-gray-400 text-lg select-none">
+                {React.string({`\u2630`})}
+              </span>
+            }
+          } else {
+            React.null
+          }}
+          <p className="text-base font-semibold text-jp-gray-900 dark:text-white">
+            {React.string(widget.widgetName)}
+          </p>
+          {if isEditMode {
+            <span className="text-xs ml-2 text-gray-400 size-label">
+              {React.string(
+                `${widget.position.w->Int.toString}/12 \u00d7 ${widget.position.h->Int.toString}h`,
+              )}
+            </span>
+          } else {
+            React.null
+          }}
+        </div>
+        {if isEditMode {
+          <div className="flex items-center gap-2">
+            <button
+              className="p-1.5 rounded-md hover:bg-gray-100 text-gray-500 hover:text-blue-600 transition-colors"
+              title="Edit widget"
+              onClick={_ => onEdit()}>
+              <Icon name="nd-pencil-edit-box" size=16 />
+            </button>
+            <button
+              className="p-1.5 rounded-md hover:bg-red-50 text-red-400 hover:text-red-600 transition-colors"
+              title="Remove widget"
+              onClick={_ => onRemove()}>
+              <Icon name="nd-cross" size=16 />
+            </button>
+          </div>
+        } else {
+          React.null
+        }}
+      </div>
+      <div className="px-2 pb-4 overflow-hidden">
+        <GenericChartRenderer widget />
+      </div>
+    </div>
+  </InsightsHelper.Card>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardCard.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardCard.res
@@ -1,0 +1,165 @@
+@react.component
+let make = (
+  ~dashboard: CustomDashboardTypes.dashboard,
+  ~onOpen,
+  ~onDelete,
+  ~onSetDefault,
+  ~onRename,
+  ~onDuplicate,
+) => {
+  let widgetCount = dashboard.widgets->Array.length
+  let updatedText = CustomDashboardUtils.formatUpdatedAt(dashboard.updatedAt)
+  let (showMenu, setShowMenu) = React.useState(_ => false)
+  let (isRenaming, setIsRenaming) = React.useState(_ => false)
+  let (renameValue, setRenameValue) = React.useState(_ => dashboard.dashboardName)
+
+  let menuRef = React.useRef(Nullable.null)
+
+  // Close menu on outside click — delay so menu item clicks fire first
+  React.useEffect(() => {
+    if showMenu {
+      let handleClickOutside = (_evt: Dom.mouseEvent) => {
+        setShowMenu(_ => false)
+      }
+      let timerId = Js.Global.setTimeout(() => {
+        Webapi.Dom.document->Webapi.Dom.Document.addClickEventListener(handleClickOutside)
+      }, 10)
+      Some(
+        () => {
+          Js.Global.clearTimeout(timerId)
+          Webapi.Dom.document->Webapi.Dom.Document.removeClickEventListener(handleClickOutside)
+        },
+      )
+    } else {
+      None
+    }
+  }, [showMenu])
+
+  let handleRenameSubmit = () => {
+    let trimmed = renameValue->String.trim
+    if trimmed->LogicUtils.isNonEmptyString && trimmed !== dashboard.dashboardName {
+      onRename(trimmed)
+    }
+    setIsRenaming(_ => false)
+  }
+
+  <div
+    className="border rounded-lg bg-white dark:bg-jp-gray-lightgray_background overflow-visible hover:shadow-md transition-shadow h-full">
+    <div className="p-5 flex flex-col gap-3 h-full min-h-[180px]">
+      // Header
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {if dashboard.isDefault {
+            <Icon name="star" size=16 className="text-yellow-500 shrink-0" />
+          } else {
+            React.null
+          }}
+          {if isRenaming {
+            <input
+              autoFocus=true
+              type_="text"
+              value={renameValue}
+              onChange={evt => setRenameValue(_ => ReactEvent.Form.target(evt)["value"])}
+              onBlur={_ => handleRenameSubmit()}
+              onKeyDown={evt => {
+                if ReactEvent.Keyboard.key(evt) === "Enter" {
+                  handleRenameSubmit()
+                } else if ReactEvent.Keyboard.key(evt) === "Escape" {
+                  setIsRenaming(_ => false)
+                  setRenameValue(_ => dashboard.dashboardName)
+                }
+              }}
+              className="text-lg font-bold text-jp-gray-900 dark:text-white bg-transparent border-b-2 border-blue-500 outline-none w-full"
+            />
+          } else {
+            <p className="text-lg font-bold text-jp-gray-900 dark:text-white truncate">
+              {React.string(dashboard.dashboardName)}
+            </p>
+          }}
+        </div>
+        <div className="relative shrink-0 ml-2" ref={menuRef->ReactDOM.Ref.domRef}>
+          <button
+            className="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-jp-gray-lightgray_background text-gray-400 hover:text-gray-600"
+            onClick={evt => {
+              evt->JsxEvent.Mouse.stopPropagation
+              setShowMenu(prev => !prev)
+            }}>
+            <Icon name="ellipsis-v" size=16 />
+          </button>
+          {if showMenu {
+            <div
+              className="absolute right-0 mt-1 w-48 bg-white dark:bg-jp-gray-lightgray_background border rounded-lg shadow-lg z-20 py-1"
+              onClick={evt => evt->JsxEvent.Mouse.stopPropagation}>
+              // Rename
+              <button
+                className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-2.5"
+                onClick={_ => {
+                  setShowMenu(_ => false)
+                  setRenameValue(_ => dashboard.dashboardName)
+                  setIsRenaming(_ => true)
+                }}>
+                <Icon name="pencil-alt" size=14 />
+                {React.string("Rename")}
+              </button>
+              // Set as Default
+              <button
+                className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-2.5"
+                onClick={_ => {
+                  setShowMenu(_ => false)
+                  onSetDefault()
+                }}>
+                <Icon name="star" size=14 />
+                {React.string(dashboard.isDefault ? "Unset Default" : "Set as Default")}
+              </button>
+              // Duplicate
+              <button
+                className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 flex items-center gap-2.5"
+                onClick={_ => {
+                  setShowMenu(_ => false)
+                  onDuplicate()
+                }}>
+                <Icon name="nd-copy" size=14 />
+                {React.string("Duplicate")}
+              </button>
+              <div className="border-t my-1" />
+              // Delete
+              <button
+                className="w-full text-left px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 flex items-center gap-2.5"
+                onClick={_ => {
+                  setShowMenu(_ => false)
+                  onDelete()
+                }}>
+                <Icon name="nd-delete-dustbin" size=14 />
+                {React.string("Delete")}
+              </button>
+            </div>
+          } else {
+            React.null
+          }}
+        </div>
+      </div>
+      // Description
+      {switch dashboard.description {
+      | Some(desc) if desc->LogicUtils.isNonEmptyString =>
+        <p className="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">
+          {React.string(desc)}
+        </p>
+      | _ => React.null
+      }}
+      // Footer
+      <div className="mt-auto flex items-center justify-between pt-2 border-t border-gray-100">
+        <div className="flex items-center gap-4 text-xs text-gray-400">
+          <span>
+            {React.string(`${widgetCount->Int.toString} widget${widgetCount !== 1 ? "s" : ""}`)}
+          </span>
+          {if updatedText->LogicUtils.isNonEmptyString {
+            <span> {React.string(`Updated: ${updatedText}`)} </span>
+          } else {
+            React.null
+          }}
+        </div>
+        <Button text="Open" buttonType={Secondary} buttonSize=Small onClick={_ => onOpen()} />
+      </div>
+    </div>
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardCard.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardCard.res
@@ -9,6 +9,7 @@ let make = (
 ) => {
   let widgetCount = dashboard.widgets->Array.length
   let updatedText = CustomDashboardUtils.formatUpdatedAt(dashboard.updatedAt)
+  let showPopUp = PopUpState.useShowPopUp()
   let (showMenu, setShowMenu) = React.useState(_ => false)
   let (isRenaming, setIsRenaming) = React.useState(_ => false)
   let (renameValue, setRenameValue) = React.useState(_ => dashboard.dashboardName)
@@ -127,7 +128,16 @@ let make = (
                 className="w-full text-left px-4 py-2.5 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 flex items-center gap-2.5"
                 onClick={_ => {
                   setShowMenu(_ => false)
-                  onDelete()
+                  showPopUp({
+                    popUpType: (Danger, WithoutIcon),
+                    heading: `Delete '${dashboard.dashboardName}'?`,
+                    description: "This dashboard will be deleted permanently"->React.string,
+                    handleCancel: {text: "Cancel"},
+                    handleConfirm: {
+                      text: "Delete Dashboard",
+                      onClick: _ => onDelete(),
+                    },
+                  })
                 }}>
                 <Icon name="nd-delete-dustbin" size=14 />
                 {React.string("Delete")}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardEmptyState.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardEmptyState.res
@@ -17,10 +17,6 @@ let make = (~onCreateClick) => {
         )}
       </p>
     </div>
-    <Button
-      text="+ Create Dashboard"
-      buttonType={Primary}
-      onClick={_ => onCreateClick()}
-    />
+    <Button text="+ Create Dashboard" buttonType={Primary} onClick={_ => onCreateClick()} />
   </div>
 }

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardEmptyState.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardEmptyState.res
@@ -1,0 +1,26 @@
+@react.component
+let make = (~onCreateClick) => {
+  <div className="flex flex-col items-center justify-center py-20 gap-6">
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="w-20 h-20 rounded-xl bg-blue-50 dark:bg-jp-gray-lightgray_background flex items-center justify-center">
+        <Icon name="graph-dark" size=32 />
+      </div>
+    </div>
+    <div className="flex flex-col items-center gap-2 text-center">
+      <p className="text-xl font-semibold text-jp-gray-900 dark:text-white">
+        {React.string("Build Your Custom Dashboard")}
+      </p>
+      <p className="text-sm text-grey-text max-w-md">
+        {React.string(
+          "Combine charts from payments, refunds, and disputes into a single view tailored to your business needs.",
+        )}
+      </p>
+    </div>
+    <Button
+      text="+ Create Dashboard"
+      buttonType={Primary}
+      onClick={_ => onCreateClick()}
+    />
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
@@ -39,9 +39,7 @@ let make = (~onOpenDashboard) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
       let data =
-        Dict.fromArray([
-          ("dashboard_name", dashboardName->JSON.Encode.string),
-        ])->JSON.Encode.object
+        Dict.fromArray([("dashboard_name", dashboardName->JSON.Encode.string)])->JSON.Encode.object
       let body = CustomDashboardUtils.buildOperationBody(~operationType="Delete", ~data)
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard deleted", ~toastType=ToastSuccess)
@@ -57,7 +55,7 @@ let make = (~onOpenDashboard) => {
       let data =
         Dict.fromArray([
           ("dashboard_name", dashboardName->JSON.Encode.string),
-          ("is_default", (!currentlyDefault)->JSON.Encode.bool),
+          ("is_default", !currentlyDefault->JSON.Encode.bool),
         ])->JSON.Encode.object
       let body = CustomDashboardUtils.buildOperationBody(~operationType="Update", ~data)
       let _ = await updateDetails(url, body, Post)
@@ -102,15 +100,12 @@ let make = (~onOpenDashboard) => {
         ("description", `Duplicated from ${dashboardName}`->JSON.Encode.string),
       ]
       let dataEntries = if widgets->Array.length > 0 {
-        dataEntries->Array.concat([
-          ("widgets", widgets->CustomDashboardUtils.serializeWidgets),
-        ])
+        dataEntries->Array.concat([("widgets", widgets->CustomDashboardUtils.serializeWidgets)])
       } else {
         dataEntries
       }
       let data = dataEntries->Dict.fromArray->JSON.Encode.object
-      let body = CustomDashboardUtils.buildOperationBody(~operationType="Create", ~data,
-      )
+      let body = CustomDashboardUtils.buildOperationBody(~operationType="Create", ~data)
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard duplicated", ~toastType=ToastSuccess)
       fetchDashboards()->ignore
@@ -152,7 +147,8 @@ let make = (~onOpenDashboard) => {
               dashboard
               onOpen={() => onOpenDashboard(dashboard)}
               onDelete={() => handleDelete(dashboard.dashboardName)->ignore}
-              onSetDefault={() => handleSetDefault(dashboard.dashboardName, dashboard.isDefault)->ignore}
+              onSetDefault={() =>
+                handleSetDefault(dashboard.dashboardName, dashboard.isDefault)->ignore}
               onRename={newName => handleRename(dashboard.dashboardName, newName)->ignore}
               onDuplicate={() => handleDuplicate(dashboard.dashboardName)->ignore}
             />

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
@@ -23,9 +23,10 @@ let make = (~onOpenDashboard) => {
       setDashboards(_ => parsed)
       setScreenState(_ => Success)
     } catch {
-    | _ =>
-      setDashboards(_ => [])
-      setScreenState(_ => Success)
+    | _ => {
+        setDashboards(_ => [])
+        setScreenState(_ => Error("Failed to load dashboards"))
+      }
     }
   }
 
@@ -37,12 +38,11 @@ let make = (~onOpenDashboard) => {
   let handleDelete = async (dashboardName: string) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let data = Dict.make()
-      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
-      let body = CustomDashboardUtils.buildOperationBody(
-        ~operationType="Delete",
-        ~data=data->JSON.Encode.object,
-      )
+      let data =
+        Dict.fromArray([
+          ("dashboard_name", dashboardName->JSON.Encode.string),
+        ])->JSON.Encode.object
+      let body = CustomDashboardUtils.buildOperationBody(~operationType="Delete", ~data)
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard deleted", ~toastType=ToastSuccess)
       fetchDashboards()->ignore
@@ -51,16 +51,15 @@ let make = (~onOpenDashboard) => {
     }
   }
 
-  let handleSetDefault = async (dashboardName: string) => {
+  let handleSetDefault = async (dashboardName: string, currentlyDefault: bool) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let data = Dict.make()
-      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
-      data->Dict.set("is_default", true->JSON.Encode.bool)
-      let body = CustomDashboardUtils.buildOperationBody(
-        ~operationType="Update",
-        ~data=data->JSON.Encode.object,
-      )
+      let data =
+        Dict.fromArray([
+          ("dashboard_name", dashboardName->JSON.Encode.string),
+          ("is_default", (!currentlyDefault)->JSON.Encode.bool),
+        ])->JSON.Encode.object
+      let body = CustomDashboardUtils.buildOperationBody(~operationType="Update", ~data)
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Default updated", ~toastType=ToastSuccess)
       fetchDashboards()->ignore
@@ -72,13 +71,12 @@ let make = (~onOpenDashboard) => {
   let handleRename = async (dashboardName: string, newName: string) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let data = Dict.make()
-      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
-      data->Dict.set("new_dashboard_name", newName->JSON.Encode.string)
-      let body = CustomDashboardUtils.buildOperationBody(
-        ~operationType="Update",
-        ~data=data->JSON.Encode.object,
-      )
+      let data =
+        Dict.fromArray([
+          ("dashboard_name", dashboardName->JSON.Encode.string),
+          ("new_dashboard_name", newName->JSON.Encode.string),
+        ])->JSON.Encode.object
+      let body = CustomDashboardUtils.buildOperationBody(~operationType="Update", ~data)
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard renamed", ~toastType=ToastSuccess)
       fetchDashboards()->ignore
@@ -90,24 +88,28 @@ let make = (~onOpenDashboard) => {
   let handleDuplicate = async (dashboardName: string) => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      // Find the source dashboard to copy its widgets
       let sourceDashboard = dashboards->Array.find(d => d.dashboardName === dashboardName)
       let widgets = switch sourceDashboard {
-      | Some(d) => d.widgets
+      | Some(d) =>
+        d.widgets->Array.map(widget => {
+          ...widget,
+          widgetId: `${Date.now()->Float.toString}-${Math.random()->Float.toString}`,
+        })
       | None => []
       }
-      let data = Dict.make()
-      data->Dict.set(
-        "dashboard_name",
-        `${dashboardName} (Copy)`->JSON.Encode.string,
-      )
-      data->Dict.set("description", `Duplicated from ${dashboardName}`->JSON.Encode.string)
-      if widgets->Array.length > 0 {
-        data->Dict.set("widgets", widgets->Identity.genericTypeToJson)
+      let dataEntries = [
+        ("dashboard_name", `${dashboardName} (Copy)`->JSON.Encode.string),
+        ("description", `Duplicated from ${dashboardName}`->JSON.Encode.string),
+      ]
+      let dataEntries = if widgets->Array.length > 0 {
+        dataEntries->Array.concat([
+          ("widgets", widgets->CustomDashboardUtils.serializeWidgets),
+        ])
+      } else {
+        dataEntries
       }
-      let body = CustomDashboardUtils.buildOperationBody(
-        ~operationType="Create",
-        ~data=data->JSON.Encode.object,
+      let data = dataEntries->Dict.fromArray->JSON.Encode.object
+      let body = CustomDashboardUtils.buildOperationBody(~operationType="Create", ~data,
       )
       let _ = await updateDetails(url, body, Post)
       showToast(~message="Dashboard duplicated", ~toastType=ToastSuccess)
@@ -144,13 +146,13 @@ let make = (~onOpenDashboard) => {
       } else {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {dashboards
-          ->Array.mapWithIndex((dashboard, index) =>
+          ->Array.map(dashboard =>
             <DashboardCard
-              key={index->Int.toString}
+              key={dashboard.dashboardName}
               dashboard
               onOpen={() => onOpenDashboard(dashboard)}
               onDelete={() => handleDelete(dashboard.dashboardName)->ignore}
-              onSetDefault={() => handleSetDefault(dashboard.dashboardName)->ignore}
+              onSetDefault={() => handleSetDefault(dashboard.dashboardName, dashboard.isDefault)->ignore}
               onRename={newName => handleRename(dashboard.dashboardName, newName)->ignore}
               onDuplicate={() => handleDuplicate(dashboard.dashboardName)->ignore}
             />

--- a/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
+++ b/src/screens/NewAnalytics/CustomDashboards/DashboardList/DashboardList.res
@@ -1,0 +1,187 @@
+@react.component
+let make = (~onOpenDashboard) => {
+  open APIUtils
+  let getURL = useGetURL()
+  let fetchDetails = useGetMethod()
+  let updateDetails = useUpdateMethod()
+  let showToast = ToastState.useShowToast()
+  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+  let (dashboards, setDashboards) = React.useState(_ => [])
+  let (showCreateModal, setShowCreateModal) = React.useState(_ => false)
+
+  let fetchDashboards = async () => {
+    try {
+      setScreenState(_ => Loading)
+      let url = getURL(
+        ~entityName=V1(USERS),
+        ~userType=#USER_DATA,
+        ~methodType=Get,
+        ~queryParameters=Some("keys=CustomDashboards"),
+      )
+      let response = await fetchDetails(url)
+      let parsed = CustomDashboardUtils.parseDashboards(response)
+      setDashboards(_ => parsed)
+      setScreenState(_ => Success)
+    } catch {
+    | _ =>
+      setDashboards(_ => [])
+      setScreenState(_ => Success)
+    }
+  }
+
+  React.useEffect(() => {
+    fetchDashboards()->ignore
+    None
+  }, [])
+
+  let handleDelete = async (dashboardName: string) => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      let data = Dict.make()
+      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="Delete",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      showToast(~message="Dashboard deleted", ~toastType=ToastSuccess)
+      fetchDashboards()->ignore
+    } catch {
+    | _ => showToast(~message="Failed to delete dashboard", ~toastType=ToastError)
+    }
+  }
+
+  let handleSetDefault = async (dashboardName: string) => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      let data = Dict.make()
+      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
+      data->Dict.set("is_default", true->JSON.Encode.bool)
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="Update",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      showToast(~message="Default updated", ~toastType=ToastSuccess)
+      fetchDashboards()->ignore
+    } catch {
+    | _ => showToast(~message="Failed to update dashboard", ~toastType=ToastError)
+    }
+  }
+
+  let handleRename = async (dashboardName: string, newName: string) => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      let data = Dict.make()
+      data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
+      data->Dict.set("new_dashboard_name", newName->JSON.Encode.string)
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="Update",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      showToast(~message="Dashboard renamed", ~toastType=ToastSuccess)
+      fetchDashboards()->ignore
+    } catch {
+    | _ => showToast(~message="Failed to rename dashboard", ~toastType=ToastError)
+    }
+  }
+
+  let handleDuplicate = async (dashboardName: string) => {
+    try {
+      let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+      // Find the source dashboard to copy its widgets
+      let sourceDashboard = dashboards->Array.find(d => d.dashboardName === dashboardName)
+      let widgets = switch sourceDashboard {
+      | Some(d) => d.widgets
+      | None => []
+      }
+      let data = Dict.make()
+      data->Dict.set(
+        "dashboard_name",
+        `${dashboardName} (Copy)`->JSON.Encode.string,
+      )
+      data->Dict.set("description", `Duplicated from ${dashboardName}`->JSON.Encode.string)
+      if widgets->Array.length > 0 {
+        data->Dict.set("widgets", widgets->Identity.genericTypeToJson)
+      }
+      let body = CustomDashboardUtils.buildOperationBody(
+        ~operationType="Create",
+        ~data=data->JSON.Encode.object,
+      )
+      let _ = await updateDetails(url, body, Post)
+      showToast(~message="Dashboard duplicated", ~toastType=ToastSuccess)
+      fetchDashboards()->ignore
+    } catch {
+    | _ => showToast(~message="Failed to duplicate dashboard", ~toastType=ToastError)
+    }
+  }
+
+  let handleCreateSuccess = (dashboard: CustomDashboardTypes.dashboard) => {
+    setShowCreateModal(_ => false)
+    fetchDashboards()->ignore
+    onOpenDashboard(dashboard)
+  }
+
+  <PageLoaderWrapper screenState>
+    <div className="mt-5 flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <p className="text-xl font-semibold text-jp-gray-900 dark:text-white">
+          {React.string("My Dashboards")}
+        </p>
+        {if dashboards->Array.length > 0 {
+          <Button
+            text="+ Create Dashboard"
+            buttonType={Primary}
+            onClick={_ => setShowCreateModal(_ => true)}
+          />
+        } else {
+          React.null
+        }}
+      </div>
+      {if dashboards->Array.length === 0 {
+        <DashboardEmptyState onCreateClick={() => setShowCreateModal(_ => true)} />
+      } else {
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {dashboards
+          ->Array.mapWithIndex((dashboard, index) =>
+            <DashboardCard
+              key={index->Int.toString}
+              dashboard
+              onOpen={() => onOpenDashboard(dashboard)}
+              onDelete={() => handleDelete(dashboard.dashboardName)->ignore}
+              onSetDefault={() => handleSetDefault(dashboard.dashboardName)->ignore}
+              onRename={newName => handleRename(dashboard.dashboardName, newName)->ignore}
+              onDuplicate={() => handleDuplicate(dashboard.dashboardName)->ignore}
+            />
+          )
+          ->React.array}
+          {if dashboards->Array.length < CustomDashboardConstants.maxDashboards {
+            <div
+              className="border-2 border-dashed border-blue-300 rounded-lg bg-blue-50/30 dark:bg-blue-900/10 flex flex-col items-center justify-center gap-3 min-h-[180px] cursor-pointer hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+              onClick={_ => setShowCreateModal(_ => true)}>
+              <Icon name="nd-plus" size=20 className="text-blue-500" />
+              <span className="text-sm font-medium text-blue-600">
+                {React.string("Create Dashboard")}
+              </span>
+              <span className="text-xs text-gray-400 text-center">
+                {React.string("Start building your")}
+                <br />
+                {React.string("custom analytics view")}
+              </span>
+            </div>
+          } else {
+            React.null
+          }}
+        </div>
+      }}
+      {if showCreateModal {
+        <CreateDashboardModal
+          onClose={() => setShowCreateModal(_ => false)} onSuccess={handleCreateSuccess}
+        />
+      } else {
+        React.null
+      }}
+    </div>
+  </PageLoaderWrapper>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
@@ -1,0 +1,147 @@
+@react.component
+let make = (~widget: CustomDashboardTypes.widget) => {
+  open APIUtils
+  open LogicUtils
+  open InsightsUtils
+  let getURL = useGetURL()
+  let updateDetails = useUpdateMethod()
+  let {filterValueJson} = React.useContext(FilterContext.filterContext)
+  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+  let (chartData, setChartData) = React.useState(_ => JSON.Encode.array([]))
+  let (rawData, setRawData) = React.useState(_ => [])
+  let startTimeVal = filterValueJson->getString("startTime", "")
+  let endTimeVal = filterValueJson->getString("endTime", "")
+  let isoStringToCustomTimeZone = TimeZoneHook.useIsoStringToCustomTimeZone()
+  let featureFlag = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+
+  let widgetConfig = widget.config
+  let title = widget.widgetName
+  let primaryMetric = widgetConfig.metrics->Array.get(0)->Option.getOr("")
+
+  let fetchData = async () => {
+    if startTimeVal->isNonEmptyString && endTimeVal->isNonEmptyString {
+      setScreenState(_ => Loading)
+      try {
+        let url = getURL(
+          ~entityName=CustomDashboardUtils.getDomainApiEntity(widgetConfig.domain),
+          ~methodType=Post,
+          ~id=Some(CustomDashboardUtils.getDomainString(widgetConfig.domain)),
+        )
+
+        let metrics: array<InsightsTypes.metrics> =
+          widgetConfig.metrics->Array.map(m => m->Obj.magic)
+
+        let groupByNames = if widgetConfig.groupBy->Array.length > 0 {
+          Some(widgetConfig.groupBy)
+        } else {
+          None
+        }
+
+        let body = switch widgetConfig.granularity {
+        | Some(g) =>
+          requestBody(
+            ~startTime=startTimeVal,
+            ~endTime=endTimeVal,
+            ~metrics,
+            ~groupByNames,
+            ~granularity=Some(g),
+            ~filter=generateFilterObject(~globalFilters=filterValueJson)->Some,
+          )
+        | None =>
+          requestBody(
+            ~startTime=startTimeVal,
+            ~endTime=endTimeVal,
+            ~metrics,
+            ~groupByNames,
+            ~filter=generateFilterObject(~globalFilters=filterValueJson)->Some,
+          )
+        }
+        let response = await updateDetails(url, body, Post)
+        let queryData =
+          response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+
+        if queryData->Array.length > 0 {
+          setRawData(_ => queryData)
+
+          switch widget.chartType {
+          | LineChart | ColumnChart => {
+              let sortedData = queryData->NewAnalyticsUtils.sortQueryDataByDate
+              let filledData = [sortedData]->Array.map(data => {
+                fillMissingDataPoints(
+                  ~data,
+                  ~startDate=startTimeVal,
+                  ~endDate=endTimeVal,
+                  ~timeKey="time_bucket",
+                  ~defaultValue={
+                    "time_bucket": startTimeVal,
+                  }->Identity.genericTypeToJson,
+                  ~granularity=widgetConfig.granularity->Option.getOr("G_ONEDAY"),
+                  ~isoStringToCustomTimeZone,
+                  ~granularityEnabled=featureFlag.granularity,
+                )
+              })
+              setChartData(_ => filledData->Identity.genericTypeToJson)
+            }
+          | _ => setChartData(_ => queryData->Identity.genericTypeToJson)
+          }
+          setScreenState(_ => Success)
+        } else {
+          setScreenState(_ => Custom)
+        }
+      } catch {
+      | _ => setScreenState(_ => Custom)
+      }
+    }
+  }
+
+  React.useEffect(() => {
+    fetchData()->ignore
+    None
+  }, (startTimeVal, endTimeVal, filterValueJson))
+
+  <PageLoaderWrapper
+    screenState customLoader={<InsightsHelper.Shimmer layoutId=title />} customUI={<NewAnalyticsHelper.NoData />}>
+    {switch widget.chartType {
+    | LineChart => {
+        let payload = GenericChartRendererUtils.buildLineGraphPayload(
+          ~data=chartData,
+          ~xKey=primaryMetric,
+          ~yKey="time_bucket",
+          ~title,
+        )
+        let options = LineGraphUtils.getLineGraphOptions(payload)
+        <LineGraph options className="mr-3" />
+      }
+    | BarChart => {
+        let payload = GenericChartRendererUtils.buildBarGraphPayload(
+          ~data=rawData,
+          ~xKey=primaryMetric,
+          ~yKey=widgetConfig.groupBy->Array.get(0)->Option.getOr("time_bucket"),
+          ~title,
+        )
+        let options = BarGraphUtils.getBarGraphOptions(payload)
+        <BarGraph options className="mr-3" />
+      }
+    | ColumnChart => {
+        let payload = GenericChartRendererUtils.buildLineGraphPayload(
+          ~data=chartData,
+          ~xKey=primaryMetric,
+          ~yKey="time_bucket",
+          ~title,
+        )
+        let options = LineGraphUtils.getLineGraphOptions(payload)
+        <LineGraph options className="mr-3" />
+      }
+    | PieChart | StackedBarChart | SankeyChart | FunnelChart => {
+        let payload = GenericChartRendererUtils.buildBarGraphPayload(
+          ~data=rawData,
+          ~xKey=primaryMetric,
+          ~yKey=widgetConfig.groupBy->Array.get(0)->Option.getOr("time_bucket"),
+          ~title,
+        )
+        let options = BarGraphUtils.getBarGraphOptions(payload)
+        <BarGraph options className="mr-3" />
+      }
+    }}
+  </PageLoaderWrapper>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
@@ -17,19 +17,28 @@ let make = (~widget: CustomDashboardTypes.widget) => {
   let widgetConfig = widget.config
   let title = widget.widgetName
   let primaryMetric = widgetConfig.metrics->Array.get(0)->Option.getOr("")
+  let responseField = WidgetConfiguratorUtils.getResponseFieldName(primaryMetric)
+  let groupByKey = widgetConfig.groupBy->Array.get(0)->Option.getOr("time_bucket")
+  let isTimeSeries = WidgetConfiguratorUtils.needsTimeSeries(widget.chartType)
+  let chartHeightPx = Math.Int.max(120, widget.position.h * 80 - 60)
 
   let fetchData = async () => {
     if startTimeVal->isNonEmptyString && endTimeVal->isNonEmptyString {
       setScreenState(_ => Loading)
       try {
-        let url = getURL(
-          ~entityName=CustomDashboardUtils.getDomainApiEntity(widgetConfig.domain),
-          ~methodType=Post,
-          ~id=Some(CustomDashboardUtils.getDomainString(widgetConfig.domain)),
+        let entityName = CustomDashboardUtils.getDomainApiEntity(
+          widgetConfig.domain,
+          ~metrics=widgetConfig.metrics,
         )
+        let idParam = switch widgetConfig.domain {
+        | AuthEvents => None
+        | _ => Some(CustomDashboardUtils.getDomainString(widgetConfig.domain))
+        }
+        let url = getURL(~entityName, ~methodType=Post, ~id=idParam)
 
-        let metrics: array<InsightsTypes.metrics> =
-          widgetConfig.metrics->Array.map(m => m->Obj.magic)
+        // Type-safe conversion of metric strings to polyvariants
+        // Uses explicit mapping instead of Obj.magic for type safety
+        let metrics = CustomDashboardUtils.metricsStringsToPolyvariants(widgetConfig.metrics)
 
         let groupByNames = if widgetConfig.groupBy->Array.length > 0 {
           Some(widgetConfig.groupBy)
@@ -38,7 +47,7 @@ let make = (~widget: CustomDashboardTypes.widget) => {
         }
 
         let body = switch widgetConfig.granularity {
-        | Some(g) =>
+        | Some(g) if isTimeSeries =>
           requestBody(
             ~startTime=startTimeVal,
             ~endTime=endTimeVal,
@@ -47,7 +56,7 @@ let make = (~widget: CustomDashboardTypes.widget) => {
             ~granularity=Some(g),
             ~filter=generateFilterObject(~globalFilters=filterValueJson)->Some,
           )
-        | None =>
+        | _ =>
           requestBody(
             ~startTime=startTimeVal,
             ~endTime=endTimeVal,
@@ -57,32 +66,28 @@ let make = (~widget: CustomDashboardTypes.widget) => {
           )
         }
         let response = await updateDetails(url, body, Post)
-        let queryData =
-          response->getDictFromJsonObject->getArrayFromDict("queryData", [])
+        let queryData = response->getDictFromJsonObject->getArrayFromDict("queryData", [])
 
         if queryData->Array.length > 0 {
           setRawData(_ => queryData)
 
-          switch widget.chartType {
-          | LineChart | ColumnChart => {
-              let sortedData = queryData->NewAnalyticsUtils.sortQueryDataByDate
-              let filledData = [sortedData]->Array.map(data => {
-                fillMissingDataPoints(
-                  ~data,
-                  ~startDate=startTimeVal,
-                  ~endDate=endTimeVal,
-                  ~timeKey="time_bucket",
-                  ~defaultValue={
-                    "time_bucket": startTimeVal,
-                  }->Identity.genericTypeToJson,
-                  ~granularity=widgetConfig.granularity->Option.getOr("G_ONEDAY"),
-                  ~isoStringToCustomTimeZone,
-                  ~granularityEnabled=featureFlag.granularity,
-                )
-              })
-              setChartData(_ => filledData->Identity.genericTypeToJson)
-            }
-          | _ => setChartData(_ => queryData->Identity.genericTypeToJson)
+          if isTimeSeries {
+            let sortedData = queryData->NewAnalyticsUtils.sortQueryDataByDate
+            let filledData = [sortedData]->Array.map(data => {
+              fillMissingDataPoints(
+                ~data,
+                ~startDate=startTimeVal,
+                ~endDate=endTimeVal,
+                ~timeKey="time_bucket",
+                ~defaultValue={"time_bucket": startTimeVal}->Identity.genericTypeToJson,
+                ~granularity=widgetConfig.granularity->Option.getOr("G_ONEDAY"),
+                ~isoStringToCustomTimeZone,
+                ~granularityEnabled=featureFlag.granularity,
+              )
+            })
+            setChartData(_ => filledData->Identity.genericTypeToJson)
+          } else {
+            setChartData(_ => queryData->Identity.genericTypeToJson)
           }
           setScreenState(_ => Success)
         } else {
@@ -97,51 +102,266 @@ let make = (~widget: CustomDashboardTypes.widget) => {
   React.useEffect(() => {
     fetchData()->ignore
     None
-  }, (startTimeVal, endTimeVal, filterValueJson))
+  }, (startTimeVal, endTimeVal, filterValueJson, primaryMetric, groupByKey, (widget.chartType :> string)))
 
-  <PageLoaderWrapper
-    screenState customLoader={<InsightsHelper.Shimmer layoutId=title />} customUI={<NewAnalyticsHelper.NoData />}>
-    {switch widget.chartType {
-    | LineChart => {
-        let payload = GenericChartRendererUtils.buildLineGraphPayload(
-          ~data=chartData,
-          ~xKey=primaryMetric,
-          ~yKey="time_bucket",
-          ~title,
-        )
-        let options = LineGraphUtils.getLineGraphOptions(payload)
-        <LineGraph options className="mr-3" />
+  let containerStyle = ReactDOM.Style.make(
+    ~height=`${chartHeightPx->Int.toString}px`,
+    ~width="100%",
+    (),
+  )
+
+  <div style={containerStyle}>
+    <PageLoaderWrapper
+      screenState
+      customLoader={<InsightsHelper.Shimmer layoutId=title />}
+      customUI={<NewAnalyticsHelper.NoData />}>
+      {
+        switch widget.chartType {
+        | LineChart => {
+            let payload = GenericChartRendererUtils.buildLineGraphPayload(
+              ~data=chartData,
+              ~xKey=responseField,
+              ~yKey="time_bucket",
+              ~title,
+              ~chartHeight=chartHeightPx,
+            )
+            let options = LineGraphUtils.getLineGraphOptions(payload)
+            <LineGraph options />
+          }
+        | BarChart => {
+            let payload = GenericChartRendererUtils.buildBarGraphPayload(
+              ~data=rawData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~title,
+            )
+            let options = BarGraphUtils.getBarGraphOptions(payload)
+            <BarGraph options />
+          }
+        | ColumnChart => {
+            let payload = GenericChartRendererUtils.buildColumnGraphPayload(
+              ~data=rawData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~title,
+            )
+            let options = ColumnGraphUtils.getColumnGraphOptions(payload)
+            <ColumnGraph options />
+          }
+        | StackedBarChart => {
+            let payload = GenericChartRendererUtils.buildStackedBarGraphPayload(
+              ~data=rawData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~_title=title,
+            )
+            let options = StackedBarGraphUtils.getStackedBarGraphOptions(
+              payload,
+              ~yMax=100,
+              ~labelItemDistance=20,
+            )
+            <StackedBarGraph options />
+          }
+        | FunnelChart => {
+            let payload = GenericChartRendererUtils.buildFunnelData(
+              ~data=rawData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~title,
+            )
+            let options = ColumnGraphUtils.getColumnGraphOptions(payload)
+            <ColumnGraph options />
+          }
+        | SankeyChart => {
+            let payload = GenericChartRendererUtils.buildSankeyGraphPayload(
+              ~data=rawData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~title,
+            )
+            let options = SankeyGraphUtils.getSankyGraphOptions(payload)
+            <SankeyGraph options />
+          }
+        | PieChart => {
+            let filteredData = rawData->Array.filter(item => {
+              let dict = item->getDictFromJsonObject
+              let val = dict->getString(groupByKey, "")
+              val->isNonEmptyString
+            })
+            let payload = GenericChartRendererUtils.buildPieGraphPayload(
+              ~data=filteredData,
+              ~xKey=responseField,
+              ~yKey=groupByKey,
+              ~title,
+            )
+            let options = PieGraphUtils.getPieChartOptions(payload)
+            <div className="flex items-center justify-center h-full overflow-hidden">
+              <PieGraph options />
+            </div>
+          }
+        // ── Table View ──
+        | Table => {
+            let columns = if rawData->Array.length > 0 {
+              rawData
+              ->Array.get(0)
+              ->Option.map(item => item->getDictFromJsonObject->Dict.keysToArray)
+              ->Option.getOr([])
+              ->Array.filter(key =>
+                // Filter out null-only columns and internal fields
+                key !== "time_range" &&
+                rawData->Array.some(row =>
+                  row->getDictFromJsonObject->Dict.get(key)->Option.map(v =>
+                    v !== JSON.Encode.null
+                  )->Option.getOr(false)
+                )
+              )
+            } else {
+              []
+            }
+            <div className="overflow-auto h-full">
+              <table className="w-full text-sm text-left">
+                <thead className="text-xs text-gray-500 uppercase bg-gray-50 dark:bg-jp-gray-950 sticky top-0">
+                  <tr>
+                    {columns
+                    ->Array.map(col =>
+                      <th key={col} className="px-4 py-3 font-medium border-b">
+                        {React.string(col->LogicUtils.snakeToTitle)}
+                      </th>
+                    )
+                    ->React.array}
+                  </tr>
+                </thead>
+                <tbody>
+                  {rawData
+                  ->Array.mapWithIndex((row, rowIdx) => {
+                    let dict = row->getDictFromJsonObject
+                    <tr
+                      key={rowIdx->Int.toString}
+                      className="border-b hover:bg-gray-50 dark:hover:bg-jp-gray-950">
+                      {columns
+                      ->Array.map(col => {
+                        let val = dict->Dict.get(col)->Option.getOr(JSON.Encode.null)
+                        let display = switch val->JSON.Classify.classify {
+                        | String(s) => s->LogicUtils.snakeToTitle
+                        | Number(n) =>
+                          if n->Float.toInt->Int.toFloat === n {
+                            n->Float.toInt->Int.toString
+                          } else {
+                            n->Js.Float.toFixedWithPrecision(~digits=2)
+                          }
+                        | Bool(b) => b ? "Yes" : "No"
+                        | Null => "-"
+                        | _ => "-"
+                        }
+                        <td key={col} className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                          {React.string(display)}
+                        </td>
+                      })
+                      ->React.array}
+                    </tr>
+                  })
+                  ->React.array}
+                </tbody>
+              </table>
+            </div>
+          }
+        // ── Stat Number (big single value) ──
+        | StatNumber => {
+            // Get the first data point's value for the primary metric
+            let value = rawData
+              ->Array.get(0)
+              ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
+              ->Option.getOr(0.0)
+            let isRate = primaryMetric->Js.String2.includes("rate") || primaryMetric->Js.String2.includes("pct")
+            let displayValue = if isRate {
+              `${value->Js.Float.toFixedWithPrecision(~digits=1)}%`
+            } else if value > 1000000.0 {
+              `${(value /. 1000000.0)->Js.Float.toFixedWithPrecision(~digits=2)}M`
+            } else if value > 1000.0 {
+              `${(value /. 1000.0)->Js.Float.toFixedWithPrecision(~digits=1)}K`
+            } else if value->Float.toInt->Int.toFloat === value {
+              value->Float.toInt->Int.toString
+            } else {
+              value->Js.Float.toFixedWithPrecision(~digits=2)
+            }
+            <div className="flex flex-col items-center justify-center h-full gap-2">
+              <p className="text-5xl font-bold text-jp-gray-900 dark:text-white">
+                {React.string(displayValue)}
+              </p>
+              <p className="text-sm text-gray-400">
+                {React.string(title)}
+              </p>
+            </div>
+          }
+        // ── Gauge (percentage dial) ──
+        | Gauge => {
+            let value = rawData
+              ->Array.get(0)
+              ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
+              ->Option.getOr(0.0)
+            // Clamp to 99.9 at 100% to avoid degenerate SVG arc (start == end point)
+            let clampedValue = if value >= 100.0 {
+              99.9
+            } else {
+              Js.Math.max_float(0.0, value)
+            }
+            let angle = clampedValue /. 100.0 *. 180.0
+            let displayStr = if value >= 100.0 {
+              "100%"
+            } else {
+              `${clampedValue->Js.Float.toFixedWithPrecision(~digits=1)}%`
+            }
+            // SVG gauge arc
+            <div className="flex flex-col items-center justify-center h-full gap-2">
+              <svg width="180" height="110" viewBox="0 0 180 110">
+                // Background arc (gray)
+                <path
+                  d="M 10 100 A 80 80 0 0 1 170 100"
+                  fill="none"
+                  stroke="#e5e7eb"
+                  strokeWidth="16"
+                  strokeLinecap="round"
+                />
+                // Value arc (colored)
+                {
+                  // Calculate end point of the arc based on value
+                  let rad = (180.0 -. angle) *. Math.Constants.pi /. 180.0
+                  let endX = 90.0 -. 80.0 *. Math.cos(rad)
+                  let endY = 100.0 -. 80.0 *. Math.sin(rad)
+                  let largeArc = if angle > 90.0 { "1" } else { "0" }
+                  let color = if clampedValue >= 80.0 {
+                    "#10b981"
+                  } else if clampedValue >= 50.0 {
+                    "#f59e0b"
+                  } else {
+                    "#ef4444"
+                  }
+                  <path
+                    d={`M 10 100 A 80 80 0 ${largeArc} 1 ${endX->Js.Float.toFixedWithPrecision(~digits=1)} ${endY->Js.Float.toFixedWithPrecision(~digits=1)}`}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth="16"
+                    strokeLinecap="round"
+                  />
+                }
+                // Center text
+                <text
+                  x="90"
+                  y="95"
+                  textAnchor="middle"
+                  className="text-2xl font-bold"
+                  fill="#1f2937"
+                  fontSize="24">
+                  {React.string(displayStr)}
+                </text>
+              </svg>
+              <p className="text-sm text-gray-400 -mt-2">
+                {React.string(title)}
+              </p>
+            </div>
+          }
+        }
       }
-    | BarChart => {
-        let payload = GenericChartRendererUtils.buildBarGraphPayload(
-          ~data=rawData,
-          ~xKey=primaryMetric,
-          ~yKey=widgetConfig.groupBy->Array.get(0)->Option.getOr("time_bucket"),
-          ~title,
-        )
-        let options = BarGraphUtils.getBarGraphOptions(payload)
-        <BarGraph options className="mr-3" />
-      }
-    | ColumnChart => {
-        let payload = GenericChartRendererUtils.buildLineGraphPayload(
-          ~data=chartData,
-          ~xKey=primaryMetric,
-          ~yKey="time_bucket",
-          ~title,
-        )
-        let options = LineGraphUtils.getLineGraphOptions(payload)
-        <LineGraph options className="mr-3" />
-      }
-    | PieChart | StackedBarChart | SankeyChart | FunnelChart => {
-        let payload = GenericChartRendererUtils.buildBarGraphPayload(
-          ~data=rawData,
-          ~xKey=primaryMetric,
-          ~yKey=widgetConfig.groupBy->Array.get(0)->Option.getOr("time_bucket"),
-          ~title,
-        )
-        let options = BarGraphUtils.getBarGraphOptions(payload)
-        <BarGraph options className="mr-3" />
-      }
-    }}
-  </PageLoaderWrapper>
+    </PageLoaderWrapper>
+  </div>
 }

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRenderer.res
@@ -102,7 +102,14 @@ let make = (~widget: CustomDashboardTypes.widget) => {
   React.useEffect(() => {
     fetchData()->ignore
     None
-  }, (startTimeVal, endTimeVal, filterValueJson, primaryMetric, groupByKey, (widget.chartType :> string)))
+  }, (
+    startTimeVal,
+    endTimeVal,
+    filterValueJson,
+    primaryMetric,
+    groupByKey,
+    (widget.chartType :> string),
+  ))
 
   let containerStyle = ReactDOM.Style.make(
     ~height=`${chartHeightPx->Int.toString}px`,
@@ -115,253 +122,258 @@ let make = (~widget: CustomDashboardTypes.widget) => {
       screenState
       customLoader={<InsightsHelper.Shimmer layoutId=title />}
       customUI={<NewAnalyticsHelper.NoData />}>
-      {
-        switch widget.chartType {
-        | LineChart => {
-            let payload = GenericChartRendererUtils.buildLineGraphPayload(
-              ~data=chartData,
-              ~xKey=responseField,
-              ~yKey="time_bucket",
-              ~title,
-              ~chartHeight=chartHeightPx,
-            )
-            let options = LineGraphUtils.getLineGraphOptions(payload)
-            <LineGraph options />
-          }
-        | BarChart => {
-            let payload = GenericChartRendererUtils.buildBarGraphPayload(
-              ~data=rawData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~title,
-            )
-            let options = BarGraphUtils.getBarGraphOptions(payload)
-            <BarGraph options />
-          }
-        | ColumnChart => {
-            let payload = GenericChartRendererUtils.buildColumnGraphPayload(
-              ~data=rawData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~title,
-            )
-            let options = ColumnGraphUtils.getColumnGraphOptions(payload)
-            <ColumnGraph options />
-          }
-        | StackedBarChart => {
-            let payload = GenericChartRendererUtils.buildStackedBarGraphPayload(
-              ~data=rawData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~_title=title,
-            )
-            let options = StackedBarGraphUtils.getStackedBarGraphOptions(
-              payload,
-              ~yMax=100,
-              ~labelItemDistance=20,
-            )
-            <StackedBarGraph options />
-          }
-        | FunnelChart => {
-            let payload = GenericChartRendererUtils.buildFunnelData(
-              ~data=rawData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~title,
-            )
-            let options = ColumnGraphUtils.getColumnGraphOptions(payload)
-            <ColumnGraph options />
-          }
-        | SankeyChart => {
-            let payload = GenericChartRendererUtils.buildSankeyGraphPayload(
-              ~data=rawData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~title,
-            )
-            let options = SankeyGraphUtils.getSankyGraphOptions(payload)
-            <SankeyGraph options />
-          }
-        | PieChart => {
-            let filteredData = rawData->Array.filter(item => {
-              let dict = item->getDictFromJsonObject
-              let val = dict->getString(groupByKey, "")
-              val->isNonEmptyString
-            })
-            let payload = GenericChartRendererUtils.buildPieGraphPayload(
-              ~data=filteredData,
-              ~xKey=responseField,
-              ~yKey=groupByKey,
-              ~title,
-            )
-            let options = PieGraphUtils.getPieChartOptions(payload)
-            <div className="flex items-center justify-center h-full overflow-hidden">
-              <PieGraph options />
-            </div>
-          }
-        // ── Table View ──
-        | Table => {
-            let columns = if rawData->Array.length > 0 {
-              rawData
-              ->Array.get(0)
-              ->Option.map(item => item->getDictFromJsonObject->Dict.keysToArray)
-              ->Option.getOr([])
-              ->Array.filter(key =>
-                // Filter out null-only columns and internal fields
-                key !== "time_range" &&
+      {switch widget.chartType {
+      | LineChart => {
+          let payload = GenericChartRendererUtils.buildLineGraphPayload(
+            ~data=chartData,
+            ~xKey=responseField,
+            ~yKey="time_bucket",
+            ~title,
+            ~chartHeight=chartHeightPx,
+          )
+          let options = LineGraphUtils.getLineGraphOptions(payload)
+          <LineGraph options />
+        }
+      | BarChart => {
+          let payload = GenericChartRendererUtils.buildBarGraphPayload(
+            ~data=rawData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~title,
+          )
+          let options = BarGraphUtils.getBarGraphOptions(payload)
+          <BarGraph options />
+        }
+      | ColumnChart => {
+          let payload = GenericChartRendererUtils.buildColumnGraphPayload(
+            ~data=rawData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~title,
+          )
+          let options = ColumnGraphUtils.getColumnGraphOptions(payload)
+          <ColumnGraph options />
+        }
+      | StackedBarChart => {
+          let payload = GenericChartRendererUtils.buildStackedBarGraphPayload(
+            ~data=rawData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~_title=title,
+          )
+          let options = StackedBarGraphUtils.getStackedBarGraphOptions(
+            payload,
+            ~yMax=100,
+            ~labelItemDistance=20,
+          )
+          <StackedBarGraph options />
+        }
+      | FunnelChart => {
+          let payload = GenericChartRendererUtils.buildFunnelData(
+            ~data=rawData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~title,
+          )
+          let options = ColumnGraphUtils.getColumnGraphOptions(payload)
+          <ColumnGraph options />
+        }
+      | SankeyChart => {
+          let payload = GenericChartRendererUtils.buildSankeyGraphPayload(
+            ~data=rawData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~title,
+          )
+          let options = SankeyGraphUtils.getSankyGraphOptions(payload)
+          <SankeyGraph options />
+        }
+      | PieChart => {
+          let filteredData = rawData->Array.filter(item => {
+            let dict = item->getDictFromJsonObject
+            let val = dict->getString(groupByKey, "")
+            val->isNonEmptyString
+          })
+          let payload = GenericChartRendererUtils.buildPieGraphPayload(
+            ~data=filteredData,
+            ~xKey=responseField,
+            ~yKey=groupByKey,
+            ~title,
+          )
+          let options = PieGraphUtils.getPieChartOptions(payload)
+          <div className="flex items-center justify-center h-full overflow-hidden">
+            <PieGraph options />
+          </div>
+        }
+      // ── Table View ──
+      | Table => {
+          let columns = if rawData->Array.length > 0 {
+            rawData
+            ->Array.get(0)
+            ->Option.map(item => item->getDictFromJsonObject->Dict.keysToArray)
+            ->Option.getOr([])
+            ->Array.filter(key =>
+              // Filter out null-only columns and internal fields
+              key !== "time_range" &&
                 rawData->Array.some(row =>
-                  row->getDictFromJsonObject->Dict.get(key)->Option.map(v =>
-                    v !== JSON.Encode.null
-                  )->Option.getOr(false)
+                  row
+                  ->getDictFromJsonObject
+                  ->Dict.get(key)
+                  ->Option.map(v => v !== JSON.Encode.null)
+                  ->Option.getOr(false)
                 )
-              )
-            } else {
-              []
-            }
-            <div className="overflow-auto h-full">
-              <table className="w-full text-sm text-left">
-                <thead className="text-xs text-gray-500 uppercase bg-gray-50 dark:bg-jp-gray-950 sticky top-0">
-                  <tr>
+            )
+          } else {
+            []
+          }
+          <div className="overflow-auto h-full">
+            <table className="w-full text-sm text-left">
+              <thead
+                className="text-xs text-gray-500 uppercase bg-gray-50 dark:bg-jp-gray-950 sticky top-0">
+                <tr>
+                  {columns
+                  ->Array.map(col =>
+                    <th key={col} className="px-4 py-3 font-medium border-b">
+                      {React.string(col->LogicUtils.snakeToTitle)}
+                    </th>
+                  )
+                  ->React.array}
+                </tr>
+              </thead>
+              <tbody>
+                {rawData
+                ->Array.mapWithIndex((row, rowIdx) => {
+                  let dict = row->getDictFromJsonObject
+                  <tr
+                    key={rowIdx->Int.toString}
+                    className="border-b hover:bg-gray-50 dark:hover:bg-jp-gray-950">
                     {columns
-                    ->Array.map(col =>
-                      <th key={col} className="px-4 py-3 font-medium border-b">
-                        {React.string(col->LogicUtils.snakeToTitle)}
-                      </th>
-                    )
+                    ->Array.map(col => {
+                      let val = dict->Dict.get(col)->Option.getOr(JSON.Encode.null)
+                      let display = switch val->JSON.Classify.classify {
+                      | String(s) => s->LogicUtils.snakeToTitle
+                      | Number(n) =>
+                        if n->Float.toInt->Int.toFloat === n {
+                          n->Float.toInt->Int.toString
+                        } else {
+                          n->Js.Float.toFixedWithPrecision(~digits=2)
+                        }
+                      | Bool(b) => b ? "Yes" : "No"
+                      | Null => "-"
+                      | _ => "-"
+                      }
+                      <td key={col} className="px-4 py-3 text-gray-700 dark:text-gray-300">
+                        {React.string(display)}
+                      </td>
+                    })
                     ->React.array}
                   </tr>
-                </thead>
-                <tbody>
-                  {rawData
-                  ->Array.mapWithIndex((row, rowIdx) => {
-                    let dict = row->getDictFromJsonObject
-                    <tr
-                      key={rowIdx->Int.toString}
-                      className="border-b hover:bg-gray-50 dark:hover:bg-jp-gray-950">
-                      {columns
-                      ->Array.map(col => {
-                        let val = dict->Dict.get(col)->Option.getOr(JSON.Encode.null)
-                        let display = switch val->JSON.Classify.classify {
-                        | String(s) => s->LogicUtils.snakeToTitle
-                        | Number(n) =>
-                          if n->Float.toInt->Int.toFloat === n {
-                            n->Float.toInt->Int.toString
-                          } else {
-                            n->Js.Float.toFixedWithPrecision(~digits=2)
-                          }
-                        | Bool(b) => b ? "Yes" : "No"
-                        | Null => "-"
-                        | _ => "-"
-                        }
-                        <td key={col} className="px-4 py-3 text-gray-700 dark:text-gray-300">
-                          {React.string(display)}
-                        </td>
-                      })
-                      ->React.array}
-                    </tr>
-                  })
-                  ->React.array}
-                </tbody>
-              </table>
-            </div>
+                })
+                ->React.array}
+              </tbody>
+            </table>
+          </div>
+        }
+      // ── Stat Number (big single value) ──
+      | StatNumber => {
+          // Get the first data point's value for the primary metric
+          let value =
+            rawData
+            ->Array.get(0)
+            ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
+            ->Option.getOr(0.0)
+          let isRate =
+            primaryMetric->Js.String2.includes("rate") || primaryMetric->Js.String2.includes("pct")
+          let displayValue = if isRate {
+            `${value->Js.Float.toFixedWithPrecision(~digits=1)}%`
+          } else if value > 1000000.0 {
+            `${(value /. 1000000.0)->Js.Float.toFixedWithPrecision(~digits=2)}M`
+          } else if value > 1000.0 {
+            `${(value /. 1000.0)->Js.Float.toFixedWithPrecision(~digits=1)}K`
+          } else if value->Float.toInt->Int.toFloat === value {
+            value->Float.toInt->Int.toString
+          } else {
+            value->Js.Float.toFixedWithPrecision(~digits=2)
           }
-        // ── Stat Number (big single value) ──
-        | StatNumber => {
-            // Get the first data point's value for the primary metric
-            let value = rawData
-              ->Array.get(0)
-              ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
-              ->Option.getOr(0.0)
-            let isRate = primaryMetric->Js.String2.includes("rate") || primaryMetric->Js.String2.includes("pct")
-            let displayValue = if isRate {
-              `${value->Js.Float.toFixedWithPrecision(~digits=1)}%`
-            } else if value > 1000000.0 {
-              `${(value /. 1000000.0)->Js.Float.toFixedWithPrecision(~digits=2)}M`
-            } else if value > 1000.0 {
-              `${(value /. 1000.0)->Js.Float.toFixedWithPrecision(~digits=1)}K`
-            } else if value->Float.toInt->Int.toFloat === value {
-              value->Float.toInt->Int.toString
-            } else {
-              value->Js.Float.toFixedWithPrecision(~digits=2)
-            }
-            <div className="flex flex-col items-center justify-center h-full gap-2">
-              <p className="text-5xl font-bold text-jp-gray-900 dark:text-white">
-                {React.string(displayValue)}
-              </p>
-              <p className="text-sm text-gray-400">
-                {React.string(title)}
-              </p>
-            </div>
+          <div className="flex flex-col items-center justify-center h-full gap-2">
+            <p className="text-5xl font-bold text-jp-gray-900 dark:text-white">
+              {React.string(displayValue)}
+            </p>
+            <p className="text-sm text-gray-400"> {React.string(title)} </p>
+          </div>
+        }
+      // ── Gauge (percentage dial) ──
+      | Gauge => {
+          let value =
+            rawData
+            ->Array.get(0)
+            ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
+            ->Option.getOr(0.0)
+          // Clamp to 99.9 at 100% to avoid degenerate SVG arc (start == end point)
+          let clampedValue = if value >= 100.0 {
+            99.9
+          } else {
+            Js.Math.max_float(0.0, value)
           }
-        // ── Gauge (percentage dial) ──
-        | Gauge => {
-            let value = rawData
-              ->Array.get(0)
-              ->Option.map(item => item->getDictFromJsonObject->getFloat(responseField, 0.0))
-              ->Option.getOr(0.0)
-            // Clamp to 99.9 at 100% to avoid degenerate SVG arc (start == end point)
-            let clampedValue = if value >= 100.0 {
-              99.9
-            } else {
-              Js.Math.max_float(0.0, value)
-            }
-            let angle = clampedValue /. 100.0 *. 180.0
-            let displayStr = if value >= 100.0 {
-              "100%"
-            } else {
-              `${clampedValue->Js.Float.toFixedWithPrecision(~digits=1)}%`
-            }
-            // SVG gauge arc
-            <div className="flex flex-col items-center justify-center h-full gap-2">
-              <svg width="180" height="110" viewBox="0 0 180 110">
-                // Background arc (gray)
+          let angle = clampedValue /. 100.0 *. 180.0
+          let displayStr = if value >= 100.0 {
+            "100%"
+          } else {
+            `${clampedValue->Js.Float.toFixedWithPrecision(~digits=1)}%`
+          }
+          // SVG gauge arc
+          <div className="flex flex-col items-center justify-center h-full gap-2">
+            <svg width="180" height="110" viewBox="0 0 180 110">
+              // Background arc (gray)
+              <path
+                d="M 10 100 A 80 80 0 0 1 170 100"
+                fill="none"
+                stroke="#e5e7eb"
+                strokeWidth="16"
+                strokeLinecap="round"
+              />
+              {
+                // Calculate end point of the arc based on value
+                let rad = (180.0 -. angle) *. Math.Constants.pi /. 180.0
+                let endX = 90.0 -. 80.0 *. Math.cos(rad)
+                let endY = 100.0 -. 80.0 *. Math.sin(rad)
+                let largeArc = if angle > 90.0 {
+                  "1"
+                } else {
+                  "0"
+                }
+                let color = if clampedValue >= 80.0 {
+                  "#10b981"
+                } else if clampedValue >= 50.0 {
+                  "#f59e0b"
+                } else {
+                  "#ef4444"
+                }
                 <path
-                  d="M 10 100 A 80 80 0 0 1 170 100"
+                  d={`M 10 100 A 80 80 0 ${largeArc} 1 ${endX->Js.Float.toFixedWithPrecision(
+                      ~digits=1,
+                    )} ${endY->Js.Float.toFixedWithPrecision(~digits=1)}`}
                   fill="none"
-                  stroke="#e5e7eb"
+                  stroke={color}
                   strokeWidth="16"
                   strokeLinecap="round"
                 />
-                // Value arc (colored)
-                {
-                  // Calculate end point of the arc based on value
-                  let rad = (180.0 -. angle) *. Math.Constants.pi /. 180.0
-                  let endX = 90.0 -. 80.0 *. Math.cos(rad)
-                  let endY = 100.0 -. 80.0 *. Math.sin(rad)
-                  let largeArc = if angle > 90.0 { "1" } else { "0" }
-                  let color = if clampedValue >= 80.0 {
-                    "#10b981"
-                  } else if clampedValue >= 50.0 {
-                    "#f59e0b"
-                  } else {
-                    "#ef4444"
-                  }
-                  <path
-                    d={`M 10 100 A 80 80 0 ${largeArc} 1 ${endX->Js.Float.toFixedWithPrecision(~digits=1)} ${endY->Js.Float.toFixedWithPrecision(~digits=1)}`}
-                    fill="none"
-                    stroke={color}
-                    strokeWidth="16"
-                    strokeLinecap="round"
-                  />
-                }
-                // Center text
-                <text
-                  x="90"
-                  y="95"
-                  textAnchor="middle"
-                  className="text-2xl font-bold"
-                  fill="#1f2937"
-                  fontSize="24">
-                  {React.string(displayStr)}
-                </text>
-              </svg>
-              <p className="text-sm text-gray-400 -mt-2">
-                {React.string(title)}
-              </p>
-            </div>
-          }
+              }
+              // Center text
+              <text
+                x="90"
+                y="95"
+                textAnchor="middle"
+                className="text-2xl font-bold"
+                fill="#1f2937"
+                fontSize="24">
+                {React.string(displayStr)}
+              </text>
+            </svg>
+            <p className="text-sm text-gray-400 -mt-2"> {React.string(title)} </p>
+          </div>
         }
-      }
+      }}
     </PageLoaderWrapper>
   </div>
 }

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
@@ -1,0 +1,97 @@
+open LogicUtils
+open InsightsUtils
+open NewAnalyticsUtils
+
+let getLineGraphObj = (
+  ~array: array<JSON.t>,
+  ~key: string,
+  ~name: string,
+  ~color: string,
+  ~isAmount=false,
+  ~currency="",
+): LineGraphTypes.dataObj => {
+  let data = array->Array.map(item => {
+    let value = item->getDictFromJsonObject->getFloat(key, 0.0)
+    if isAmount {
+      let conversionFactor = CurrencyUtils.getCurrencyConversionFactor(currency)
+      value /. conversionFactor
+    } else {
+      value
+    }
+  })
+  {
+    showInLegend: true,
+    name,
+    data,
+    color,
+  }
+}
+
+let buildLineGraphPayload = (
+  ~data: JSON.t,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): LineGraphTypes.lineGraphPayload => {
+  let categories = data->getCategories(0, yKey)
+
+  let lineData =
+    data
+    ->getArrayFromJson([])
+    ->Array.mapWithIndex((item, index) => {
+      let name = getLabelName(~key=yKey, ~index, ~points=item)
+      let color = index->getColor
+      getLineGraphObj(~array=item->getArrayFromJson([]), ~key=xKey, ~name, ~color)
+    })
+
+  let tooltipFormatter = tooltipFormatter(
+    ~secondaryCategories=[],
+    ~title,
+    ~metricType=Volume,
+  )
+
+  {
+    chartHeight: Custom(280),
+    chartLeftSpacing: DefaultLeftSpacing,
+    categories,
+    data: lineData,
+    title: {text: ""},
+    yAxisMaxValue: None,
+    yAxisMinValue: Some(0),
+    tooltipFormatter,
+    yAxisFormatter: LineGraphUtils.lineGraphYAxisFormatter(
+      ~statType=Default,
+      ~currency="",
+      ~suffix="",
+    ),
+    legend: {
+      useHTML: true,
+      labelFormatter: LineGraphUtils.valueFormatter,
+    },
+  }
+}
+
+let buildBarGraphPayload = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): BarGraphTypes.barGraphPayload => {
+  let categories = data->Array.map(item => {
+    item->getDictFromJsonObject->getString(yKey, "NA")
+  })
+
+  let barData: BarGraphTypes.dataObj = {
+    showInLegend: false,
+    name: title,
+    data: data->Array.map(item => item->getDictFromJsonObject->getFloat(xKey, 0.0)),
+    color: 0->getColor,
+  }
+
+  {
+    categories,
+    data: [barData],
+    title: {text: ""},
+    tooltipFormatter: bargraphTooltipFormatter(~title, ~metricType=Volume),
+  }
+}

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
@@ -2,56 +2,23 @@ open LogicUtils
 open InsightsUtils
 open NewAnalyticsUtils
 
-let getLineGraphObj = (
-  ~array: array<JSON.t>,
-  ~key: string,
-  ~name: string,
-  ~color: string,
-  ~isAmount=false,
-  ~currency="",
-): LineGraphTypes.dataObj => {
-  let data = array->Array.map(item => {
-    let value = item->getDictFromJsonObject->getFloat(key, 0.0)
-    if isAmount {
-      let conversionFactor = CurrencyUtils.getCurrencyConversionFactor(currency)
-      value /. conversionFactor
-    } else {
-      value
-    }
-  })
-  {
-    showInLegend: true,
-    name,
-    data,
-    color,
-  }
-}
 
 let buildLineGraphPayload = (
   ~data: JSON.t,
   ~xKey: string,
   ~yKey: string,
   ~title: string,
+  ~chartHeight: int=280,
 ): LineGraphTypes.lineGraphPayload => {
   let categories = data->getCategories(0, yKey)
 
-  let lineData =
-    data
-    ->getArrayFromJson([])
-    ->Array.mapWithIndex((item, index) => {
-      let name = getLabelName(~key=yKey, ~index, ~points=item)
-      let color = index->getColor
-      getLineGraphObj(~array=item->getArrayFromJson([]), ~key=xKey, ~name, ~color)
-    })
+  // Reuse existing InsightsUtils.getLineGraphData
+  let lineData = data->getLineGraphData(~xKey, ~yKey, ~currency="")
 
-  let tooltipFormatter = tooltipFormatter(
-    ~secondaryCategories=[],
-    ~title,
-    ~metricType=Volume,
-  )
+  let tooltipFormatter = tooltipFormatter(~secondaryCategories=[], ~title, ~metricType=Volume)
 
   {
-    chartHeight: Custom(280),
+    chartHeight: Custom(chartHeight),
     chartLeftSpacing: DefaultLeftSpacing,
     categories,
     data: lineData,
@@ -77,15 +44,16 @@ let buildBarGraphPayload = (
   ~yKey: string,
   ~title: string,
 ): BarGraphTypes.barGraphPayload => {
-  let categories = data->Array.map(item => {
-    item->getDictFromJsonObject->getString(yKey, "NA")
-  })
+  let categories =
+    data->Array.map(item => {
+      item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle
+    })
 
   let barData: BarGraphTypes.dataObj = {
     showInLegend: false,
     name: title,
     data: data->Array.map(item => item->getDictFromJsonObject->getFloat(xKey, 0.0)),
-    color: 0->getColor,
+    color: getColor(0),
   }
 
   {
@@ -93,5 +61,266 @@ let buildBarGraphPayload = (
     data: [barData],
     title: {text: ""},
     tooltipFormatter: bargraphTooltipFormatter(~title, ~metricType=Volume),
+  }
+}
+
+let buildColumnGraphPayload = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): ColumnGraphTypes.columnGraphPayload => {
+  let columnData =
+    data->Array.mapWithIndex((item, index) => {
+      let dict = item->getDictFromJsonObject
+      let dataPoint: ColumnGraphTypes.dataObj = {
+        name: dict->getString(yKey, "NA")->snakeToTitle,
+        y: dict->getFloat(xKey, 0.0),
+        color: getColor(index),
+      }
+      dataPoint
+    })
+
+  let seriesObj: ColumnGraphTypes.seriesObj = {
+    showInLegend: true,
+    name: title,
+    colorByPoint: true,
+    data: columnData,
+    color: getColor(0),
+  }
+
+  let tooltipFormatter = (
+    @this
+    (this: ColumnGraphTypes.pointFormatter) => {
+      let point = this.points->Array.get(0)
+      switch point {
+      | Some(p) =>
+        `<div style="padding:8px;background:#fff;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,0.15);border:1px solid #e5e7eb;">
+          <div style="font-weight:600;margin-bottom:4px;">${p.key}</div>
+          <div style="color:${p.color};">${p.y->Js.Float.toFixedWithPrecision(~digits=2)}</div>
+        </div>`
+      | None => ""
+      }
+    }
+  )->ColumnGraphTypes.asTooltipPointFormatter
+
+  let yAxisFormatter = (
+    @this
+    (_this: ColumnGraphTypes.yAxisFormatter) => {
+      ""
+    }
+  )->ColumnGraphTypes.asTooltipPointFormatter
+
+  {
+    data: [seriesObj],
+    title: {text: ""},
+    tooltipFormatter,
+    yAxisFormatter,
+  }
+}
+
+let buildStackedBarGraphPayload = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~_title: string,
+): StackedBarGraphTypes.stackedBarGraphPayload => {
+  let categories =
+    data->Array.map(item =>
+      item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle
+    )
+
+  let stackedData: StackedBarGraphTypes.dataObj = {
+    name: xKey->snakeToTitle,
+    data: data->Array.map(item => item->getDictFromJsonObject->getFloat(xKey, 0.0)),
+    color: getColor(0),
+  }
+
+  let labelFormatter = (
+    @this
+    (this: StackedBarGraphTypes.labelFormatter) => {
+      `<span style="font-size:11px;">${this.name}</span>`
+    }
+  )->StackedBarGraphTypes.asLabelFormatter
+
+  {
+    categories,
+    data: [stackedData],
+    labelFormatter,
+  }
+}
+
+let buildSankeyGraphPayload = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): SankeyGraphTypes.sankeyPayload => {
+  // Build flow data: source → category → value
+  // Each grouped data point becomes a flow from "Total" to the category
+  let sankeyData: SankeyGraphTypes.data =
+    data->Array.map(item => {
+      let dict = item->getDictFromJsonObject
+      let category = dict->getString(yKey, "Unknown")->snakeToTitle
+      let value = dict->getFloat(xKey, 0.0)->Float.toInt
+      ("Total", category, value, "")
+    })
+
+  let nodes: SankeyGraphTypes.nodes =
+    [
+      (
+        {
+          id: "Total",
+          dataLabels: {align: "left", x: -10, name: 0},
+        }: SankeyGraphTypes.node
+      ),
+    ]->Array.concat(
+      data->Array.mapWithIndex((item, index) => {
+        let category = item->getDictFromJsonObject->getString(yKey, "Unknown")->snakeToTitle
+        (
+          {
+            id: category,
+            dataLabels: {align: "right", x: 10, name: index + 1},
+          }: SankeyGraphTypes.node
+        )
+      }),
+    )
+
+  let colors = data->Array.mapWithIndex((_, index) => getColor(index))
+
+  {
+    title: {text: title},
+    data: sankeyData,
+    nodes,
+    colors,
+  }
+}
+
+let buildFunnelData = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): ColumnGraphTypes.columnGraphPayload => {
+  // Sort data descending by value for funnel effect
+  let sorted =
+    data
+    ->Array.map(item => {
+      let dict = item->getDictFromJsonObject
+      (dict->getString(yKey, "NA")->snakeToTitle, dict->getFloat(xKey, 0.0))
+    })
+    ->Array.toSorted((a, b) => {
+      let (_, va) = a
+      let (_, vb) = b
+      if vb > va { 1.0 } else if vb < va { -1.0 } else { 0.0 }
+    })
+
+  let columnData =
+    sorted->Array.mapWithIndex(((name, value), index) => {
+      let dataPoint: ColumnGraphTypes.dataObj = {
+        name,
+        y: value,
+        color: getColor(index),
+      }
+      dataPoint
+    })
+
+  let seriesObj: ColumnGraphTypes.seriesObj = {
+    showInLegend: false,
+    name: title,
+    colorByPoint: true,
+    data: columnData,
+    color: getColor(0),
+  }
+
+  let tooltipFormatter = (
+    @this
+    (this: ColumnGraphTypes.pointFormatter) => {
+      let point = this.points->Array.get(0)
+      switch point {
+      | Some(p) =>
+        `<div style="padding:8px;background:#fff;border-radius:6px;box-shadow:0 2px 8px rgba(0,0,0,0.15);border:1px solid #e5e7eb;">
+          <div style="font-weight:600;margin-bottom:4px;">${p.key}</div>
+          <div style="color:${p.color};">${p.y->Js.Float.toFixedWithPrecision(~digits=2)}</div>
+        </div>`
+      | None => ""
+      }
+    }
+  )->ColumnGraphTypes.asTooltipPointFormatter
+
+  let yAxisFormatter = (
+    @this
+    (_this: ColumnGraphTypes.yAxisFormatter) => {
+      ""
+    }
+  )->ColumnGraphTypes.asTooltipPointFormatter
+
+  {
+    data: [seriesObj],
+    title: {text: ""},
+    tooltipFormatter,
+    yAxisFormatter,
+  }
+}
+
+let buildPieGraphPayload = (
+  ~data: array<JSON.t>,
+  ~xKey: string,
+  ~yKey: string,
+  ~title: string,
+): PieGraphTypes.pieGraphPayload<'t> => {
+  // Calculate total for percentage display
+  let total =
+    data->Array.reduce(0.0, (acc, item) => {
+      acc +. item->getDictFromJsonObject->getFloat(xKey, 0.0)
+    })
+
+  let pieData =
+    data->Array.mapWithIndex((item, index) => {
+      let dict = item->getDictFromJsonObject
+      let value = dict->getFloat(xKey, 0.0)
+      let name = dict->getString(yKey, "Unknown")->snakeToTitle
+      let pct = if total > 0.0 {
+        value /. total *. 100.0
+      } else {
+        0.0
+      }
+      let pctStr = pct->Js.Float.toFixedWithPrecision(~digits=0)
+      let dataPoint: PieGraphTypes.pieGraphDataType = {
+        name: `${name} ${pctStr}%`,
+        y: value,
+        color: getColor(index),
+      }
+      dataPoint
+    })
+
+  let pieDataObj: PieGraphTypes.dataObj<'t> = {
+    \"type": "pie",
+    innerSize: "55%",
+    showInLegend: true,
+    name: title,
+    data: pieData,
+  }
+
+  // Pie size 60% leaves bottom 40% for legend (200px container → 120px pie + 80px legend)
+  {
+    data: [pieDataObj],
+    title: {text: ""},
+    tooltipFormatter: PieGraphUtils.pieGraphTooltipFormatter(
+      ~title,
+      ~valueFormatterType=Volume,
+    ),
+    legendFormatter: PieGraphUtils.pieGraphLegendFormatter(),
+    chartSize: "60%",
+    startAngle: 0,
+    endAngle: 360,
+    legend: {
+      enabled: true,
+      layout: "horizontal",
+      align: "center",
+      verticalAlign: "bottom",
+      y: 0,
+      itemMarginBottom: 2,
+    },
   }
 }

--- a/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/GenericChartRenderer/GenericChartRendererUtils.res
@@ -2,7 +2,6 @@ open LogicUtils
 open InsightsUtils
 open NewAnalyticsUtils
 
-
 let buildLineGraphPayload = (
   ~data: JSON.t,
   ~xKey: string,
@@ -44,10 +43,9 @@ let buildBarGraphPayload = (
   ~yKey: string,
   ~title: string,
 ): BarGraphTypes.barGraphPayload => {
-  let categories =
-    data->Array.map(item => {
-      item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle
-    })
+  let categories = data->Array.map(item => {
+    item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle
+  })
 
   let barData: BarGraphTypes.dataObj = {
     showInLegend: false,
@@ -70,16 +68,15 @@ let buildColumnGraphPayload = (
   ~yKey: string,
   ~title: string,
 ): ColumnGraphTypes.columnGraphPayload => {
-  let columnData =
-    data->Array.mapWithIndex((item, index) => {
-      let dict = item->getDictFromJsonObject
-      let dataPoint: ColumnGraphTypes.dataObj = {
-        name: dict->getString(yKey, "NA")->snakeToTitle,
-        y: dict->getFloat(xKey, 0.0),
-        color: getColor(index),
-      }
-      dataPoint
-    })
+  let columnData = data->Array.mapWithIndex((item, index) => {
+    let dict = item->getDictFromJsonObject
+    let dataPoint: ColumnGraphTypes.dataObj = {
+      name: dict->getString(yKey, "NA")->snakeToTitle,
+      y: dict->getFloat(xKey, 0.0),
+      color: getColor(index),
+    }
+    dataPoint
+  })
 
   let seriesObj: ColumnGraphTypes.seriesObj = {
     showInLegend: true,
@@ -126,9 +123,7 @@ let buildStackedBarGraphPayload = (
   ~_title: string,
 ): StackedBarGraphTypes.stackedBarGraphPayload => {
   let categories =
-    data->Array.map(item =>
-      item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle
-    )
+    data->Array.map(item => item->getDictFromJsonObject->getString(yKey, "NA")->snakeToTitle)
 
   let stackedData: StackedBarGraphTypes.dataObj = {
     name: xKey->snakeToTitle,
@@ -158,33 +153,32 @@ let buildSankeyGraphPayload = (
 ): SankeyGraphTypes.sankeyPayload => {
   // Build flow data: source → category → value
   // Each grouped data point becomes a flow from "Total" to the category
-  let sankeyData: SankeyGraphTypes.data =
-    data->Array.map(item => {
-      let dict = item->getDictFromJsonObject
-      let category = dict->getString(yKey, "Unknown")->snakeToTitle
-      let value = dict->getFloat(xKey, 0.0)->Float.toInt
-      ("Total", category, value, "")
-    })
+  let sankeyData: SankeyGraphTypes.data = data->Array.map(item => {
+    let dict = item->getDictFromJsonObject
+    let category = dict->getString(yKey, "Unknown")->snakeToTitle
+    let value = dict->getFloat(xKey, 0.0)->Float.toInt
+    ("Total", category, value, "")
+  })
 
-  let nodes: SankeyGraphTypes.nodes =
-    [
+  let nodes: SankeyGraphTypes.nodes = [
+    (
+      {
+        id: "Total",
+        dataLabels: {align: "left", x: -10, name: 0},
+      }: SankeyGraphTypes.node
+    ),
+  ]->Array.concat(
+    data->Array.mapWithIndex((item, index) => {
+      let category = item->getDictFromJsonObject->getString(yKey, "Unknown")->snakeToTitle
+
       (
         {
-          id: "Total",
-          dataLabels: {align: "left", x: -10, name: 0},
+          id: category,
+          dataLabels: {align: "right", x: 10, name: index + 1},
         }: SankeyGraphTypes.node
-      ),
-    ]->Array.concat(
-      data->Array.mapWithIndex((item, index) => {
-        let category = item->getDictFromJsonObject->getString(yKey, "Unknown")->snakeToTitle
-        (
-          {
-            id: category,
-            dataLabels: {align: "right", x: 10, name: index + 1},
-          }: SankeyGraphTypes.node
-        )
-      }),
-    )
+      )
+    }),
+  )
 
   let colors = data->Array.mapWithIndex((_, index) => getColor(index))
 
@@ -212,18 +206,23 @@ let buildFunnelData = (
     ->Array.toSorted((a, b) => {
       let (_, va) = a
       let (_, vb) = b
-      if vb > va { 1.0 } else if vb < va { -1.0 } else { 0.0 }
+      if vb > va {
+        1.0
+      } else if vb < va {
+        -1.0
+      } else {
+        0.0
+      }
     })
 
-  let columnData =
-    sorted->Array.mapWithIndex(((name, value), index) => {
-      let dataPoint: ColumnGraphTypes.dataObj = {
-        name,
-        y: value,
-        color: getColor(index),
-      }
-      dataPoint
-    })
+  let columnData = sorted->Array.mapWithIndex(((name, value), index) => {
+    let dataPoint: ColumnGraphTypes.dataObj = {
+      name,
+      y: value,
+      color: getColor(index),
+    }
+    dataPoint
+  })
 
   let seriesObj: ColumnGraphTypes.seriesObj = {
     showInLegend: false,
@@ -270,29 +269,27 @@ let buildPieGraphPayload = (
   ~title: string,
 ): PieGraphTypes.pieGraphPayload<'t> => {
   // Calculate total for percentage display
-  let total =
-    data->Array.reduce(0.0, (acc, item) => {
-      acc +. item->getDictFromJsonObject->getFloat(xKey, 0.0)
-    })
+  let total = data->Array.reduce(0.0, (acc, item) => {
+    acc +. item->getDictFromJsonObject->getFloat(xKey, 0.0)
+  })
 
-  let pieData =
-    data->Array.mapWithIndex((item, index) => {
-      let dict = item->getDictFromJsonObject
-      let value = dict->getFloat(xKey, 0.0)
-      let name = dict->getString(yKey, "Unknown")->snakeToTitle
-      let pct = if total > 0.0 {
-        value /. total *. 100.0
-      } else {
-        0.0
-      }
-      let pctStr = pct->Js.Float.toFixedWithPrecision(~digits=0)
-      let dataPoint: PieGraphTypes.pieGraphDataType = {
-        name: `${name} ${pctStr}%`,
-        y: value,
-        color: getColor(index),
-      }
-      dataPoint
-    })
+  let pieData = data->Array.mapWithIndex((item, index) => {
+    let dict = item->getDictFromJsonObject
+    let value = dict->getFloat(xKey, 0.0)
+    let name = dict->getString(yKey, "Unknown")->snakeToTitle
+    let pct = if total > 0.0 {
+      value /. total *. 100.0
+    } else {
+      0.0
+    }
+    let pctStr = pct->Js.Float.toFixedWithPrecision(~digits=0)
+    let dataPoint: PieGraphTypes.pieGraphDataType = {
+      name: `${name} ${pctStr}%`,
+      y: value,
+      color: getColor(index),
+    }
+    dataPoint
+  })
 
   let pieDataObj: PieGraphTypes.dataObj<'t> = {
     \"type": "pie",
@@ -306,10 +303,7 @@ let buildPieGraphPayload = (
   {
     data: [pieDataObj],
     title: {text: ""},
-    tooltipFormatter: PieGraphUtils.pieGraphTooltipFormatter(
-      ~title,
-      ~valueFormatterType=Volume,
-    ),
+    tooltipFormatter: PieGraphUtils.pieGraphTooltipFormatter(~title, ~valueFormatterType=Volume),
     legendFormatter: PieGraphUtils.pieGraphLegendFormatter(),
     chartSize: "60%",
     startAngle: 0,

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
@@ -8,6 +8,7 @@ let make = (
   open LogicUtils
   open APIUtils
   open WidgetConfiguratorUtils
+  open CustomDashboardTypes
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
   let showToast = ToastState.useShowToast()
@@ -21,7 +22,7 @@ let make = (
     | None => ""
     }
   )
-  let (description, setDescription) = React.useState(_ => "")
+  // Description field removed — widget type has no description field in BE
   let (domain, setDomain) = React.useState(_ =>
     switch editingWidget {
     | Some(w) => w.config.domain
@@ -224,18 +225,6 @@ let make = (
                 className="w-full px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-jp-gray-950 dark:text-white dark:border-gray-700"
               />
             </div>
-            <div>
-              <label className="text-xs font-medium text-gray-600 mb-1 block">
-                {React.string("Description (optional)")}
-              </label>
-              <input
-                type_="text"
-                value={description}
-                onChange={evt => setDescription(_ => ReactEvent.Form.target(evt)["value"])}
-                placeholder="Brief description of this widget"
-                className="w-full px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-jp-gray-950 dark:text-white dark:border-gray-700"
-              />
-            </div>
           </div>
         </div>
         // ═══════════════════════════════════════
@@ -247,24 +236,66 @@ let make = (
             {chartTypeOptions
             ->Array.map(opt => {
               let isActive = chartType === opt.value
-              <button
-                key={opt.label}
-                className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all ${isActive
-                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20 shadow-sm"
-                    : "border-gray-200 dark:border-gray-700 hover:border-gray-300 hover:bg-gray-50"}`}
-                onClick={_ => setChartType(_ => opt.value)}>
-                {WidgetIcons.getChartIcon(opt.value, ~isActive)}
-                <span
-                  className={`text-xs font-medium ${isActive
-                      ? "text-blue-700"
-                      : "text-gray-600"}`}>
-                  {React.string(opt.label)}
-                </span>
-                <span className="text-[10px] text-gray-400"> {React.string(opt.description)} </span>
-              </button>
+              let hasGroupBy = groupBy->LogicUtils.isNonEmptyString
+              let isCompatible = WidgetConfiguratorUtils.isChartTypeCompatible(
+                opt.value,
+                ~hasGroupBy,
+                ~selectedMetrics,
+              )
+              let disabledReason = WidgetConfiguratorUtils.getChartTypeDisabledReason(
+                opt.value,
+                ~hasGroupBy,
+                ~selectedMetrics,
+              )
+              let baseClass = if isActive {
+                "border-blue-500 bg-blue-50 dark:bg-blue-900/20 shadow-sm"
+              } else if isCompatible {
+                "border-gray-200 dark:border-gray-700 hover:border-gray-300 hover:bg-gray-50 cursor-pointer"
+              } else {
+                "border-gray-100 dark:border-gray-800 opacity-40 cursor-not-allowed"
+              }
+              <div key={opt.label} className="relative" title={disabledReason->Option.getOr("")}>
+                <button
+                  className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all w-full ${baseClass}`}
+                  disabled={!isCompatible && !isActive}
+                  onClick={_ =>
+                    if isCompatible {
+                      setChartType(_ => opt.value)
+                    }}>
+                  {WidgetIcons.getChartIcon(opt.value, ~isActive)}
+                  <span
+                    className={`text-xs font-medium ${isActive
+                        ? "text-blue-700"
+                        : "text-gray-600"}`}>
+                    {React.string(opt.label)}
+                  </span>
+                  <span className="text-[10px] text-gray-400">
+                    {React.string(opt.description)}
+                  </span>
+                </button>
+                {if !isCompatible && !isActive {
+                  <div className="absolute -top-1 -right-1 w-4 h-4 bg-gray-300 rounded-full flex items-center justify-center">
+                    <span className="text-[8px] text-white font-bold"> {React.string("!")} </span>
+                  </div>
+                } else {
+                  React.null
+                }}
+              </div>
             })
             ->React.array}
           </div>
+          {
+            let hasGroupBy = groupBy->LogicUtils.isNonEmptyString
+            if !hasGroupBy && WidgetConfiguratorUtils.needsGroupBy(chartType) {
+              <p className="text-xs text-amber-600 mt-2">
+                {React.string(
+                  "Current chart type requires a Group By dimension. Select one below or switch to Line chart.",
+                )}
+              </p>
+            } else {
+              React.null
+            }
+          }
         </div>
         // ═══════════════════════════════════════
         // SECTION 3: Data Source

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
@@ -153,10 +153,7 @@ let make = (
           ~data=data->JSON.Encode.object,
         )
         let _ = await updateDetails(url, body, Post)
-        showToast(
-          ~message=isEditMode ? "Widget updated" : "Widget added",
-          ~toastType=ToastSuccess,
-        )
+        showToast(~message=isEditMode ? "Widget updated" : "Widget added", ~toastType=ToastSuccess)
         onSuccess()
       } catch {
       | _ =>
@@ -172,7 +169,9 @@ let make = (
   // ── Section helper ──
   let sectionTitle = (title: string, ~subtitle: string="") => {
     <div className="mb-3">
-      <h3 className="text-sm font-semibold text-jp-gray-900 dark:text-white"> {React.string(title)} </h3>
+      <h3 className="text-sm font-semibold text-jp-gray-900 dark:text-white">
+        {React.string(title)}
+      </h3>
       {if subtitle->isNonEmptyString {
         <p className="text-xs text-gray-400 mt-0.5"> {React.string(subtitle)} </p>
       } else {
@@ -192,7 +191,8 @@ let make = (
       className="bg-white dark:bg-jp-gray-lightgray_background w-full max-w-xl shadow-2xl flex flex-col overflow-hidden"
       onClick={evt => evt->JsxEvent.Mouse.stopPropagation}>
       // ── Header ──
-      <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50 dark:bg-jp-gray-950">
+      <div
+        className="flex items-center justify-between px-6 py-4 border-b bg-gray-50 dark:bg-jp-gray-950">
         <div>
           <h2 className="text-lg font-bold text-jp-gray-900 dark:text-white">
             {React.string(isEditMode ? "Edit Widget" : "Add Widget")}
@@ -201,7 +201,8 @@ let make = (
             {React.string("Configure your chart visualization and data source")}
           </p>
         </div>
-        <button className="p-2 rounded-lg hover:bg-gray-200 transition-colors" onClick={_ => onClose()}>
+        <button
+          className="p-2 rounded-lg hover:bg-gray-200 transition-colors" onClick={_ => onClose()}>
           <Icon name="nd-cross" size=18 />
         </button>
       </div>
@@ -274,7 +275,8 @@ let make = (
                   </span>
                 </button>
                 {if !isCompatible && !isActive {
-                  <div className="absolute -top-1 -right-1 w-4 h-4 bg-gray-300 rounded-full flex items-center justify-center">
+                  <div
+                    className="absolute -top-1 -right-1 w-4 h-4 bg-gray-300 rounded-full flex items-center justify-center">
                     <span className="text-[8px] text-white font-bold"> {React.string("!")} </span>
                   </div>
                 } else {
@@ -335,11 +337,9 @@ let make = (
         // SECTION 4: Metrics
         // ═══════════════════════════════════════
         <div>
-          {sectionTitle(
-            "Metrics *",
-            ~subtitle="Select one or more metrics to visualize",
-          )}
-          <div className="flex flex-col gap-1 max-h-64 overflow-y-auto border rounded-lg p-2 bg-gray-50 dark:bg-jp-gray-950">
+          {sectionTitle("Metrics *", ~subtitle="Select one or more metrics to visualize")}
+          <div
+            className="flex flex-col gap-1 max-h-64 overflow-y-auto border rounded-lg p-2 bg-gray-50 dark:bg-jp-gray-950">
             {availableMetrics
             ->Array.map(metric => {
               let isSelected = selectedMetrics->Array.includes(metric.value)
@@ -362,7 +362,8 @@ let make = (
                           : "text-gray-700 dark:text-gray-300"}`}>
                       {React.string(metric.label)}
                     </p>
-                    <span className="text-[9px] px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500">
+                    <span
+                      className="text-[9px] px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500">
                       {React.string(metric.category)}
                     </span>
                   </div>
@@ -387,9 +388,7 @@ let make = (
                   key={m}
                   className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full">
                   {React.string(label)}
-                  <button
-                    className="hover:text-blue-900"
-                    onClick={_ => toggleMetric(m)}>
+                  <button className="hover:text-blue-900" onClick={_ => toggleMetric(m)}>
                     {React.string({`\u00d7`})}
                   </button>
                 </span>
@@ -448,13 +447,14 @@ let make = (
         <div>
           {sectionTitle("Widget Size", ~subtitle="Width (columns) and height")}
           <div className="flex flex-col gap-5">
-            // Visual size preview
             {
               let previewWPct = Float.fromInt(widgetW) /. 12.0 *. 100.0
               let previewWStr = previewWPct->Js.Float.toFixedWithPrecision(~digits=1)
               let previewHPx = widgetH * 8 // Scaled down (80px / 10)
               <div className="bg-gray-100 dark:bg-jp-gray-950 rounded-lg p-3">
-                <div className="bg-gray-50 dark:bg-gray-800 rounded border border-dashed border-gray-300 dark:border-gray-600 relative" style={ReactDOM.Style.make(~height="100px", ())}>
+                <div
+                  className="bg-gray-50 dark:bg-gray-800 rounded border border-dashed border-gray-300 dark:border-gray-600 relative"
+                  style={ReactDOM.Style.make(~height="100px", ())}>
                   <div
                     className="bg-blue-100 dark:bg-blue-900/30 border-2 border-blue-400 rounded transition-all duration-200"
                     style={ReactDOM.Style.make(
@@ -472,7 +472,9 @@ let make = (
                   </span>
                   <span className="text-xs text-gray-300"> {React.string("\u2022")} </span>
                   <span className="text-xs text-blue-600 font-semibold">
-                    {React.string(`${widgetH->Int.toString}h tall (${(widgetH * 80)->Int.toString}px)`)}
+                    {React.string(
+                      `${widgetH->Int.toString}h tall (${(widgetH * 80)->Int.toString}px)`,
+                    )}
                   </span>
                 </div>
               </div>
@@ -480,14 +482,19 @@ let make = (
             // Width slider
             <div>
               <div className="flex items-center gap-2 mb-2">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2" strokeLinecap="round">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#6b7280"
+                  strokeWidth="2"
+                  strokeLinecap="round">
                   <line x1="5" y1="12" x2="19" y2="12" />
                   <polyline points="5,8 1,12 5,16" />
                   <polyline points="19,8 23,12 19,16" />
                 </svg>
-                <span className="text-xs font-medium text-gray-600">
-                  {React.string("Width")}
-                </span>
+                <span className="text-xs font-medium text-gray-600"> {React.string("Width")} </span>
                 <span className="ml-auto text-xs text-blue-600 font-semibold">
                   {React.string(`${widgetW->Int.toString}/12`)}
                 </span>
@@ -513,7 +520,14 @@ let make = (
             // Height slider
             <div>
               <div className="flex items-center gap-2 mb-2">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2" strokeLinecap="round">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#6b7280"
+                  strokeWidth="2"
+                  strokeLinecap="round">
                   <line x1="12" y1="5" x2="12" y2="19" />
                   <polyline points="8,5 12,1 16,5" />
                   <polyline points="8,19 12,23 16,19" />
@@ -522,7 +536,9 @@ let make = (
                   {React.string("Height")}
                 </span>
                 <span className="ml-auto text-xs text-blue-600 font-semibold">
-                  {React.string(`${widgetH->Int.toString} units (${(widgetH * 80)->Int.toString}px)`)}
+                  {React.string(
+                    `${widgetH->Int.toString} units (${(widgetH * 80)->Int.toString}px)`,
+                  )}
                 </span>
               </div>
               <input
@@ -575,7 +591,9 @@ let make = (
                   {React.string(widgetName->isNonEmptyString ? widgetName : "Untitled Widget")}
                   <span className="text-gray-400 ml-2">
                     {React.string(
-                      `\u2014 ${CustomDashboardUtils.getChartTypeLabel(chartType)} \u2022 ${CustomDashboardUtils.getDomainLabel(domain)}`,
+                      `\u2014 ${CustomDashboardUtils.getChartTypeLabel(
+                          chartType,
+                        )} \u2022 ${CustomDashboardUtils.getDomainLabel(domain)}`,
                     )}
                   </span>
                 </p>
@@ -629,9 +647,7 @@ let make = (
             <div>
               <span className="text-gray-400"> {React.string("Size: ")} </span>
               <span className="text-gray-700 dark:text-gray-300 font-medium">
-                {React.string(
-                  `${widgetW->Int.toString}/12 \u00d7 ${widgetH->Int.toString}h`,
-                )}
+                {React.string(`${widgetW->Int.toString}/12 \u00d7 ${widgetH->Int.toString}h`)}
               </span>
             </div>
             {if needsTimeSeries(chartType) {
@@ -653,7 +669,8 @@ let make = (
         </div>
       </div>
       // ── Footer ──
-      <div className="flex items-center justify-between px-6 py-4 border-t bg-gray-50 dark:bg-jp-gray-950">
+      <div
+        className="flex items-center justify-between px-6 py-4 border-t bg-gray-50 dark:bg-jp-gray-950">
         <div className="text-xs text-gray-400">
           {if !canSubmit {
             React.string("Fill name and select at least one metric")

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfigurator.res
@@ -1,0 +1,645 @@
+@react.component
+let make = (
+  ~dashboardName: string,
+  ~editingWidget: option<CustomDashboardTypes.widget>,
+  ~onClose,
+  ~onSuccess,
+) => {
+  open LogicUtils
+  open APIUtils
+  open WidgetConfiguratorUtils
+  let getURL = useGetURL()
+  let updateDetails = useUpdateMethod()
+  let showToast = ToastState.useShowToast()
+
+  let isEditMode = editingWidget->Option.isSome
+
+  // ── Form State ──
+  let (widgetName, setWidgetName) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.widgetName
+    | None => ""
+    }
+  )
+  let (description, setDescription) = React.useState(_ => "")
+  let (domain, setDomain) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.config.domain
+    | None => CustomDashboardTypes.Payments
+    }
+  )
+  let (chartType, setChartType) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.chartType
+    | None => CustomDashboardTypes.LineChart
+    }
+  )
+  let (selectedMetrics, setSelectedMetrics) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.config.metrics
+    | None => []
+    }
+  )
+  let (groupBy, setGroupBy) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.config.groupBy->Array.get(0)->Option.getOr("")
+    | None => ""
+    }
+  )
+  let (granularity, setGranularity) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.config.granularity->Option.getOr("G_ONEDAY")
+    | None => "G_ONEDAY"
+    }
+  )
+  let (widgetW, setWidgetW) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.position.w
+    | None => 6
+    }
+  )
+  let (widgetH, setWidgetH) = React.useState(_ =>
+    switch editingWidget {
+    | Some(w) => w.position.h
+    | None => 4
+    }
+  )
+  let (isSubmitting, setIsSubmitting) = React.useState(_ => false)
+
+  let availableMetrics = getMetricsForDomain(domain)
+  let availableDimensions = getDimensionsForDomain(domain)
+
+  let handleDomainChange = (newDomain: CustomDashboardTypes.analyticsDomain) => {
+    setDomain(_ => newDomain)
+    setSelectedMetrics(_ => [])
+    setGroupBy(_ => "")
+  }
+
+  let toggleMetric = (metric: string) => {
+    setSelectedMetrics(prev =>
+      if prev->Array.includes(metric) {
+        prev->Array.filter(m => m !== metric)
+      } else {
+        prev->Array.concat([metric])
+      }
+    )
+  }
+
+  let handleSubmit = async () => {
+    if widgetName->String.trim->isNonEmptyString && selectedMetrics->Array.length > 0 {
+      setIsSubmitting(_ => true)
+      try {
+        let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
+
+        let configDict = Dict.make()
+        configDict->Dict.set(
+          "domain",
+          domain->CustomDashboardUtils.getDomainString->JSON.Encode.string,
+        )
+        configDict->Dict.set(
+          "metrics",
+          selectedMetrics->Array.map(JSON.Encode.string)->JSON.Encode.array,
+        )
+        configDict->Dict.set(
+          "group_by",
+          if groupBy->isNonEmptyString {
+            [groupBy->JSON.Encode.string]->JSON.Encode.array
+          } else {
+            []->JSON.Encode.array
+          },
+        )
+        configDict->Dict.set("filters", JSON.Encode.object(Dict.make()))
+        configDict->Dict.set(
+          "granularity",
+          if needsTimeSeries(chartType) {
+            granularity->JSON.Encode.string
+          } else {
+            JSON.Encode.null
+          },
+        )
+        configDict->Dict.set("time_range_preset", JSON.Encode.null)
+
+        let posDict = Dict.make()
+        posDict->Dict.set("x", 0->JSON.Encode.int)
+        posDict->Dict.set("y", 0->JSON.Encode.int)
+        posDict->Dict.set("w", widgetW->JSON.Encode.int)
+        posDict->Dict.set("h", widgetH->JSON.Encode.int)
+
+        let widgetDict = Dict.make()
+        widgetDict->Dict.set("widget_name", widgetName->String.trim->JSON.Encode.string)
+        widgetDict->Dict.set("chart_type", (chartType :> string)->JSON.Encode.string)
+        widgetDict->Dict.set("position", posDict->JSON.Encode.object)
+        widgetDict->Dict.set("config", configDict->JSON.Encode.object)
+
+        let data = Dict.make()
+        data->Dict.set("dashboard_name", dashboardName->JSON.Encode.string)
+
+        let operationType = switch editingWidget {
+        | Some(w) => {
+            widgetDict->Dict.set("widget_id", w.widgetId->JSON.Encode.string)
+            data->Dict.set("widget_id", w.widgetId->JSON.Encode.string)
+            data->Dict.set("widget", widgetDict->JSON.Encode.object)
+            "UpdateWidget"
+          }
+        | None => {
+            data->Dict.set("widget", widgetDict->JSON.Encode.object)
+            "AddWidget"
+          }
+        }
+
+        let body = CustomDashboardUtils.buildOperationBody(
+          ~operationType,
+          ~data=data->JSON.Encode.object,
+        )
+        let _ = await updateDetails(url, body, Post)
+        showToast(
+          ~message=isEditMode ? "Widget updated" : "Widget added",
+          ~toastType=ToastSuccess,
+        )
+        onSuccess()
+      } catch {
+      | _ =>
+        showToast(~message="Failed to save widget", ~toastType=ToastError)
+        setIsSubmitting(_ => false)
+      }
+    }
+  }
+
+  let canSubmit =
+    widgetName->String.trim->String.length > 0 && selectedMetrics->Array.length > 0 && !isSubmitting
+
+  // ── Section helper ──
+  let sectionTitle = (title: string, ~subtitle: string="") => {
+    <div className="mb-3">
+      <h3 className="text-sm font-semibold text-jp-gray-900 dark:text-white"> {React.string(title)} </h3>
+      {if subtitle->isNonEmptyString {
+        <p className="text-xs text-gray-400 mt-0.5"> {React.string(subtitle)} </p>
+      } else {
+        React.null
+      }}
+    </div>
+  }
+
+  <div
+    className="fixed inset-0 z-50 flex items-stretch justify-end bg-black bg-opacity-40"
+    onClick={evt => {
+      evt->JsxEvent.Mouse.stopPropagation
+      onClose()
+    }}>
+    // ── Slide-in panel from the right (Grafana-style) ──
+    <div
+      className="bg-white dark:bg-jp-gray-lightgray_background w-full max-w-xl shadow-2xl flex flex-col overflow-hidden"
+      onClick={evt => evt->JsxEvent.Mouse.stopPropagation}>
+      // ── Header ──
+      <div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50 dark:bg-jp-gray-950">
+        <div>
+          <h2 className="text-lg font-bold text-jp-gray-900 dark:text-white">
+            {React.string(isEditMode ? "Edit Widget" : "Add Widget")}
+          </h2>
+          <p className="text-xs text-gray-400 mt-0.5">
+            {React.string("Configure your chart visualization and data source")}
+          </p>
+        </div>
+        <button className="p-2 rounded-lg hover:bg-gray-200 transition-colors" onClick={_ => onClose()}>
+          <Icon name="nd-cross" size=18 />
+        </button>
+      </div>
+      // ── Scrollable body ──
+      <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-8">
+        // ═══════════════════════════════════════
+        // SECTION 1: General
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle("General", ~subtitle="Basic widget information")}
+          <div className="flex flex-col gap-4">
+            <div>
+              <label className="text-xs font-medium text-gray-600 mb-1 block">
+                {React.string("Widget Name *")}
+              </label>
+              <input
+                type_="text"
+                value={widgetName}
+                onChange={evt => setWidgetName(_ => ReactEvent.Form.target(evt)["value"])}
+                placeholder="e.g. Payment Success Rate by Connector"
+                className="w-full px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:bg-jp-gray-950 dark:text-white dark:border-gray-700"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-gray-600 mb-1 block">
+                {React.string("Description (optional)")}
+              </label>
+              <input
+                type_="text"
+                value={description}
+                onChange={evt => setDescription(_ => ReactEvent.Form.target(evt)["value"])}
+                placeholder="Brief description of this widget"
+                className="w-full px-3 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-jp-gray-950 dark:text-white dark:border-gray-700"
+              />
+            </div>
+          </div>
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 2: Visualization
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle("Visualization", ~subtitle="Choose how to display your data")}
+          <div className="grid grid-cols-3 gap-2">
+            {chartTypeOptions
+            ->Array.map(opt => {
+              let isActive = chartType === opt.value
+              <button
+                key={opt.label}
+                className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all ${isActive
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20 shadow-sm"
+                    : "border-gray-200 dark:border-gray-700 hover:border-gray-300 hover:bg-gray-50"}`}
+                onClick={_ => setChartType(_ => opt.value)}>
+                {WidgetIcons.getChartIcon(opt.value, ~isActive)}
+                <span
+                  className={`text-xs font-medium ${isActive
+                      ? "text-blue-700"
+                      : "text-gray-600"}`}>
+                  {React.string(opt.label)}
+                </span>
+                <span className="text-[10px] text-gray-400"> {React.string(opt.description)} </span>
+              </button>
+            })
+            ->React.array}
+          </div>
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 3: Data Source
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle("Data Source", ~subtitle="Select the analytics domain")}
+          <div className="grid grid-cols-2 gap-2">
+            {domainOptions
+            ->Array.map(opt => {
+              let isActive = domain === opt.value
+              <button
+                key={opt.label}
+                className={`flex items-center gap-3 p-3 rounded-lg border-2 text-left transition-all ${isActive
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                    : "border-gray-200 dark:border-gray-700 hover:border-gray-300"}`}
+                onClick={_ => handleDomainChange(opt.value)}>
+                {WidgetIcons.getDomainIcon(opt.value, ~isActive)}
+                <div>
+                  <p
+                    className={`text-sm font-medium ${isActive
+                        ? "text-blue-700"
+                        : "text-gray-700 dark:text-gray-300"}`}>
+                    {React.string(opt.label)}
+                  </p>
+                  <p className="text-[10px] text-gray-400">
+                    {React.string(
+                      `${opt.description} \u2022 ${opt.metricsCount->Int.toString} metrics`,
+                    )}
+                  </p>
+                </div>
+              </button>
+            })
+            ->React.array}
+          </div>
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 4: Metrics
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle(
+            "Metrics *",
+            ~subtitle="Select one or more metrics to visualize",
+          )}
+          <div className="flex flex-col gap-1 max-h-64 overflow-y-auto border rounded-lg p-2 bg-gray-50 dark:bg-jp-gray-950">
+            {availableMetrics
+            ->Array.map(metric => {
+              let isSelected = selectedMetrics->Array.includes(metric.value)
+              <label
+                key={metric.value}
+                className={`flex items-start gap-3 p-2.5 rounded-md cursor-pointer transition-colors ${isSelected
+                    ? "bg-blue-50 dark:bg-blue-900/20"
+                    : "hover:bg-white dark:hover:bg-gray-800"}`}>
+                <input
+                  type_="checkbox"
+                  checked={isSelected}
+                  onChange={_ => toggleMetric(metric.value)}
+                  className="mt-0.5 text-blue-600 rounded"
+                />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <p
+                      className={`text-sm ${isSelected
+                          ? "text-blue-700 font-medium"
+                          : "text-gray-700 dark:text-gray-300"}`}>
+                      {React.string(metric.label)}
+                    </p>
+                    <span className="text-[9px] px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-500">
+                      {React.string(metric.category)}
+                    </span>
+                  </div>
+                  <p className="text-[10px] text-gray-400 mt-0.5">
+                    {React.string(metric.description)}
+                  </p>
+                </div>
+              </label>
+            })
+            ->React.array}
+          </div>
+          {if selectedMetrics->Array.length > 0 {
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {selectedMetrics
+              ->Array.map(m => {
+                let label =
+                  availableMetrics
+                  ->Array.find(opt => opt.value === m)
+                  ->Option.map(opt => opt.label)
+                  ->Option.getOr(m)
+                <span
+                  key={m}
+                  className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full">
+                  {React.string(label)}
+                  <button
+                    className="hover:text-blue-900"
+                    onClick={_ => toggleMetric(m)}>
+                    {React.string({`\u00d7`})}
+                  </button>
+                </span>
+              })
+              ->React.array}
+            </div>
+          } else {
+            React.null
+          }}
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 5: Group By / Dimension
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle("Group By", ~subtitle="Split data by a dimension (optional)")}
+          <select
+            value={groupBy}
+            onChange={evt => setGroupBy(_ => ReactEvent.Form.target(evt)["value"])}
+            className="w-full px-3 py-2.5 border rounded-lg text-sm bg-white dark:bg-jp-gray-950 dark:text-white dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value=""> {React.string("None (aggregate)")} </option>
+            {availableDimensions
+            ->Array.map(dim =>
+              <option key={dim.value} value={dim.value}> {React.string(dim.label)} </option>
+            )
+            ->React.array}
+          </select>
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 6: Time Granularity (for time-series charts)
+        // ═══════════════════════════════════════
+        {if needsTimeSeries(chartType) {
+          <div>
+            {sectionTitle("Time Granularity", ~subtitle="Data aggregation interval")}
+            <div className="flex gap-2">
+              {granularityOptions
+              ->Array.map(opt => {
+                let isActive = granularity === opt.value
+                <button
+                  key={opt.value}
+                  className={`px-4 py-2 rounded-lg border-2 text-sm font-medium transition-all ${isActive
+                      ? "border-blue-500 bg-blue-50 text-blue-700"
+                      : "border-gray-200 text-gray-600 hover:border-gray-300"}`}
+                  onClick={_ => setGranularity(_ => opt.value)}>
+                  {React.string(opt.label)}
+                </button>
+              })
+              ->React.array}
+            </div>
+          </div>
+        } else {
+          React.null
+        }}
+        // ═══════════════════════════════════════
+        // SECTION 7: Size
+        // ═══════════════════════════════════════
+        <div>
+          {sectionTitle("Widget Size", ~subtitle="Width (columns) and height")}
+          <div className="flex flex-col gap-5">
+            // Visual size preview
+            {
+              let previewWPct = Float.fromInt(widgetW) /. 12.0 *. 100.0
+              let previewWStr = previewWPct->Js.Float.toFixedWithPrecision(~digits=1)
+              let previewHPx = widgetH * 8 // Scaled down (80px / 10)
+              <div className="bg-gray-100 dark:bg-jp-gray-950 rounded-lg p-3">
+                <div className="bg-gray-50 dark:bg-gray-800 rounded border border-dashed border-gray-300 dark:border-gray-600 relative" style={ReactDOM.Style.make(~height="100px", ())}>
+                  <div
+                    className="bg-blue-100 dark:bg-blue-900/30 border-2 border-blue-400 rounded transition-all duration-200"
+                    style={ReactDOM.Style.make(
+                      ~width=`${previewWStr}%`,
+                      ~height=`${previewHPx->Int.toString}px`,
+                      ~minHeight="16px",
+                      ~maxHeight="100px",
+                      (),
+                    )}
+                  />
+                </div>
+                <div className="flex items-center justify-center gap-3 mt-2">
+                  <span className="text-xs text-blue-600 font-semibold">
+                    {React.string(`${widgetW->Int.toString}/12 wide`)}
+                  </span>
+                  <span className="text-xs text-gray-300"> {React.string("\u2022")} </span>
+                  <span className="text-xs text-blue-600 font-semibold">
+                    {React.string(`${widgetH->Int.toString}h tall (${(widgetH * 80)->Int.toString}px)`)}
+                  </span>
+                </div>
+              </div>
+            }
+            // Width slider
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2" strokeLinecap="round">
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                  <polyline points="5,8 1,12 5,16" />
+                  <polyline points="19,8 23,12 19,16" />
+                </svg>
+                <span className="text-xs font-medium text-gray-600">
+                  {React.string("Width")}
+                </span>
+                <span className="ml-auto text-xs text-blue-600 font-semibold">
+                  {React.string(`${widgetW->Int.toString}/12`)}
+                </span>
+              </div>
+              <input
+                type_="range"
+                min="2"
+                max="12"
+                step=1.0
+                value={widgetW->Int.toString}
+                onChange={evt => {
+                  let v = ReactEvent.Form.target(evt)["value"]
+                  setWidgetW(_ => v->Int.fromString->Option.getOr(6))
+                }}
+                className="w-full accent-blue-600"
+              />
+              <div className="flex justify-between text-[10px] text-gray-400 mt-1">
+                <span> {React.string("2 cols")} </span>
+                <span> {React.string("6 cols")} </span>
+                <span> {React.string("12 cols")} </span>
+              </div>
+            </div>
+            // Height slider
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6b7280" strokeWidth="2" strokeLinecap="round">
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <polyline points="8,5 12,1 16,5" />
+                  <polyline points="8,19 12,23 16,19" />
+                </svg>
+                <span className="text-xs font-medium text-gray-600">
+                  {React.string("Height")}
+                </span>
+                <span className="ml-auto text-xs text-blue-600 font-semibold">
+                  {React.string(`${widgetH->Int.toString} units (${(widgetH * 80)->Int.toString}px)`)}
+                </span>
+              </div>
+              <input
+                type_="range"
+                min="2"
+                max="10"
+                step=1.0
+                value={widgetH->Int.toString}
+                onChange={evt => {
+                  let v = ReactEvent.Form.target(evt)["value"]
+                  setWidgetH(_ => v->Int.fromString->Option.getOr(4))
+                }}
+                className="w-full accent-blue-600"
+              />
+              <div className="flex justify-between text-[10px] text-gray-400 mt-1">
+                <span> {React.string("2 (160px)")} </span>
+                <span> {React.string("6 (480px)")} </span>
+                <span> {React.string("10 (800px)")} </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        // ═══════════════════════════════════════
+        // SECTION 8: Live Preview
+        // ═══════════════════════════════════════
+        {if selectedMetrics->Array.length > 0 {
+          let previewWidget: CustomDashboardTypes.widget = {
+            widgetId: "preview",
+            widgetName: widgetName->isNonEmptyString ? widgetName : "Preview",
+            chartType,
+            position: {x: 0, y: 0, w: 12, h: 4},
+            config: {
+              domain,
+              metrics: selectedMetrics,
+              groupBy: groupBy->isNonEmptyString ? [groupBy] : [],
+              filters: JSON.Encode.object(Dict.make()),
+              granularity: if WidgetConfiguratorUtils.needsTimeSeries(chartType) {
+                Some(granularity)
+              } else {
+                None
+              },
+              timeRangePreset: None,
+            },
+          }
+          <div>
+            {sectionTitle("Preview", ~subtitle="Live chart preview with current date range")}
+            <div className="border rounded-lg bg-white dark:bg-jp-gray-950 overflow-hidden">
+              <div className="p-3 border-b bg-gray-50 dark:bg-jp-gray-lightgray_background">
+                <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                  {React.string(widgetName->isNonEmptyString ? widgetName : "Untitled Widget")}
+                  <span className="text-gray-400 ml-2">
+                    {React.string(
+                      `\u2014 ${CustomDashboardUtils.getChartTypeLabel(chartType)} \u2022 ${CustomDashboardUtils.getDomainLabel(domain)}`,
+                    )}
+                  </span>
+                </p>
+              </div>
+              <div className="p-2" style={ReactDOM.Style.make(~minHeight="250px", ())}>
+                <GenericChartRenderer widget=previewWidget />
+              </div>
+            </div>
+          </div>
+        } else {
+          <div>
+            {sectionTitle("Preview")}
+            <div
+              className="border-2 border-dashed rounded-lg p-8 flex flex-col items-center justify-center text-gray-400"
+              style={ReactDOM.Style.make(~minHeight="200px", ())}>
+              <Icon name="chart-area" size=32 className="text-gray-300 mb-2" />
+              <p className="text-sm"> {React.string("Select metrics to see preview")} </p>
+            </div>
+          </div>
+        }}
+        // ═══════════════════════════════════════
+        // SECTION 9: Summary
+        // ═══════════════════════════════════════
+        <div className="bg-gray-50 dark:bg-jp-gray-950 rounded-lg p-4 border">
+          {sectionTitle("Summary")}
+          <div className="grid grid-cols-2 gap-3 text-xs">
+            <div>
+              <span className="text-gray-400"> {React.string("Chart: ")} </span>
+              <span className="text-gray-700 dark:text-gray-300 font-medium">
+                {React.string(CustomDashboardUtils.getChartTypeLabel(chartType))}
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-400"> {React.string("Domain: ")} </span>
+              <span className="text-gray-700 dark:text-gray-300 font-medium">
+                {React.string(CustomDashboardUtils.getDomainLabel(domain))}
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-400"> {React.string("Metrics: ")} </span>
+              <span className="text-gray-700 dark:text-gray-300 font-medium">
+                {React.string(selectedMetrics->Array.length->Int.toString ++ " selected")}
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-400"> {React.string("Group By: ")} </span>
+              <span className="text-gray-700 dark:text-gray-300 font-medium">
+                {React.string(groupBy->isNonEmptyString ? groupBy : "None")}
+              </span>
+            </div>
+            <div>
+              <span className="text-gray-400"> {React.string("Size: ")} </span>
+              <span className="text-gray-700 dark:text-gray-300 font-medium">
+                {React.string(
+                  `${widgetW->Int.toString}/12 \u00d7 ${widgetH->Int.toString}h`,
+                )}
+              </span>
+            </div>
+            {if needsTimeSeries(chartType) {
+              <div>
+                <span className="text-gray-400"> {React.string("Granularity: ")} </span>
+                <span className="text-gray-700 dark:text-gray-300 font-medium">
+                  {React.string(
+                    granularityOptions
+                    ->Array.find(g => g.value === granularity)
+                    ->Option.map(g => g.label)
+                    ->Option.getOr(granularity),
+                  )}
+                </span>
+              </div>
+            } else {
+              React.null
+            }}
+          </div>
+        </div>
+      </div>
+      // ── Footer ──
+      <div className="flex items-center justify-between px-6 py-4 border-t bg-gray-50 dark:bg-jp-gray-950">
+        <div className="text-xs text-gray-400">
+          {if !canSubmit {
+            React.string("Fill name and select at least one metric")
+          } else {
+            React.string("Ready to save")
+          }}
+        </div>
+        <div className="flex items-center gap-3">
+          <Button text="Cancel" buttonType={Secondary} onClick={_ => onClose()} />
+          <Button
+            text={isEditMode ? "Save Widget" : "Add Widget"}
+            buttonType={Primary}
+            onClick={_ => handleSubmit()->ignore}
+            buttonState={canSubmit ? Normal : Disabled}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
@@ -190,8 +190,8 @@ let paymentIntentMetricValues = [
   "payments_success_rate",
   "payment_intent_count",
   "smart_retried_amount",
-  "payment_processed_amount",  // exists in both, V2 is fine
-  "sessionized_payment_processed_amount",  // exists in both, V2 is fine
+  "payment_processed_amount", // exists in both, V2 is fine
+  "sessionized_payment_processed_amount", // exists in both, V2 is fine
 ]
 
 let isPaymentIntentMetric = (metric: string): bool => {
@@ -588,10 +588,7 @@ let isNumericMetric = (metric: string): bool => {
 }
 
 // Check if selected metrics support a given chart type
-let doMetricsSupportChartType = (
-  metrics: array<string>,
-  chartType: chartType,
-): bool => {
+let doMetricsSupportChartType = (metrics: array<string>, chartType: chartType): bool => {
   if metrics->Array.length === 0 {
     true // No metrics selected yet, allow all
   } else {
@@ -607,8 +604,7 @@ let doMetricsSupportChartType = (
     | FunnelChart =>
       // Funnel charts only work with funnel metrics
       hasFunnelMetric || (!hasDistributionMetric && !hasNumericMetric)
-    | SankeyChart =>
-      // Sankey charts need flow data - temporarily disable for most metrics
+    | SankeyChart => // Sankey charts need flow data - temporarily disable for most metrics
       // Only enable if specifically using routing/flow metrics
       false
     | _ =>
@@ -631,7 +627,8 @@ let isChartTypeCompatible = (
     // Check if chart type needs groupBy (only enforce after user starts configuring)
     let needsGroupByCheck = switch chartType {
     | LineChart | ColumnChart => true
-    | BarChart | PieChart | StackedBarChart | FunnelChart => hasGroupBy || selectedMetrics->Array.length === 0
+    | BarChart | PieChart | StackedBarChart | FunnelChart =>
+      hasGroupBy || selectedMetrics->Array.length === 0
     | SankeyChart => hasGroupBy
     | Table | StatNumber | Gauge => true
     }

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
@@ -31,6 +31,9 @@ let chartTypeOptions: array<chartTypeOption> = [
   {value: PieChart, label: "Pie", description: "Distribution", icon: "chart-pie"},
   {value: StackedBarChart, label: "Stacked", description: "Composition", icon: "bars"},
   {value: FunnelChart, label: "Funnel", description: "Drop-off analysis", icon: "funnel-dollar"},
+  {value: Table, label: "Table", description: "Tabular data view", icon: "table"},
+  {value: StatNumber, label: "Number", description: "Single big stat value", icon: "stat-number"},
+  {value: Gauge, label: "Gauge", description: "Percentage meter", icon: "gauge"},
 ]
 
 let granularityOptions: array<granularityOption> = [
@@ -50,22 +53,88 @@ let paymentMetrics: array<metricOption> = [
     category: "Volume",
   },
   {
-    value: "sessionized_payment_intent_count",
+    value: "sessionized_payment_count",
     label: "Payment Count",
     description: "Total number of payment attempts",
     category: "Volume",
   },
   {
-    value: "sessionized_payments_success_rate",
+    value: "sessionized_payment_success_count",
+    label: "Payment Success Count",
+    description: "Number of successful payments",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_payment_success_rate",
     label: "Payment Success Rate",
     description: "Percentage of successful payments",
     category: "Performance",
+  },
+  {
+    value: "sessionized_avg_ticket_size",
+    label: "Avg Ticket Size",
+    description: "Average payment amount per transaction",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_connector_success_rate",
+    label: "Connector Success Rate",
+    description: "Success rate by connector",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_retries_count",
+    label: "Retries Count",
+    description: "Number of payment retries",
+    category: "Volume",
   },
   {
     value: "payment_success_rate",
     label: "Success Rate (Non-Sessionized)",
     description: "Raw success rate without session grouping",
     category: "Performance",
+  },
+  {
+    value: "payment_count",
+    label: "Payment Count (Non-Sessionized)",
+    description: "Raw payment count",
+    category: "Volume",
+  },
+  {
+    value: "payment_processed_amount",
+    label: "Processed Amount (Non-Sessionized)",
+    description: "Raw processed amount",
+    category: "Volume",
+  },
+  {
+    value: "payment_success_count",
+    label: "Success Count (Non-Sessionized)",
+    description: "Raw success count",
+    category: "Volume",
+  },
+  {
+    value: "avg_ticket_size",
+    label: "Avg Ticket Size (Non-Sessionized)",
+    description: "Raw average ticket size",
+    category: "Performance",
+  },
+  {
+    value: "retries_count",
+    label: "Retries Count (Non-Sessionized)",
+    description: "Raw retries count",
+    category: "Volume",
+  },
+  {
+    value: "connector_success_rate",
+    label: "Connector Success Rate (Non-Sessionized)",
+    description: "Raw connector success rate",
+    category: "Performance",
+  },
+  {
+    value: "debit_routing",
+    label: "Debit Routing (Non-Sessionized)",
+    description: "Raw debit routing metric",
+    category: "Routing",
   },
   {
     value: "payments_distribution",
@@ -79,10 +148,58 @@ let paymentMetrics: array<metricOption> = [
     description: "Top reasons for payment failures",
     category: "Failures",
   },
+  // PaymentIntent metrics (V2 API — used by Insights overview)
+  {
+    value: "sessionized_payments_success_rate",
+    label: "Payments Success Rate (V2)",
+    description: "Success rate from payment intents (V2 API)",
+    category: "Performance (V2)",
+  },
+  {
+    value: "sessionized_payment_intent_count",
+    label: "Payment Intent Count (V2)",
+    description: "Total payment intents count (V2 API)",
+    category: "Volume (V2)",
+  },
+  {
+    value: "sessionized_payment_processed_amount",
+    label: "Processed Amount (V2)",
+    description: "Processed amount from payment intents (V2 API)",
+    category: "Volume (V2)",
+  },
+  {
+    value: "sessionized_smart_retried_amount",
+    label: "Smart Retried Amount (V2)",
+    description: "Amount recovered via smart retries (V2 API)",
+    category: "Recovery (V2)",
+  },
+  {
+    value: "sessionized_payments_distribution",
+    label: "Payments Distribution (V2)",
+    description: "Distribution from payment intents (V2 API)",
+    category: "Distribution (V2)",
+  },
 ]
 
+// V2 (PaymentIntent) metrics — these must use ANALYTICS_PAYMENTS_V2 entity
+let paymentIntentMetricValues = [
+  "sessionized_payments_success_rate",
+  "sessionized_payment_intent_count",
+  "sessionized_smart_retried_amount",
+  "sessionized_payments_distribution",
+  "payments_success_rate",
+  "payment_intent_count",
+  "smart_retried_amount",
+  "payment_processed_amount",  // exists in both, V2 is fine
+  "sessionized_payment_processed_amount",  // exists in both, V2 is fine
+]
+
+let isPaymentIntentMetric = (metric: string): bool => {
+  paymentIntentMetricValues->Array.includes(metric)
+}
+
 // ════════════════════════════════════════
-// SMART RETRY METRICS
+// SMART RETRY METRICS (all V2 / PaymentIntent)
 // ════════════════════════════════════════
 let smartRetryMetrics: array<metricOption> = [
   {
@@ -98,7 +215,19 @@ let smartRetryMetrics: array<metricOption> = [
     category: "Volume",
   },
   {
-    value: "payments_distribution",
+    value: "sessionized_payment_intent_count",
+    label: "Payment Intent Count",
+    description: "Total payment intents with retries",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_payments_success_rate",
+    label: "Success Rate (with Retries)",
+    description: "Success rate including smart retries",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_payments_distribution",
     label: "Payments Distribution",
     description: "Distribution of retried payments",
     category: "Distribution",
@@ -145,6 +274,30 @@ let refundMetrics: array<metricOption> = [
     description: "Distribution of refund reasons",
     category: "Analysis",
   },
+  {
+    value: "refund_success_rate",
+    label: "Refund Success Rate (Non-Sessionized)",
+    description: "Raw refund success rate",
+    category: "Performance",
+  },
+  {
+    value: "refund_count",
+    label: "Refund Count (Non-Sessionized)",
+    description: "Raw refund count",
+    category: "Volume",
+  },
+  {
+    value: "refund_success_count",
+    label: "Refund Success Count (Non-Sessionized)",
+    description: "Raw refund success count",
+    category: "Volume",
+  },
+  {
+    value: "refund_processed_amount",
+    label: "Refund Processed Amount (Non-Sessionized)",
+    description: "Raw refund processed amount",
+    category: "Volume",
+  },
 ]
 
 // ════════════════════════════════════════
@@ -156,6 +309,36 @@ let disputeMetrics: array<metricOption> = [
     label: "Dispute Status",
     description: "Disputes breakdown by status",
     category: "Status",
+  },
+  {
+    value: "total_amount_disputed",
+    label: "Total Amount Disputed",
+    description: "Total monetary amount of disputes",
+    category: "Volume",
+  },
+  {
+    value: "total_dispute_lost_amount",
+    label: "Total Dispute Lost Amount",
+    description: "Total amount lost in disputes",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_dispute_status_metric",
+    label: "Dispute Status (Sessionized)",
+    description: "Sessionized dispute status breakdown",
+    category: "Status",
+  },
+  {
+    value: "sessionized_total_amount_disputed",
+    label: "Total Amount Disputed (Sessionized)",
+    description: "Sessionized total dispute amount",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_total_dispute_lost_amount",
+    label: "Total Dispute Lost (Sessionized)",
+    description: "Sessionized total dispute lost amount",
+    category: "Volume",
   },
 ]
 
@@ -242,7 +425,7 @@ let authMetrics: array<metricOption> = [
 // ════════════════════════════════════════
 let routingMetrics: array<metricOption> = [
   {
-    value: "sessionized_payments_success_rate",
+    value: "sessionized_payment_success_rate",
     label: "Authorization Rate",
     description: "Overall authorization/success rate",
     category: "Performance",
@@ -254,7 +437,7 @@ let routingMetrics: array<metricOption> = [
     category: "Performance",
   },
   {
-    value: "sessionized_payment_intent_count",
+    value: "sessionized_payment_count",
     label: "Transaction Count",
     description: "Total transactions routed",
     category: "Volume",
@@ -264,6 +447,18 @@ let routingMetrics: array<metricOption> = [
     label: "Transaction Amount",
     description: "Total amount routed",
     category: "Volume",
+  },
+  {
+    value: "sessionized_connector_success_rate",
+    label: "Connector Success Rate",
+    description: "Success rate per connector",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_debit_routing",
+    label: "Debit Routing",
+    description: "Debit routing metrics",
+    category: "Routing",
   },
 ]
 
@@ -285,24 +480,47 @@ let paymentDimensions: array<dimensionOption> = [
   {value: "connector", label: "Connector"},
   {value: "payment_method", label: "Payment Method"},
   {value: "payment_method_type", label: "Payment Method Type"},
-  {value: "card_network", label: "Card Network"},
+  {value: "currency", label: "Currency"},
   {value: "authentication_type", label: "Authentication Type"},
+  {value: "status", label: "Payment Status"},
+  {value: "client_source", label: "Client Source"},
+  {value: "client_version", label: "Client Version"},
+  {value: "profile_id", label: "Profile ID"},
+  {value: "card_network", label: "Card Network"},
+  {value: "merchant_id", label: "Merchant ID"},
+  {value: "card_last_4", label: "Card Last 4"},
+  {value: "card_issuer", label: "Card Issuer"},
   {value: "error_reason", label: "Error Reason"},
+  {value: "routing_approach", label: "Routing Approach"},
 ]
 
 let refundDimensions: array<dimensionOption> = [
+  {value: "currency", label: "Currency"},
+  {value: "refund_status", label: "Refund Status"},
   {value: "connector", label: "Connector"},
-  {value: "refund_error_message", label: "Refund Error Message"},
+  {value: "refund_type", label: "Refund Type"},
+  {value: "profile_id", label: "Profile ID"},
   {value: "refund_reason", label: "Refund Reason"},
+  {value: "refund_error_message", label: "Refund Error Message"},
 ]
 
 let disputeDimensions: array<dimensionOption> = [
   {value: "connector", label: "Connector"},
+  {value: "dispute_stage", label: "Dispute Stage"},
+  {value: "currency", label: "Currency"},
 ]
 
 let authDimensions: array<dimensionOption> = [
-  {value: "authentication_connector", label: "Authentication Connector"},
   {value: "authentication_status", label: "Authentication Status"},
+  {value: "trans_status", label: "Transaction Status"},
+  {value: "authentication_type", label: "Authentication Type"},
+  {value: "error_message", label: "Error Message"},
+  {value: "authentication_connector", label: "Authentication Connector"},
+  {value: "message_version", label: "Message Version"},
+  {value: "platform", label: "Platform"},
+  {value: "currency", label: "Currency"},
+  {value: "merchant_country", label: "Merchant Country"},
+  {value: "billing_country", label: "Billing Country"},
 ]
 
 let routingDimensions: array<dimensionOption> = [
@@ -327,8 +545,169 @@ let getDimensionsForDomain = (domain: analyticsDomain): array<dimensionOption> =
 
 let needsTimeSeries = (chartType: chartType) => {
   switch chartType {
-  | LineChart | ColumnChart => true
+  | LineChart => true
   | _ => false
+  }
+}
+
+let needsGroupBy = (chartType: chartType) => {
+  switch chartType {
+  | PieChart | BarChart | StackedBarChart | FunnelChart | SankeyChart => true
+  | _ => false
+  }
+}
+
+// Check if a metric is a distribution/category metric (returns categorical data)
+let isDistributionMetric = (metric: string): bool => {
+  switch metric {
+  | "payments_distribution"
+  | "sessionized_payments_distribution"
+  | "failure_reasons"
+  | "refund_error_message"
+  | "sessionized_refund_error_message"
+  | "authentication_error_message"
+  | "refund_reason"
+  | "sessionized_refund_reason"
+  | "dispute_status_metric"
+  | "sessionized_dispute_status_metric" => true
+  | _ => false
+  }
+}
+
+// Check if a metric is a funnel metric
+let isFunnelMetric = (metric: string): bool => {
+  switch metric {
+  | "authentication_funnel" => true
+  | _ => false
+  }
+}
+
+// Check if a metric is numeric (can be plotted on line charts, aggregated)
+let isNumericMetric = (metric: string): bool => {
+  !isDistributionMetric(metric) && !isFunnelMetric(metric)
+}
+
+// Check if selected metrics support a given chart type
+let doMetricsSupportChartType = (
+  metrics: array<string>,
+  chartType: chartType,
+): bool => {
+  if metrics->Array.length === 0 {
+    true // No metrics selected yet, allow all
+  } else {
+    let hasDistributionMetric = metrics->Array.some(isDistributionMetric)
+    let hasFunnelMetric = metrics->Array.some(isFunnelMetric)
+    let hasNumericMetric = metrics->Array.some(isNumericMetric)
+
+    switch chartType {
+    | LineChart =>
+      // Line charts need numeric metrics (time series)
+      // Distribution metrics don't work well as trends
+      !hasDistributionMetric && !hasFunnelMetric
+    | FunnelChart =>
+      // Funnel charts only work with funnel metrics
+      hasFunnelMetric || (!hasDistributionMetric && !hasNumericMetric)
+    | SankeyChart =>
+      // Sankey charts need flow data - temporarily disable for most metrics
+      // Only enable if specifically using routing/flow metrics
+      false
+    | _ =>
+      // Bar, Column, Pie, Stacked work with distribution and numeric metrics
+      !hasFunnelMetric
+    }
+  }
+}
+
+// Check if a chart type is compatible with the current config
+let isChartTypeCompatible = (
+  chartType: chartType,
+  ~hasGroupBy: bool,
+  ~selectedMetrics: array<string>=[],
+): bool => {
+  // If nothing is selected yet, all chart types are available
+  if selectedMetrics->Array.length === 0 && !hasGroupBy {
+    true
+  } else {
+    // Check if chart type needs groupBy (only enforce after user starts configuring)
+    let needsGroupByCheck = switch chartType {
+    | LineChart | ColumnChart => true
+    | BarChart | PieChart | StackedBarChart | FunnelChart => hasGroupBy || selectedMetrics->Array.length === 0
+    | SankeyChart => hasGroupBy
+    | Table | StatNumber | Gauge => true
+    }
+
+    // Then check if selected metrics support this chart type
+    let metricsSupportChart = doMetricsSupportChartType(selectedMetrics, chartType)
+
+    needsGroupByCheck && metricsSupportChart
+  }
+}
+
+// Get a reason why a chart type is disabled
+let getChartTypeDisabledReason = (
+  chartType: chartType,
+  ~hasGroupBy: bool,
+  ~selectedMetrics: array<string>=[],
+): option<string> => {
+  if isChartTypeCompatible(chartType, ~hasGroupBy, ~selectedMetrics) {
+    None
+  } else {
+    let hasMetrics = selectedMetrics->Array.length > 0
+
+    // Check if it's a groupBy issue
+    let isGroupByIssue = switch chartType {
+    | BarChart | PieChart | StackedBarChart | FunnelChart | SankeyChart => !hasGroupBy && hasMetrics
+    | _ => false
+    }
+
+    let hasDistributionMetric = selectedMetrics->Array.some(isDistributionMetric)
+    let hasFunnelMetric = selectedMetrics->Array.some(isFunnelMetric)
+
+    if isGroupByIssue {
+      Some("Select a Group By dimension first")
+    } else if hasDistributionMetric && chartType === LineChart {
+      Some("Distribution metrics don't support Line charts. Use Bar, Column, or Pie.")
+    } else if hasFunnelMetric && chartType !== FunnelChart {
+      Some("Funnel metrics only work with Funnel charts")
+    } else if chartType === SankeyChart {
+      Some("Sankey requires flow data (coming soon)")
+    } else {
+      Some("Not compatible with selected metrics")
+    }
+  }
+}
+
+// Map request metric name → response field name
+// The BE uses different names in request vs response
+let getResponseFieldName = (requestMetric: string): string => {
+  switch requestMetric {
+  // Sessionized payment metrics → response uses non-prefixed names
+  | "sessionized_payment_success_rate" => "payment_success_rate"
+  | "sessionized_payment_count" => "payment_count"
+  | "sessionized_payment_success_count" => "payment_success_count"
+  | "sessionized_payment_processed_amount" => "payment_processed_amount"
+  | "sessionized_avg_ticket_size" => "avg_ticket_size"
+  | "sessionized_retries_count" => "retries_count"
+  | "sessionized_connector_success_rate" => "connector_success_rate"
+  | "sessionized_debit_routing" => "debit_routed_transaction_count"
+  // Sessionized refund metrics
+  | "sessionized_refund_processed_amount" => "refund_processed_amount"
+  | "sessionized_refund_count" => "refund_count"
+  | "sessionized_refund_success_count" => "refund_success_count"
+  | "sessionized_refund_success_rate" => "refund_success_rate"
+  | "sessionized_refund_error_message" => "refund_error_message"
+  | "sessionized_refund_reason" => "refund_reason"
+  // Sessionized dispute metrics
+  | "sessionized_dispute_status_metric" => "dispute_status_metric"
+  | "sessionized_total_amount_disputed" => "total_amount_disputed"
+  | "sessionized_total_dispute_lost_amount" => "total_dispute_lost_amount"
+  // PaymentIntent V2 metrics
+  | "sessionized_payments_success_rate" => "payments_success_rate"
+  | "sessionized_payment_intent_count" => "payment_intent_count"
+  | "sessionized_smart_retried_amount" => "smart_retried_amount"
+  | "sessionized_payments_distribution" => "payments_distribution"
+  // Non-sessionized and others — same name
+  | other => other
   }
 }
 

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetConfiguratorUtils.res
@@ -1,0 +1,387 @@
+open CustomDashboardTypes
+
+type metricOption = {
+  value: string,
+  label: string,
+  description: string,
+  category: string,
+}
+
+type dimensionOption = {
+  value: string,
+  label: string,
+}
+
+type granularityOption = {
+  value: string,
+  label: string,
+}
+
+type chartTypeOption = {
+  value: chartType,
+  label: string,
+  description: string,
+  icon: string,
+}
+
+let chartTypeOptions: array<chartTypeOption> = [
+  {value: LineChart, label: "Line", description: "Trends over time", icon: "chart-line"},
+  {value: BarChart, label: "Bar", description: "Compare categories", icon: "chart-bar"},
+  {value: ColumnChart, label: "Column", description: "Vertical bars", icon: "columns"},
+  {value: PieChart, label: "Pie", description: "Distribution", icon: "chart-pie"},
+  {value: StackedBarChart, label: "Stacked", description: "Composition", icon: "bars"},
+  {value: FunnelChart, label: "Funnel", description: "Drop-off analysis", icon: "funnel-dollar"},
+]
+
+let granularityOptions: array<granularityOption> = [
+  {value: "G_ONEHOUR", label: "Hourly"},
+  {value: "G_ONEDAY", label: "Daily"},
+  {value: "G_ONEWEEK", label: "Weekly"},
+]
+
+// ════════════════════════════════════════
+// PAYMENT METRICS
+// ════════════════════════════════════════
+let paymentMetrics: array<metricOption> = [
+  {
+    value: "sessionized_payment_processed_amount",
+    label: "Payment Processed Amount",
+    description: "Total amount of payments processed",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_payment_intent_count",
+    label: "Payment Count",
+    description: "Total number of payment attempts",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_payments_success_rate",
+    label: "Payment Success Rate",
+    description: "Percentage of successful payments",
+    category: "Performance",
+  },
+  {
+    value: "payment_success_rate",
+    label: "Success Rate (Non-Sessionized)",
+    description: "Raw success rate without session grouping",
+    category: "Performance",
+  },
+  {
+    value: "payments_distribution",
+    label: "Payments Distribution",
+    description: "Distribution of payments by selected dimension",
+    category: "Distribution",
+  },
+  {
+    value: "failure_reasons",
+    label: "Failure Reasons",
+    description: "Top reasons for payment failures",
+    category: "Failures",
+  },
+]
+
+// ════════════════════════════════════════
+// SMART RETRY METRICS
+// ════════════════════════════════════════
+let smartRetryMetrics: array<metricOption> = [
+  {
+    value: "sessionized_smart_retried_amount",
+    label: "Smart Retried Amount",
+    description: "Amount recovered via smart retries",
+    category: "Recovery",
+  },
+  {
+    value: "sessionized_payment_processed_amount",
+    label: "Payment Processed Amount",
+    description: "Total processed amount including retries",
+    category: "Volume",
+  },
+  {
+    value: "payments_distribution",
+    label: "Payments Distribution",
+    description: "Distribution of retried payments",
+    category: "Distribution",
+  },
+]
+
+// ════════════════════════════════════════
+// REFUND METRICS
+// ════════════════════════════════════════
+let refundMetrics: array<metricOption> = [
+  {
+    value: "sessionized_refund_processed_amount",
+    label: "Refund Processed Amount",
+    description: "Total refund amount processed",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_refund_count",
+    label: "Refund Count",
+    description: "Total number of refund attempts",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_refund_success_count",
+    label: "Refund Success Count",
+    description: "Number of successful refunds",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_refund_success_rate",
+    label: "Refund Success Rate",
+    description: "Percentage of successful refunds",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_refund_error_message",
+    label: "Refund Error Messages",
+    description: "Distribution of refund error messages",
+    category: "Failures",
+  },
+  {
+    value: "sessionized_refund_reason",
+    label: "Refund Reasons",
+    description: "Distribution of refund reasons",
+    category: "Analysis",
+  },
+]
+
+// ════════════════════════════════════════
+// DISPUTE METRICS
+// ════════════════════════════════════════
+let disputeMetrics: array<metricOption> = [
+  {
+    value: "dispute_status_metric",
+    label: "Dispute Status",
+    description: "Disputes breakdown by status",
+    category: "Status",
+  },
+]
+
+// ════════════════════════════════════════
+// AUTHENTICATION METRICS
+// ════════════════════════════════════════
+let authMetrics: array<metricOption> = [
+  {
+    value: "authentication_count",
+    label: "Authentication Count",
+    description: "Total 3DS authentication requests",
+    category: "Volume",
+  },
+  {
+    value: "authentication_attempt_count",
+    label: "Attempt Count",
+    description: "Number of authentication attempts",
+    category: "Volume",
+  },
+  {
+    value: "authentication_success_count",
+    label: "Success Count",
+    description: "Successful authentications",
+    category: "Volume",
+  },
+  {
+    value: "challenge_flow_count",
+    label: "Challenge Flow Count",
+    description: "Authentications that triggered 3DS challenge",
+    category: "Flow",
+  },
+  {
+    value: "challenge_attempt_count",
+    label: "Challenge Attempt Count",
+    description: "Attempts within challenge flow",
+    category: "Flow",
+  },
+  {
+    value: "challenge_success_count",
+    label: "Challenge Success Count",
+    description: "Successful challenge completions",
+    category: "Flow",
+  },
+  {
+    value: "frictionless_flow_count",
+    label: "Frictionless Flow Count",
+    description: "Authentications completed without challenge",
+    category: "Flow",
+  },
+  {
+    value: "frictionless_success_count",
+    label: "Frictionless Success Count",
+    description: "Successful frictionless authentications",
+    category: "Flow",
+  },
+  {
+    value: "authentication_funnel",
+    label: "Authentication Funnel",
+    description: "Full authentication flow funnel analysis",
+    category: "Analysis",
+  },
+  {
+    value: "authentication_error_message",
+    label: "Authentication Errors",
+    description: "Distribution of authentication error messages",
+    category: "Failures",
+  },
+  {
+    value: "authentication_exemption_requested_count",
+    label: "Exemption Requested",
+    description: "SCA exemptions requested",
+    category: "Exemptions",
+  },
+  {
+    value: "authentication_exemption_approved_count",
+    label: "Exemption Approved",
+    description: "SCA exemptions approved by issuer",
+    category: "Exemptions",
+  },
+]
+
+// ════════════════════════════════════════
+// ROUTING METRICS
+// ════════════════════════════════════════
+let routingMetrics: array<metricOption> = [
+  {
+    value: "sessionized_payments_success_rate",
+    label: "Authorization Rate",
+    description: "Overall authorization/success rate",
+    category: "Performance",
+  },
+  {
+    value: "payment_success_rate",
+    label: "First Attempt Auth Rate",
+    description: "Success rate on first attempt",
+    category: "Performance",
+  },
+  {
+    value: "sessionized_payment_intent_count",
+    label: "Transaction Count",
+    description: "Total transactions routed",
+    category: "Volume",
+  },
+  {
+    value: "sessionized_payment_processed_amount",
+    label: "Transaction Amount",
+    description: "Total amount routed",
+    category: "Volume",
+  },
+]
+
+let getMetricsForDomain = (domain: analyticsDomain): array<metricOption> => {
+  switch domain {
+  | Payments => paymentMetrics
+  | SmartRetries => smartRetryMetrics
+  | Refunds => refundMetrics
+  | Disputes => disputeMetrics
+  | AuthEvents => authMetrics
+  | Routing => routingMetrics
+  }
+}
+
+// ════════════════════════════════════════
+// DIMENSIONS PER DOMAIN
+// ════════════════════════════════════════
+let paymentDimensions: array<dimensionOption> = [
+  {value: "connector", label: "Connector"},
+  {value: "payment_method", label: "Payment Method"},
+  {value: "payment_method_type", label: "Payment Method Type"},
+  {value: "card_network", label: "Card Network"},
+  {value: "authentication_type", label: "Authentication Type"},
+  {value: "error_reason", label: "Error Reason"},
+]
+
+let refundDimensions: array<dimensionOption> = [
+  {value: "connector", label: "Connector"},
+  {value: "refund_error_message", label: "Refund Error Message"},
+  {value: "refund_reason", label: "Refund Reason"},
+]
+
+let disputeDimensions: array<dimensionOption> = [
+  {value: "connector", label: "Connector"},
+]
+
+let authDimensions: array<dimensionOption> = [
+  {value: "authentication_connector", label: "Authentication Connector"},
+  {value: "authentication_status", label: "Authentication Status"},
+]
+
+let routingDimensions: array<dimensionOption> = [
+  {value: "connector", label: "Connector"},
+  {value: "payment_method", label: "Payment Method"},
+  {value: "payment_method_type", label: "Payment Method Type"},
+  {value: "card_network", label: "Card Network"},
+  {value: "authentication_type", label: "Authentication Type"},
+  {value: "currency", label: "Currency"},
+  {value: "routing_approach", label: "Routing Approach"},
+]
+
+let getDimensionsForDomain = (domain: analyticsDomain): array<dimensionOption> => {
+  switch domain {
+  | Payments | SmartRetries => paymentDimensions
+  | Refunds => refundDimensions
+  | Disputes => disputeDimensions
+  | AuthEvents => authDimensions
+  | Routing => routingDimensions
+  }
+}
+
+let needsTimeSeries = (chartType: chartType) => {
+  switch chartType {
+  | LineChart | ColumnChart => true
+  | _ => false
+  }
+}
+
+// Domain metadata for the selector
+type domainOption = {
+  value: analyticsDomain,
+  label: string,
+  description: string,
+  icon: string,
+  metricsCount: int,
+}
+
+let domainOptions: array<domainOption> = [
+  {
+    value: Payments,
+    label: "Payments",
+    description: "Payment transactions, success rates, failures",
+    icon: "nd-wallet",
+    metricsCount: paymentMetrics->Array.length,
+  },
+  {
+    value: SmartRetries,
+    label: "Smart Retries",
+    description: "Automatic retry recovery and amounts",
+    icon: "nd-swap-arrow-horizontal",
+    metricsCount: smartRetryMetrics->Array.length,
+  },
+  {
+    value: Refunds,
+    label: "Refunds",
+    description: "Refund processing, success, error analysis",
+    icon: "refunds",
+    metricsCount: refundMetrics->Array.length,
+  },
+  {
+    value: Disputes,
+    label: "Disputes",
+    description: "Dispute cases and status tracking",
+    icon: "nd-flag",
+    metricsCount: disputeMetrics->Array.length,
+  },
+  {
+    value: AuthEvents,
+    label: "Authentication (3DS)",
+    description: "3DS challenges, frictionless flows, exemptions",
+    icon: "nd-shield",
+    metricsCount: authMetrics->Array.length,
+  },
+  {
+    value: Routing,
+    label: "Routing Analytics",
+    description: "Connector routing performance and optimization",
+    icon: "nd-connectors",
+    metricsCount: routingMetrics->Array.length,
+  },
+]

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
@@ -1,107 +1,32 @@
-// Uniform SVG icons for the widget configurator
-// All use stroke-based rendering with consistent weight and color
-
-let lineChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="22,12 18,8 13,13 9,9 2,16" />
-    <polyline points="22,12 22,8 18,8" />
-  </svg>
-
-let barChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="3" y="12" width="4" height="9" rx="1" />
-    <rect x="10" y="7" width="4" height="14" rx="1" />
-    <rect x="17" y="3" width="4" height="18" rx="1" />
-  </svg>
-
-let columnChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="3" y="3" width="18" height="4" rx="1" />
-    <rect x="3" y="10" width="12" height="4" rx="1" />
-    <rect x="3" y="17" width="7" height="4" rx="1" />
-  </svg>
-
-let pieChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M21.21 15.89A10 10 0 1 1 8 2.83" />
-    <path d="M22 12A10 10 0 0 0 12 2v10z" />
-  </svg>
-
-let stackedChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="4" y="14" width="5" height="7" rx="1" />
-    <rect x="4" y="8" width="5" height="6" rx="1" />
-    <rect x="13" y="10" width="5" height="11" rx="1" />
-    <rect x="13" y="4" width="5" height="6" rx="1" />
-  </svg>
-
-let funnelChart = (~color: string) =>
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M3 4h18l-6 7v6l-6 3V11L3 4z" />
-  </svg>
+// Chart type and domain icons using the existing design system Icon component
+// Icon choices follow the existing InsightsHelper patterns (graph-dark, table-view)
 
 let getChartIcon = (chartType: CustomDashboardTypes.chartType, ~isActive: bool) => {
-  let color = isActive ? "#2563eb" : "#9ca3af"
-  switch chartType {
-  | LineChart => lineChart(~color)
-  | BarChart => barChart(~color)
-  | ColumnChart => columnChart(~color)
-  | PieChart => pieChart(~color)
-  | StackedBarChart => stackedChart(~color)
-  | FunnelChart | SankeyChart => funnelChart(~color)
+  let className = isActive ? "text-blue-600" : "text-gray-400"
+  let name = switch chartType {
+  | LineChart => "graph-dark"             // Same icon used in InsightsHelper.TabSwitch for graph view
+  | BarChart => "chart-bar"               // FA horizontal bar chart icon
+  | ColumnChart => "poll"                 // FA vertical bars of different heights
+  | PieChart => "chart-pie"              // FA pie/donut circle
+  | StackedBarChart => "nd-graph-chart-gantt" // ND stacked horizontal bars (Gantt-like)
+  | FunnelChart => "funnel-dollar"        // FA funnel shape
+  | SankeyChart => "sitemap"             // FA tree/flow connections
+  | Table => "table-view"                // Same icon used in InsightsHelper.TabSwitch for table view
+  | StatNumber => "hashtag"              // FA number/hash symbol
+  | Gauge => "tachometer-alt"            // FA speedometer/gauge dial
   }
+  <Icon name size=20 className />
 }
 
-// Domain icons — uniform stroke style
-let payments = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="1" y="4" width="22" height="16" rx="2" />
-    <line x1="1" y1="10" x2="23" y2="10" />
-  </svg>
-
-let smartRetries = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="1,4 1,10 7,10" />
-    <polyline points="23,20 23,14 17,14" />
-    <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10" />
-    <path d="M3.51 15A9 9 0 0 0 18.36 18.36L23 14" />
-  </svg>
-
-let refunds = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <polyline points="1,4 1,10 7,10" />
-    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
-  </svg>
-
-let disputes = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-    <line x1="12" y1="9" x2="12" y2="13" />
-    <line x1="12" y1="17" x2="12.01" y2="17" />
-  </svg>
-
-let authentication = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-  </svg>
-
-let routing = (~color: string) =>
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="5" r="3" />
-    <circle cx="5" cy="19" r="3" />
-    <circle cx="19" cy="19" r="3" />
-    <line x1="12" y1="8" x2="5" y2="16" />
-    <line x1="12" y1="8" x2="19" y2="16" />
-  </svg>
-
 let getDomainIcon = (domain: CustomDashboardTypes.analyticsDomain, ~isActive: bool) => {
-  let color = isActive ? "#2563eb" : "#9ca3af"
-  switch domain {
-  | Payments => payments(~color)
-  | SmartRetries => smartRetries(~color)
-  | Refunds => refunds(~color)
-  | Disputes => disputes(~color)
-  | AuthEvents => authentication(~color)
-  | Routing => routing(~color)
+  let className = isActive ? "text-blue-600" : "text-gray-400"
+  let name = switch domain {
+  | Payments => "nd-wallet"
+  | SmartRetries => "nd-swap-arrow-horizontal"
+  | Refunds => "refunds"
+  | Disputes => "nd-flag"
+  | AuthEvents => "nd-shield"
+  | Routing => "nd-connectors"
   }
+  <Icon name size=18 className />
 }

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
@@ -1,0 +1,107 @@
+// Uniform SVG icons for the widget configurator
+// All use stroke-based rendering with consistent weight and color
+
+let lineChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="22,12 18,8 13,13 9,9 2,16" />
+    <polyline points="22,12 22,8 18,8" />
+  </svg>
+
+let barChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="12" width="4" height="9" rx="1" />
+    <rect x="10" y="7" width="4" height="14" rx="1" />
+    <rect x="17" y="3" width="4" height="18" rx="1" />
+  </svg>
+
+let columnChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="4" rx="1" />
+    <rect x="3" y="10" width="12" height="4" rx="1" />
+    <rect x="3" y="17" width="7" height="4" rx="1" />
+  </svg>
+
+let pieChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21.21 15.89A10 10 0 1 1 8 2.83" />
+    <path d="M22 12A10 10 0 0 0 12 2v10z" />
+  </svg>
+
+let stackedChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="4" y="14" width="5" height="7" rx="1" />
+    <rect x="4" y="8" width="5" height="6" rx="1" />
+    <rect x="13" y="10" width="5" height="11" rx="1" />
+    <rect x="13" y="4" width="5" height="6" rx="1" />
+  </svg>
+
+let funnelChart = (~color: string) =>
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 4h18l-6 7v6l-6 3V11L3 4z" />
+  </svg>
+
+let getChartIcon = (chartType: CustomDashboardTypes.chartType, ~isActive: bool) => {
+  let color = isActive ? "#2563eb" : "#9ca3af"
+  switch chartType {
+  | LineChart => lineChart(~color)
+  | BarChart => barChart(~color)
+  | ColumnChart => columnChart(~color)
+  | PieChart => pieChart(~color)
+  | StackedBarChart => stackedChart(~color)
+  | FunnelChart | SankeyChart => funnelChart(~color)
+  }
+}
+
+// Domain icons — uniform stroke style
+let payments = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="1" y="4" width="22" height="16" rx="2" />
+    <line x1="1" y1="10" x2="23" y2="10" />
+  </svg>
+
+let smartRetries = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="1,4 1,10 7,10" />
+    <polyline points="23,20 23,14 17,14" />
+    <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10" />
+    <path d="M3.51 15A9 9 0 0 0 18.36 18.36L23 14" />
+  </svg>
+
+let refunds = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="1,4 1,10 7,10" />
+    <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+  </svg>
+
+let disputes = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+    <line x1="12" y1="9" x2="12" y2="13" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+
+let authentication = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+  </svg>
+
+let routing = (~color: string) =>
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="5" r="3" />
+    <circle cx="5" cy="19" r="3" />
+    <circle cx="19" cy="19" r="3" />
+    <line x1="12" y1="8" x2="5" y2="16" />
+    <line x1="12" y1="8" x2="19" y2="16" />
+  </svg>
+
+let getDomainIcon = (domain: CustomDashboardTypes.analyticsDomain, ~isActive: bool) => {
+  let color = isActive ? "#2563eb" : "#9ca3af"
+  switch domain {
+  | Payments => payments(~color)
+  | SmartRetries => smartRetries(~color)
+  | Refunds => refunds(~color)
+  | Disputes => disputes(~color)
+  | AuthEvents => authentication(~color)
+  | Routing => routing(~color)
+  }
+}

--- a/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
+++ b/src/screens/NewAnalytics/CustomDashboards/WidgetConfigurator/WidgetIcons.res
@@ -4,16 +4,16 @@
 let getChartIcon = (chartType: CustomDashboardTypes.chartType, ~isActive: bool) => {
   let className = isActive ? "text-blue-600" : "text-gray-400"
   let name = switch chartType {
-  | LineChart => "graph-dark"             // Same icon used in InsightsHelper.TabSwitch for graph view
-  | BarChart => "chart-bar"               // FA horizontal bar chart icon
-  | ColumnChart => "poll"                 // FA vertical bars of different heights
-  | PieChart => "chart-pie"              // FA pie/donut circle
+  | LineChart => "graph-dark" // Same icon used in InsightsHelper.TabSwitch for graph view
+  | BarChart => "chart-bar" // FA horizontal bar chart icon
+  | ColumnChart => "poll" // FA vertical bars of different heights
+  | PieChart => "chart-pie" // FA pie/donut circle
   | StackedBarChart => "nd-graph-chart-gantt" // ND stacked horizontal bars (Gantt-like)
-  | FunnelChart => "funnel-dollar"        // FA funnel shape
-  | SankeyChart => "sitemap"             // FA tree/flow connections
-  | Table => "table-view"                // Same icon used in InsightsHelper.TabSwitch for table view
-  | StatNumber => "hashtag"              // FA number/hash symbol
-  | Gauge => "tachometer-alt"            // FA speedometer/gauge dial
+  | FunnelChart => "funnel-dollar" // FA funnel shape
+  | SankeyChart => "sitemap" // FA tree/flow connections
+  | Table => "table-view" // Same icon used in InsightsHelper.TabSwitch for table view
+  | StatNumber => "hashtag" // FA number/hash symbol
+  | Gauge => "tachometer-alt" // FA speedometer/gauge dial
   }
   <Icon name size=20 className />
 }

--- a/src/screens/NewAnalytics/Insights/InsightsContainerUtils.res
+++ b/src/screens/NewAnalytics/Insights/InsightsContainerUtils.res
@@ -5,6 +5,7 @@ let getPageIndex = (url: RescriptReactRouter.url) => {
   switch url.path->HSwitchUtils.urlPath {
   | list{"new-analytics", "smart-retry"} => 1
   | list{"new-analytics", "refund"} => 2
+  | list{"new-analytics", "dashboards"} => 3
   | list{"new-analytics", "payment"} | _ => 0
   }
 }
@@ -13,6 +14,7 @@ let getPageFromIndex = index => {
   switch index {
   | 1 => NewAnalyticsSmartRetry
   | 2 => NewAnalyticsRefund
+  | 3 => NewAnalyticsDashboards
   | 0 | _ => NewAnalyticsPayment
   }
 }

--- a/src/screens/NewAnalytics/Insights/InsightsTypes.res
+++ b/src/screens/NewAnalytics/Insights/InsightsTypes.res
@@ -6,6 +6,7 @@ type analyticsPagesRoutes =
   | @as("new-analytics/payment") NewAnalyticsPayment
   | @as("new-analytics/smart-retry") NewAnalyticsSmartRetry
   | @as("new-analytics/refund") NewAnalyticsRefund
+  | @as("new-analytics/dashboards") NewAnalyticsDashboards
 
 type domain = [#payments | #refunds | #disputes]
 type dimension = [


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation

## Description

Add a **My Dashboards** tab to the Insights page (`/new-analytics/dashboards`) allowing merchants to create, edit, and manage custom analytics dashboards with configurable widgets.

### New Components (16 files, ~2,766 lines)

| Component | Purpose |
|-----------|--------|
| `CustomDashboardTab` | Tab root with list/canvas sub-view switching |
| `DashboardList` | Grid of dashboard cards with CRUD |
| `DashboardCard` | Card with name, description, widget count, 3-dot menu |
| `DashboardEmptyState` | Empty state with create CTA |
| `CreateDashboardModal` | Form with name, description, template selection |
| `DashboardCanvas` | Widget grid with drag-drop reordering |
| `DashboardToolbar` | View/edit mode toggle, save/cancel, add widget |
| `WidgetCard` | Chart wrapper with edit/remove controls |
| `WidgetConfigurator` | Modal: domain, metrics, dimensions, chart type, filters, size |
| `WidgetConfiguratorUtils` | Metric/dimension helpers, chart type suggestions |
| `WidgetIcons` | SVG icons for chart type picker |
| `GenericChartRenderer` | Renders any chart from widget config JSON |
| `GenericChartRendererUtils` | Builds moduleEntity from widget config |
| `CustomDashboardTypes` | TypeScript types for dashboard, widget, operations |
| `CustomDashboardUtils` | API helpers, display utils |
| `CustomDashboardConstants` | Templates, max limits |

### Infrastructure Changes (5 modified files)

| File | Change |
|------|--------|
| `FeatureFlagUtils.res` | Add `customDashboards` flag |
| `OrchestrationApp.res` | Add `/new-analytics/dashboards` route |
| `InsightsContainerUtils.res` | Add tab index 3 for dashboards |
| `InsightsTypes.res` | Add `NewAnalyticsDashboards` route variant |
| `InsightsAnalyticsContainer.res` | Add "My Dashboards" tab |

### Features

- Create/rename/delete dashboards (max 10)
- Add/edit/remove widgets (max 20 per dashboard)
- 7 chart types: line, bar, column, pie, stacked bar, sankey, funnel
- Widget configurator with domain/metrics/dimensions picker
- Drag-drop reordering via react-beautiful-dnd
- Pre-built templates (Payment Overview, Connector Comparison)
- View/edit mode toggle
- Feature-flagged via `customDashboards`

### No new dependencies

Reuses: react-beautiful-dnd, Highcharts, HeadlessUI, ReactFinalForm

## Motivation and Context

Companion to backend PR: https://github.com/juspay/hyperswitch/pull/11738

Merchants need customizable analytics dashboards. This PR adds the frontend; the backend CRUD is in the linked PR.

## How did you test it?

- ReScript build passes (`npx rescript build`)
- Webpack compiles successfully
- Manual testing: tab navigation, dashboard CRUD, widget configurator

## Checklist

- [x] I reviewed the submitted code
- [x] I tested the changes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Custom Dashboards**: Create personalized analytics dashboards to visualize key metrics and data insights
* **Dashboard Templates**: Start with preset dashboard templates or create from scratch
* **Widget Library**: Add and configure various chart types including line, bar, pie, table, gauge, sankey, and funnel charts
* **Dashboard Management**: Rename, duplicate, delete, and set default dashboards
* **Interactive Widget Editor**: Drag-and-drop layout editor with resizable widgets and live chart preview

<!-- end of auto-generated comment: release notes by coderabbit.ai -->