### PR TITLE
feat: filter merchant-level roles based on product type during invite

### DIFF
--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -162,7 +162,7 @@ let make = () => {
       )
       let result = await fetchDetails(url)
       let allOptions = result->makeSelectBoxOptions
-      let filteredOptions = if roleEntity == "merchant" {
+      let filteredOptions = if roleEntity == "merchant" || roleEntity == "profile" {
         let selectedMerchantId =
           formState.values->getDictFromJsonObject->getString("merchant_value", "")
         let selectedMerchant = merchList->Array.find(m => m.id == selectedMerchantId)
@@ -175,7 +175,7 @@ let make = () => {
         | None => false
         }
         allOptions->Array.filter(option => {
-          let isReconRole = option.label->String.toLowerCase->String.startsWith("recon")
+          let isReconRole = option.label->String.toLowerCase->String.startsWith("recon_")
           isRecon ? isReconRole : !isReconRole
         })
       } else {

--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -101,7 +101,7 @@ let make = () => {
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
-  let merchList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
+  let merchantList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
   let (roleDict, setRoleDict) = React.useState(_ => Dict.make())
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let roleTypeValue =
@@ -165,10 +165,10 @@ let make = () => {
       let filteredOptions = if roleEntity == "merchant" || roleEntity == "profile" {
         let selectedMerchantId =
           formState.values->getDictFromJsonObject->getString("merchant_value", "")
-        let selectedMerchant = merchList->Array.find(m => m.id == selectedMerchantId)
+        let selectedMerchant = merchantList->Array.find(m => m.id == selectedMerchantId)
         let isRecon = switch selectedMerchant {
-        | Some({?productType}) =>
-          switch productType {
+        | Some(selectedMerchant) =>
+          switch selectedMerchant.productType {
           | Some(Recon(_)) => true
           | _ => false
           }

--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -101,6 +101,7 @@ let make = () => {
 
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
+  let merchList = Recoil.useRecoilValueFromAtom(HyperswitchAtom.merchantListAtom)
   let (roleDict, setRoleDict) = React.useState(_ => Dict.make())
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let roleTypeValue =
@@ -160,7 +161,27 @@ let make = () => {
         ~queryParameters=Some(`entity_type=${roleEntity}`),
       )
       let result = await fetchDetails(url)
-      setOptions(_ => result->makeSelectBoxOptions)
+      let allOptions = result->makeSelectBoxOptions
+      let filteredOptions = if roleEntity == "merchant" {
+        let selectedMerchantId =
+          formState.values->getDictFromJsonObject->getString("merchant_value", "")
+        let selectedMerchant = merchList->Array.find(m => m.id == selectedMerchantId)
+        let isRecon = switch selectedMerchant {
+        | Some({?productType}) =>
+          switch productType {
+          | Some(Recon(_)) => true
+          | _ => false
+          }
+        | None => false
+        }
+        allOptions->Array.filter(option => {
+          let isReconRole = option.label->String.toLowerCase->String.startsWith("recon")
+          isRecon ? isReconRole : !isReconRole
+        })
+      } else {
+        allOptions
+      }
+      setOptions(_ => filteredOptions)
       if result->getArrayFromJson([])->Array.length > 0 {
         setDropDownLoaderState(_ => DropdownWithLoading.Success)
       } else {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When inviting users at the merchant level, the roles dropdown is now filtered based on the selected merchant's `product_type`:
- If the selected merchant's product type is **Recon**, only recon roles are shown (`recon_admin`, `recon_viewer`, `recon_operator`, `recon_data_engineer`).
- For all other product types, recon roles are excluded from the dropdown.

This is a temporary frontend-only filter. The backend API still returns all roles — filtering happens client-side after the response.

## Motivation and Context

Recon-specific roles should only be visible when inviting users to a Recon merchant, and should be hidden for non-Recon merchants. This prevents accidentally assigning recon roles to non-recon merchants and vice versa.

## How did you test it?

Manual testing:
- Selected a Recon merchant → verified only recon roles appear in the dropdown
- Selected a non-Recon merchant → verified recon roles are excluded

Recon Merchant, profile level

<img width="623" height="456" alt="Screenshot 2026-04-10 at 8 51 11 PM" src="https://github.com/user-attachments/assets/faa4f883-678d-46d8-922e-984dd6941f80" />

Hyperswitch Merchant, profile level

<img width="629" height="512" alt="Screenshot 2026-04-10 at 8 51 29 PM" src="https://github.com/user-attachments/assets/157a3c02-5e72-4bfc-9f60-e56cbf5de9be" />

Recon Merchant, merchant level

<img width="626" height="455" alt="Screenshot 2026-04-10 at 8 52 21 PM" src="https://github.com/user-attachments/assets/faca2f0c-7646-4b7b-807c-0a567d267787" />

Hyperswitch Merchant, merchant level

<img width="617" height="518" alt="Screenshot 2026-04-10 at 8 52 52 PM" src="https://github.com/user-attachments/assets/ee012525-140e-4068-b845-15a2238448cd" />

Org level roles

<img width="629" height="395" alt="Screenshot 2026-04-10 at 8 53 07 PM" src="https://github.com/user-attachments/assets/98857047-a0bd-4132-8398-3fdd1a3f6b7d" />


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dropdown filtering in user invitations. When creating invitations for merchant roles, available options now intelligently filter based on the selected merchant and product configuration. Recon-specific options appear only when relevant to the product type being configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->