### PR TITLE
feat: improve production intent form with multi-product selection

### DIFF
--- a/src/entryPoints/HyperswitchAppHelper.res
+++ b/src/entryPoints/HyperswitchAppHelper.res
@@ -26,8 +26,13 @@ module TestMode = {
     let isLiveMode = (HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom).isLiveMode
     let {roleId} = React.useContext(UserInfoProvider.defaultContext).getResolvedUserInfo()
     let isInternalUser = roleId->HyperSwitchUtils.checkIsInternalUser
+    let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
 
     let showTestMode = !isLiveMode && !isInternalUser
+    let isOrchestrationV1 = switch activeProduct {
+    | Orchestration(V1) => true
+    | _ => false
+    }
 
     <RenderIf condition={showTestMode}>
       <div
@@ -38,7 +43,9 @@ module TestMode = {
           <p className="text-nd_yellow-200 text-base leading-5 font-medium text-nowrap">
             {"You're in Test Mode"->React.string}
           </p>
-          <GetProductionAccess />
+          <RenderIf condition={isOrchestrationV1}>
+            <GetProductionAccess />
+          </RenderIf>
         </div>
       </div>
     </RenderIf>

--- a/src/entryPoints/HyperswitchAppHelper.res
+++ b/src/entryPoints/HyperswitchAppHelper.res
@@ -29,8 +29,8 @@ module TestMode = {
     let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
 
     let showTestMode = !isLiveMode && !isInternalUser
-    let showGetProductionAccess = switch activeProduct {
-    | Orchestration(V1) => true
+    let isOrchestrationV1 = switch activeProduct {
+    | ProductTypes.Orchestration(V1) => true
     | _ => false
     }
 
@@ -43,7 +43,7 @@ module TestMode = {
           <p className="text-nd_yellow-200 text-base leading-5 font-medium text-nowrap">
             {"You're in Test Mode"->React.string}
           </p>
-          <RenderIf condition={showGetProductionAccess}>
+          <RenderIf condition={isOrchestrationV1}>
             <GetProductionAccess />
           </RenderIf>
         </div>

--- a/src/entryPoints/HyperswitchAppHelper.res
+++ b/src/entryPoints/HyperswitchAppHelper.res
@@ -29,7 +29,7 @@ module TestMode = {
     let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
 
     let showTestMode = !isLiveMode && !isInternalUser
-    let isOrchestrationV1 = switch activeProduct {
+    let showGetProductionAccess = switch activeProduct {
     | Orchestration(V1) => true
     | _ => false
     }
@@ -43,7 +43,7 @@ module TestMode = {
           <p className="text-nd_yellow-200 text-base leading-5 font-medium text-nowrap">
             {"You're in Test Mode"->React.string}
           </p>
-          <RenderIf condition={isOrchestrationV1}>
+          <RenderIf condition={showGetProductionAccess}>
             <GetProductionAccess />
           </RenderIf>
         </div>

--- a/src/screens/Home/ProdIntent/GetProductionAccess.res
+++ b/src/screens/Home/ProdIntent/GetProductionAccess.res
@@ -40,9 +40,7 @@ let make = () => {
   }
 
   let isProdAccessAvailableForProduct = switch activeProduct {
-  | Orchestration(V1)
-  | DynamicRouting
-  | Recon(V2) => true
+  | Orchestration(V1) => true
   | _ => false
   }
 

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -34,20 +34,10 @@ let availableProducts = [
   },
 ]
 
-let getProductStringKey = product => {
-  switch product {
-  | Orchestration(_) => "orchestration"
-  | Recon(_) => "recon"
-  | Recovery => "recovery"
-  | CostObservability => "cost_observability"
-  | _ => ""
-  }
-}
-
 module ProductCard = {
   @react.component
   let make = (
-    ~item: productSelectionItem,
+    ~product: productSelectionItem,
     ~isSelected: bool,
     ~isDisabled: bool,
     ~onToggle: unit => unit,
@@ -56,9 +46,9 @@ module ProductCard = {
     let stateClasses = if isDisabled {
       "border-nd_gray-200 bg-nd_gray-50 cursor-not-allowed opacity-60"
     } else if isSelected {
-      "border-nd_blue-500 bg-nd_blue-50"
+      "border-nd_blue-500 bg-nd_blue-50 hover:border-nd_blue-600"
     } else {
-      "border-nd_gray-200 hover:border-nd_gray-300 bg-white"
+      "border-nd_gray-200 bg-white hover:border-nd_gray-300 hover:bg-nd_gray-50"
     }
 
     <div
@@ -69,38 +59,50 @@ module ProductCard = {
         }
       }}>
       <div className="flex items-center justify-between">
-        <Icon name={item.icon} size=24 />
-        <RenderIf condition={isSelected}>
-          <div className="w-5 h-5 rounded-full bg-nd_blue-500 flex items-center justify-center">
-            <Icon name="check" size=12 customIconColor="text-white" />
-          </div>
-        </RenderIf>
+        <div className="flex items-center gap-3">
+          <Icon name={product.icon} size=24 />
+          <span className="font-semibold text-nd_gray-700"> {product.name->React.string} </span>
+        </div>
+        <div
+          className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
+            isSelected ? "bg-nd_blue-500 border-nd_blue-500" : "border-nd_gray-300 bg-white"
+          }`}>
+          <RenderIf condition={isSelected}>
+            <Icon name="check" size=14 customIconColor="text-white" />
+          </RenderIf>
+        </div>
       </div>
-      <div className="flex flex-col gap-1">
-        <span className="text-sm font-semibold text-nd_gray-700"> {item.name->React.string} </span>
-        <span className="text-xs text-nd_gray-500"> {item.description->React.string} </span>
-      </div>
+      <p className="text-sm text-nd_gray-500"> {product.description->React.string} </p>
     </div>
   }
 }
 
 @react.component
-let make = (~selectedProducts: array<string>, ~onProductToggle: (string, bool) => unit) => {
-  <div className="grid grid-cols-2 gap-4">
-    {availableProducts
-    ->Array.map(item => {
-      let productKey = item.product->getProductStringKey
-      let isSelected = selectedProducts->Array.includes(productKey)
-      let isDisabled = productKey === "orchestration"
+let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
+  <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1">
+      <span className="text-sm font-medium text-nd_gray-700">
+        {"Select Products"->React.string}
+      </span>
+      <span className="text-xs text-nd_gray-500">
+        {"Choose the products you want production access for"->React.string}
+      </span>
+    </div>
+    <div className="grid grid-cols-2 gap-3">
+      {availableProducts
+      ->Array.map(product => {
+        let isSelected = selectedProducts->Array.some(p => p == product.product)
+        let isDisabled = product.product == Orchestration(V1)
 
-      <ProductCard
-        key={productKey}
-        item
-        isSelected
-        isDisabled
-        onToggle={() => onProductToggle(productKey, !isSelected)}
-      />
-    })
-    ->React.array}
+        <ProductCard
+          key={product.name}
+          product
+          isSelected
+          isDisabled
+          onToggle={() => onProductToggle(product.product)}
+        />
+      })
+      ->React.array}
+    </div>
   </div>
 }

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -1,0 +1,102 @@
+open ProductTypes
+
+type productSelection = {
+  product: productTypes,
+  name: string,
+  icon: string,
+  description: string,
+}
+
+let availableProducts = [
+  {
+    product: Orchestration(V1),
+    name: "Orchestration",
+    icon: "orchestrator-home",
+    description: "Payment orchestration platform",
+  },
+  {
+    product: Recon(V1),
+    name: "Reconciliation",
+    icon: "recon-home",
+    description: "Automated reconciliation",
+  },
+  {
+    product: Recovery,
+    name: "Revenue Recovery",
+    icon: "recovery-home",
+    description: "Failed payment recovery",
+  },
+  {
+    product: CostObservability,
+    name: "Cost Observability",
+    icon: "nd-piggy-bank",
+    description: "Payment cost analytics",
+  },
+]
+
+module ProductCard = {
+  @react.component
+  let make = (
+    ~product: productSelection,
+    ~isSelected: bool,
+    ~isDisabled: bool,
+    ~onToggle: unit => unit,
+  ) => {
+    let baseClasses = "flex flex-col gap-3 p-4 rounded-lg border-2 cursor-pointer transition-all duration-200"
+    let selectedClasses = isSelected
+      ? "border-hyperswitch_blue bg-blue-50"
+      : "border-gray-200 hover:border-gray-300 bg-white"
+    let disabledClasses = isDisabled ? "opacity-60 cursor-not-allowed" : ""
+
+    <div
+      className={`${baseClasses} ${selectedClasses} ${disabledClasses}`}
+      onClick={_ => {
+        if !isDisabled {
+          onToggle()
+        }
+      }}>
+      <div className="flex items-center gap-3">
+        <Icon name={product.icon} size=24 />
+        <div className="flex flex-col">
+          <span className="font-semibold text-sm text-gray-900"> {product.name->React.string} </span>
+          <span className="text-xs text-gray-500"> {product.description->React.string} </span>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <div
+          className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
+            isSelected ? "bg-hyperswitch_blue border-hyperswitch_blue" : "border-gray-300"
+          }`}>
+          <RenderIf condition={isSelected}>
+            <Icon name="check" size=12 customIconColor="text-white" />
+          </RenderIf>
+        </div>
+      </div>
+    </div>
+  }
+}
+
+@react.component
+let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
+  <div className="flex flex-col gap-3">
+    <div className="text-sm font-medium text-gray-700">
+      {"Select products for production access"->React.string}
+    </div>
+    <div className="grid grid-cols-2 gap-3">
+      {availableProducts
+      ->Array.map(productSelection => {
+        let isSelected = selectedProducts->Array.some(p => p == productSelection.product)
+        let isDisabled = productSelection.product == Orchestration(V1)
+
+        <ProductCard
+          key={productSelection.name}
+          product={productSelection}
+          isSelected
+          isDisabled
+          onToggle={() => onProductToggle(productSelection.product)}
+        />
+      })
+      ->React.array}
+    </div>
+  </div>
+}

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -56,7 +56,7 @@ module ProductCard = {
     let stateClasses = if isDisabled {
       "border-nd_gray-200 bg-nd_gray-50 cursor-not-allowed opacity-60"
     } else if isSelected {
-      "border-nd_primary_blue-500 bg-nd_primary_blue-50"
+      "border-nd_blue-500 bg-nd_blue-50"
     } else {
       "border-nd_gray-200 hover:border-nd_gray-300 bg-white"
     }
@@ -69,15 +69,17 @@ module ProductCard = {
         }
       }}>
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Icon name={item.icon} size=24 className="text-nd_primary_blue-500" />
-          <span className="font-semibold text-nd_gray-700"> {item.name->React.string} </span>
-        </div>
+        <Icon name={item.icon} size=24 />
         <RenderIf condition={isSelected}>
-          <Icon name="nd-check" size=20 className="text-nd_primary_blue-500" />
+          <div className="w-5 h-5 rounded-full bg-nd_blue-500 flex items-center justify-center">
+            <Icon name="check" size=12 customIconColor="text-white" />
+          </div>
         </RenderIf>
       </div>
-      <p className="text-sm text-nd_gray-500"> {item.description->React.string} </p>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold text-nd_gray-700"> {item.name->React.string} </span>
+        <span className="text-xs text-nd_gray-500"> {item.description->React.string} </span>
+      </div>
     </div>
   }
 }

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -1,7 +1,7 @@
 open ProductTypes
 
 type productSelectionItem = {
-  productKey: string,
+  product: productTypes,
   name: string,
   icon: string,
   description: string,
@@ -9,25 +9,25 @@ type productSelectionItem = {
 
 let availableProducts = [
   {
-    productKey: "orchestration",
+    product: Orchestration(V1),
     name: "Orchestration",
     icon: "orchestrator-home",
     description: "Payment orchestration platform",
   },
   {
-    productKey: "recon",
+    product: Recon(V1),
     name: "Reconciliation",
     icon: "recon-home",
     description: "Automated reconciliation",
   },
   {
-    productKey: "recovery",
+    product: Recovery,
     name: "Revenue Recovery",
     icon: "recovery-home",
     description: "Failed payment recovery",
   },
   {
-    productKey: "cost_observability",
+    product: CostObservability,
     name: "Cost Observability",
     icon: "nd-piggy-bank",
     description: "Payment cost analytics",
@@ -78,7 +78,7 @@ module ProductCard = {
 }
 
 @react.component
-let make = (~selectedProducts: array<string>, ~onProductToggle: (string, bool) => unit) => {
+let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
   <div className="flex flex-col gap-4">
     <div className="flex flex-col gap-1">
       <span className="text-sm font-medium text-nd_gray-700">
@@ -91,15 +91,15 @@ let make = (~selectedProducts: array<string>, ~onProductToggle: (string, bool) =
     <div className="grid grid-cols-2 gap-3">
       {availableProducts
       ->Array.map(product => {
-        let isSelected = selectedProducts->Array.some(p => p == product.productKey)
-        let isDisabled = product.productKey == "orchestration"
+        let isSelected = selectedProducts->Array.some(p => p == product.product)
+        let isDisabled = product.product == Orchestration(V1)
 
         <ProductCard
-          key={product.productKey}
+          key={product.name}
           product
           isSelected
           isDisabled
-          onToggle={() => onProductToggle(product.productKey, !isSelected)}
+          onToggle={() => onProductToggle(product.product)}
         />
       })
       ->React.array}

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -1,6 +1,6 @@
 open ProductTypes
 
-type productSelectionItem = {
+type productSelection = {
   product: productTypes,
   name: string,
   icon: string,
@@ -37,18 +37,18 @@ let availableProducts = [
 module ProductCard = {
   @react.component
   let make = (
-    ~product: productSelectionItem,
+    ~product: productSelection,
     ~isSelected: bool,
     ~isDisabled: bool,
     ~onToggle: unit => unit,
   ) => {
-    let baseClasses = "flex flex-col gap-3 p-4 rounded-lg border-2 cursor-pointer transition-all duration-200"
+    let baseClasses = "flex flex-col gap-2 p-4 rounded-lg border-2 cursor-pointer transition-all duration-200"
     let stateClasses = if isDisabled {
       "border-nd_gray-200 bg-nd_gray-50 cursor-not-allowed opacity-60"
     } else if isSelected {
-      "border-nd_blue-500 bg-nd_blue-50 hover:border-nd_blue-600"
+      "border-nd_blue-500 bg-nd_blue-50"
     } else {
-      "border-nd_gray-200 bg-white hover:border-nd_gray-300 hover:bg-nd_gray-50"
+      "border-nd_gray-200 hover:border-nd_gray-300 bg-white"
     }
 
     <div
@@ -58,48 +58,43 @@ module ProductCard = {
           onToggle()
         }
       }}>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <Icon name={product.icon} size=24 />
-          <span className="font-semibold text-nd_gray-700"> {product.name->React.string} </span>
-        </div>
-        <div
-          className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
-            isSelected ? "bg-nd_blue-500 border-nd_blue-500" : "border-nd_gray-300 bg-white"
-          }`}>
-          <RenderIf condition={isSelected}>
-            <Icon name="check" size=14 customIconColor="text-white" />
-          </RenderIf>
-        </div>
+      <div className="flex items-center gap-2">
+        <Icon name={product.icon} size=24 />
+        <span className="font-semibold text-sm text-nd_gray-700"> {product.name->React.string} </span>
+        <RenderIf condition={isSelected}>
+          <div className="ml-auto">
+            <Icon name="nd-check" size=16 customIconColor="text-nd_blue-500" />
+          </div>
+        </RenderIf>
       </div>
-      <p className="text-sm text-nd_gray-500"> {product.description->React.string} </p>
+      <p className="text-xs text-nd_gray-500 leading-relaxed"> {product.description->React.string} </p>
     </div>
   }
 }
 
 @react.component
 let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
-  <div className="flex flex-col gap-4">
+  <div className="flex flex-col gap-3">
     <div className="flex flex-col gap-1">
-      <span className="text-sm font-medium text-nd_gray-700">
-        {"Select Products"->React.string}
-      </span>
-      <span className="text-xs text-nd_gray-500">
-        {"Choose the products you want production access for"->React.string}
-      </span>
+      <h3 className="text-sm font-semibold text-nd_gray-700">
+        {"Select products for production access"->React.string}
+      </h3>
+      <p className="text-xs text-nd_gray-500">
+        {"Choose the products you want to request production access for:"->React.string}
+      </p>
     </div>
     <div className="grid grid-cols-2 gap-3">
       {availableProducts
-      ->Array.map(product => {
-        let isSelected = selectedProducts->Array.some(p => p == product.product)
-        let isDisabled = product.product == Orchestration(V1)
+      ->Array.map(productInfo => {
+        let isSelected = selectedProducts->Array.some(p => p == productInfo.product)
+        let isDisabled = productInfo.product == Orchestration(V1)
 
         <ProductCard
-          key={product.name}
-          product
+          key={productInfo.name}
+          product={productInfo}
           isSelected
           isDisabled
-          onToggle={() => onProductToggle(product.product)}
+          onToggle={() => onProductToggle(productInfo.product)}
         />
       })
       ->React.array}

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -1,6 +1,6 @@
 open ProductTypes
 
-type productSelection = {
+type productSelectionItem = {
   product: productTypes,
   name: string,
   icon: string,
@@ -34,69 +34,71 @@ let availableProducts = [
   },
 ]
 
+let getProductStringKey = product => {
+  switch product {
+  | Orchestration(_) => "orchestration"
+  | Recon(_) => "recon"
+  | Recovery => "recovery"
+  | CostObservability => "cost_observability"
+  | _ => ""
+  }
+}
+
 module ProductCard = {
   @react.component
   let make = (
-    ~product: productSelection,
+    ~item: productSelectionItem,
     ~isSelected: bool,
     ~isDisabled: bool,
     ~onToggle: unit => unit,
   ) => {
     let baseClasses = "flex flex-col gap-3 p-4 rounded-lg border-2 cursor-pointer transition-all duration-200"
-    let selectedClasses = isSelected
-      ? "border-hyperswitch_blue bg-blue-50"
-      : "border-gray-200 hover:border-gray-300 bg-white"
-    let disabledClasses = isDisabled ? "opacity-60 cursor-not-allowed" : ""
+    let stateClasses = if isDisabled {
+      "border-nd_gray-200 bg-nd_gray-50 cursor-not-allowed opacity-60"
+    } else if isSelected {
+      "border-nd_primary_blue-500 bg-nd_primary_blue-50"
+    } else {
+      "border-nd_gray-200 hover:border-nd_gray-300 bg-white"
+    }
 
     <div
-      className={`${baseClasses} ${selectedClasses} ${disabledClasses}`}
+      className={`${baseClasses} ${stateClasses}`}
       onClick={_ => {
         if !isDisabled {
           onToggle()
         }
       }}>
-      <div className="flex items-center gap-3">
-        <Icon name={product.icon} size=24 />
-        <div className="flex flex-col">
-          <span className="font-semibold text-sm text-gray-900"> {product.name->React.string} </span>
-          <span className="text-xs text-gray-500"> {product.description->React.string} </span>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Icon name={item.icon} size=24 className="text-nd_primary_blue-500" />
+          <span className="font-semibold text-nd_gray-700"> {item.name->React.string} </span>
         </div>
+        <RenderIf condition={isSelected}>
+          <Icon name="nd-check" size=20 className="text-nd_primary_blue-500" />
+        </RenderIf>
       </div>
-      <div className="flex justify-end">
-        <div
-          className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
-            isSelected ? "bg-hyperswitch_blue border-hyperswitch_blue" : "border-gray-300"
-          }`}>
-          <RenderIf condition={isSelected}>
-            <Icon name="check" size=12 customIconColor="text-white" />
-          </RenderIf>
-        </div>
-      </div>
+      <p className="text-sm text-nd_gray-500"> {item.description->React.string} </p>
     </div>
   }
 }
 
 @react.component
-let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
-  <div className="flex flex-col gap-3">
-    <div className="text-sm font-medium text-gray-700">
-      {"Select products for production access"->React.string}
-    </div>
-    <div className="grid grid-cols-2 gap-3">
-      {availableProducts
-      ->Array.map(productSelection => {
-        let isSelected = selectedProducts->Array.some(p => p == productSelection.product)
-        let isDisabled = productSelection.product == Orchestration(V1)
+let make = (~selectedProducts: array<string>, ~onProductToggle: (string, bool) => unit) => {
+  <div className="grid grid-cols-2 gap-4">
+    {availableProducts
+    ->Array.map(item => {
+      let productKey = item.product->getProductStringKey
+      let isSelected = selectedProducts->Array.includes(productKey)
+      let isDisabled = productKey === "orchestration"
 
-        <ProductCard
-          key={productSelection.name}
-          product={productSelection}
-          isSelected
-          isDisabled
-          onToggle={() => onProductToggle(productSelection.product)}
-        />
-      })
-      ->React.array}
-    </div>
+      <ProductCard
+        key={productKey}
+        item
+        isSelected
+        isDisabled
+        onToggle={() => onProductToggle(productKey, !isSelected)}
+      />
+    })
+    ->React.array}
   </div>
 }

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -1,7 +1,7 @@
 open ProductTypes
 
 type productSelectionItem = {
-  product: productTypes,
+  productKey: string,
   name: string,
   icon: string,
   description: string,
@@ -9,25 +9,25 @@ type productSelectionItem = {
 
 let availableProducts = [
   {
-    product: Orchestration(V1),
+    productKey: "orchestration",
     name: "Orchestration",
     icon: "orchestrator-home",
     description: "Payment orchestration platform",
   },
   {
-    product: Recon(V1),
+    productKey: "recon",
     name: "Reconciliation",
     icon: "recon-home",
     description: "Automated reconciliation",
   },
   {
-    product: Recovery,
+    productKey: "recovery",
     name: "Revenue Recovery",
     icon: "recovery-home",
     description: "Failed payment recovery",
   },
   {
-    product: CostObservability,
+    productKey: "cost_observability",
     name: "Cost Observability",
     icon: "nd-piggy-bank",
     description: "Payment cost analytics",
@@ -78,7 +78,7 @@ module ProductCard = {
 }
 
 @react.component
-let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTypes => unit) => {
+let make = (~selectedProducts: array<string>, ~onProductToggle: (string, bool) => unit) => {
   <div className="flex flex-col gap-4">
     <div className="flex flex-col gap-1">
       <span className="text-sm font-medium text-nd_gray-700">
@@ -91,15 +91,15 @@ let make = (~selectedProducts: array<productTypes>, ~onProductToggle: productTyp
     <div className="grid grid-cols-2 gap-3">
       {availableProducts
       ->Array.map(product => {
-        let isSelected = selectedProducts->Array.some(p => p == product.product)
-        let isDisabled = product.product == Orchestration(V1)
+        let isSelected = selectedProducts->Array.some(p => p == product.productKey)
+        let isDisabled = product.productKey == "orchestration"
 
         <ProductCard
-          key={product.name}
+          key={product.productKey}
           product
           isSelected
           isDisabled
-          onToggle={() => onProductToggle(product.product)}
+          onToggle={() => onProductToggle(product.productKey, !isSelected)}
         />
       })
       ->React.array}

--- a/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
+++ b/src/screens/Home/ProdIntent/ProdIntentProductSelection.res
@@ -53,8 +53,17 @@ module ProductCard = {
 
     <div
       className={`${baseClasses} ${stateClasses}`}
+      role="checkbox"
+      aria-checked={isSelected->Bool.toString}
+      tabIndex={isDisabled ? -1 : 0}
       onClick={_ => {
         if !isDisabled {
+          onToggle()
+        }
+      }}
+      onKeyDown={ev => {
+        if !isDisabled && (ev->ReactEvent.Keyboard.key === "Enter" || ev->ReactEvent.Keyboard.key === " ") {
+          ev->ReactEvent.Keyboard.preventDefault
           onToggle()
         }
       }}>

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -27,7 +27,15 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
         ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
         ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
       ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(err => {
+        Console.error2("Failed to send production intent email notification:", err)
+        showToast(
+          ~toastType=ToastWarning,
+          ~message="Request submitted, but email notification failed. Our team will still process your request.",
+          ~autoClose=true,
+        )
+        Promise.resolve(JSON.Encode.null)
+      })
 
       showToast(
         ~toastType=ToastSuccess,

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -27,7 +27,8 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
+      let selectedProductStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
+      let bodyValues = values->getBody(~selectedProducts=selectedProductStrings)->JSON.Encode.object
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
       showToast(

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -10,9 +10,19 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
-  let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
 
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
+
+  let toggleProduct = (product: ProductTypes.productTypes) => {
+    setSelectedProducts(current => {
+      let exists = current->Array.some(p => p == product)
+      if exists {
+        current->Array.filter(p => p != product)
+      } else {
+        current->Array.concat([product])
+      }
+    })
+  }
 
   let updateProdDetails = async values => {
     try {
@@ -20,15 +30,6 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
       let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
-
-      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
-      let emailBody = [
-        ("requested_products", selectedProducts->JSON.Encode.array),
-        ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
-        ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
-      ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->Promise.catch(_ => Promise.resolve(JSON.Encode.null))
-
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -47,16 +48,6 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
-  }
-
-  let handleProductToggle = (productKey, isSelected) => {
-    setSelectedProducts(prev => {
-      if isSelected {
-        prev->Array.concat([productKey])
-      } else {
-        prev->Array.filter(p => p !== productKey)
-      }
-    })
   }
 
   let modalBody = {
@@ -84,13 +75,11 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               <div className="flex flex-col gap-8 w-full">
                 <FormRenderer.DesktopRow>
                   <div className="flex flex-col gap-6">
-                    <div className="flex flex-col gap-3">
-                      <span className="text-sm font-medium text-black">
-                        {"Select Products"->React.string}
-                      </span>
-                      <ProdIntentProductSelection selectedProducts onProductToggle=handleProductToggle />
-                    </div>
-                    <div className="flex flex-col gap-5">
+                    <ProdIntentProductSelection
+                      selectedProducts
+                      onProductToggle=toggleProduct
+                    />
+                    <div className="grid grid-cols-2 gap-5">
                       {formFields
                       ->Array.mapWithIndex((column, index) =>
                         <FormRenderer.FieldRenderer
@@ -122,7 +111,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setShowModal
     childClass="p-0"
     borderBottom=true
-    modalClass="w-full max-w-2xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
+    modalClass="w-full max-w-3xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
     modalBody
   </Modal>
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,17 +11,41 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
-  
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
+
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
+
+  let toggleProduct = (product: ProductTypes.productTypes) => {
+    setSelectedProducts(current => {
+      let exists = current->Array.some(p => p == product)
+      if exists {
+        current->Array.filter(p => p != product)
+      } else {
+        current->Array.concat([product])
+      }
+    })
+  }
 
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
       let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
-      
+      bodyValues
+      ->LogicUtils.getDictFromJsonObject
+      ->Dict.set(
+        "product_type",
+        activeProduct->ProductUtils.getProductStringName->JSON.Encode.string,
+      )
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
-      
+
+      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
+      let emailBody = [
+        ("requested_products", selectedProducts->Array.map(ProductUtils.getProductStringName)->JSON.Encode.array),
+        ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
+        ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
+      ]->LogicUtils.getJsonFromArrayOfJson
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -37,23 +61,12 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   }
 
   let onSubmit = (values, _) => {
+    values
+    ->LogicUtils.getDictFromJsonObject
+    ->Dict.set("product_type", activeProduct->ProductUtils.getProductStringName->JSON.Encode.string)
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
-  }
-  
-  let handleProductToggle = (productKey, isSelected) => {
-    setSelectedProducts(prev => {
-      if isSelected {
-        if prev->Array.includes(productKey) {
-          prev
-        } else {
-          prev->Array.concat([productKey])
-        }
-      } else {
-        prev->Array.filter(p => p !== productKey)
-      }
-    })
   }
 
   let modalBody = {
@@ -79,25 +92,25 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
               <div className="flex flex-col gap-8 w-full">
-                <div className="px-3">
-                  <h3 className="text-sm font-medium text-nd_gray-700 mb-3">
-                    {"Select Products"->React.string}
-                  </h3>
-                  <ProdIntentProductSelection selectedProducts onProductToggle={handleProductToggle} />
-                </div>
                 <FormRenderer.DesktopRow>
-                  <div className="flex flex-col gap-5">
-                    {formFields
-                    ->Array.mapWithIndex((column, index) =>
-                      <FormRenderer.FieldRenderer
-                        key={index->Int.toString}
-                        fieldWrapperClass="w-full"
-                        field={column->getFormField}
-                        errorClass
-                        labelClass="!text-black font-medium !-ml-[0.5px]"
-                      />
-                    )
-                    ->React.array}
+                  <div className="flex flex-col gap-6">
+                    <ProdIntentProductSelection
+                      selectedProducts
+                      onProductToggle=toggleProduct
+                    />
+                    <div className="grid grid-cols-2 gap-5">
+                      {formFields
+                      ->Array.mapWithIndex((column, index) =>
+                        <FormRenderer.FieldRenderer
+                          key={index->Int.toString}
+                          fieldWrapperClass="w-full"
+                          field={column->getFormField}
+                          errorClass
+                          labelClass="!text-black font-medium !-ml-[0.5px]"
+                        />
+                      )
+                      ->React.array}
+                    </div>
                   </div>
                 </FormRenderer.DesktopRow>
                 <div className="flex justify-end w-full pr-5 pb-3">
@@ -117,7 +130,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setShowModal
     childClass="p-0"
     borderBottom=true
-    modalClass="w-full max-w-2xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
+    modalClass="w-full max-w-3xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
     modalBody
   </Modal>
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -21,22 +21,13 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
 
-      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
+      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
       let emailBody = [
         ("requested_products", selectedProducts->Array.map(ProductUtils.getProductStringName)->JSON.Encode.array),
         ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
         ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
       ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(err => {
-        Console.error("Failed to send production intent email notification:")
-        Console.error(err)
-        showToast(
-          ~toastType=ToastWarning,
-          ~message="Request submitted, but email notification failed. Our team will still process your request.",
-          ~autoClose=true,
-        )
-        Promise.resolve(JSON.Encode.null)
-      })
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
 
       showToast(
         ~toastType=ToastSuccess,

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -12,10 +12,23 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
 
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
+
+  let toggleProduct = (product: ProductTypes.productTypes) => {
+    setSelectedProducts(prev => {
+      let exists = prev->Array.some(p => p == product)
+      if exists {
+        prev->Array.filter(p => p != product)
+      } else {
+        prev->Array.concat([product])
+      }
+    })
+  }
+
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let bodyValues = values->getBody->JSON.Encode.object
+      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
       bodyValues
       ->LogicUtils.getDictFromJsonObject
       ->Dict.set(
@@ -24,6 +37,24 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
       )
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
+
+      // Trigger email notification
+      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_EMAIL, ~methodType=Post)
+      let emailBody = [
+        ("recipient_email", "biz@hyperswitch.io"->JSON.Encode.string),
+        (
+          "subject",
+          "New Production Access Request"->JSON.Encode.string,
+        ),
+        (
+          "body",
+          `A new production access request has been submitted.\n\nSelected Products: ${selectedProducts
+            ->Array.map(ProductUtils.getProductStringName)
+            ->Array.join(", ")}`->JSON.Encode.string,
+        ),
+      ]->LogicUtils.getJsonFromArrayOfJson
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -53,7 +84,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
         <div className="py-5 px-3 flex justify-between align-top">
           <CardHeader
             heading="Get access to Live environment"
-            subHeading="We require some details for business verification. Once verified, our team will reach out and provide live credentials within a business day "
+            subHeading="We require some details for business verification. Once verified, our team will reach out and provide live credentials within a business day"
             customSubHeadingStyle="w-full !max-w-none pr-10"
           />
           <div className="h-fit" onClick={_ => setShowModal(_ => false)}>
@@ -69,20 +100,26 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               initialValues={initialValues->JSON.Encode.object}
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
-              <div className="flex flex-col gap-12 w-full">
+              <div className="flex flex-col gap-8 w-full">
                 <FormRenderer.DesktopRow>
-                  <div className="flex flex-col gap-5">
-                    {formFields
-                    ->Array.mapWithIndex((column, index) =>
-                      <FormRenderer.FieldRenderer
-                        key={index->Int.toString}
-                        fieldWrapperClass="w-full"
-                        field={column->getFormField}
-                        errorClass
-                        labelClass="!text-black font-medium !-ml-[0.5px]"
-                      />
-                    )
-                    ->React.array}
+                  <div className="flex flex-col gap-6">
+                    <ProdIntentProductSelection
+                      selectedProducts={selectedProducts}
+                      onProductToggle={toggleProduct}
+                    />
+                    <div className="grid grid-cols-2 gap-4">
+                      {formFields
+                      ->Array.mapWithIndex((column, index) =>
+                        <FormRenderer.FieldRenderer
+                          key={index->Int.toString}
+                          fieldWrapperClass="w-full"
+                          field={column->getFormField}
+                          errorClass
+                          labelClass="!text-black font-medium !-ml-[0.5px]"
+                        />
+                      )
+                      ->React.array}
+                    </div>
                   </div>
                 </FormRenderer.DesktopRow>
                 <div className="flex justify-end w-full pr-5 pb-3">
@@ -102,7 +139,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setShowModal
     childClass="p-0"
     borderBottom=true
-    modalClass="w-full max-w-2xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
+    modalClass="w-full max-w-3xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
     modalBody
   </Modal>
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,41 +11,28 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
+  
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
 
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
-
-  let toggleProduct = (product: ProductTypes.productTypes) => {
-    setSelectedProducts(current => {
-      let exists = current->Array.some(p => p == product)
-      if exists {
-        current->Array.filter(p => p != product)
-      } else {
-        current->Array.concat([product])
-      }
-    })
+  let stringToProductType = (productKey: string): ProductTypes.productTypes => {
+    switch productKey {
+    | "orchestration" => Orchestration(V1)
+    | "recon" => Recon(V1)
+    | "recovery" => Recovery
+    | "cost_observability" => CostObservability
+    | _ => Orchestration(V1)
+    }
   }
 
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
-      bodyValues
-      ->LogicUtils.getDictFromJsonObject
-      ->Dict.set(
-        "product_type",
-        activeProduct->ProductUtils.getProductStringName->JSON.Encode.string,
-      )
+      let productTypes = selectedProducts->Array.map(stringToProductType)
+      let bodyValues = values->getBody(~selectedProducts=productTypes)->JSON.Encode.object
+      
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
-
-      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
-      let emailBody = [
-        ("requested_products", selectedProducts->Array.map(ProductUtils.getProductStringName)->JSON.Encode.array),
-        ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
-        ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
-      ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
-
+      
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -61,12 +48,23 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   }
 
   let onSubmit = (values, _) => {
-    values
-    ->LogicUtils.getDictFromJsonObject
-    ->Dict.set("product_type", activeProduct->ProductUtils.getProductStringName->JSON.Encode.string)
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
+  }
+  
+  let handleProductToggle = (productKey, isSelected) => {
+    setSelectedProducts(prev => {
+      if isSelected {
+        if prev->Array.includes(productKey) {
+          prev
+        } else {
+          prev->Array.concat([productKey])
+        }
+      } else {
+        prev->Array.filter(p => p !== productKey)
+      }
+    })
   }
 
   let modalBody = {
@@ -92,25 +90,25 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
               <div className="flex flex-col gap-8 w-full">
+                <div className="px-3">
+                  <h3 className="text-sm font-medium text-nd_gray-700 mb-3">
+                    {"Select Products"->React.string}
+                  </h3>
+                  <ProdIntentProductSelection selectedProducts onProductToggle={handleProductToggle} />
+                </div>
                 <FormRenderer.DesktopRow>
-                  <div className="flex flex-col gap-6">
-                    <ProdIntentProductSelection
-                      selectedProducts
-                      onProductToggle=toggleProduct
-                    />
-                    <div className="grid grid-cols-2 gap-5">
-                      {formFields
-                      ->Array.mapWithIndex((column, index) =>
-                        <FormRenderer.FieldRenderer
-                          key={index->Int.toString}
-                          fieldWrapperClass="w-full"
-                          field={column->getFormField}
-                          errorClass
-                          labelClass="!text-black font-medium !-ml-[0.5px]"
-                        />
-                      )
-                      ->React.array}
-                    </div>
+                  <div className="flex flex-col gap-5">
+                    {formFields
+                    ->Array.mapWithIndex((column, index) =>
+                      <FormRenderer.FieldRenderer
+                        key={index->Int.toString}
+                        fieldWrapperClass="w-full"
+                        field={column->getFormField}
+                        errorClass
+                        labelClass="!text-black font-medium !-ml-[0.5px]"
+                      />
+                    )
+                    ->React.array}
                   </div>
                 </FormRenderer.DesktopRow>
                 <div className="flex justify-end w-full pr-5 pb-3">
@@ -130,7 +128,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setShowModal
     childClass="p-0"
     borderBottom=true
-    modalClass="w-full max-w-3xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
+    modalClass="w-full max-w-2xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
     modalBody
   </Modal>
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -16,13 +16,14 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
+      let selectedProductStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
+      let bodyValues = values->getBody(~selectedProducts=selectedProductStrings)->JSON.Encode.object
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
 
       let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
       let emailBody = [
-        ("requested_products", selectedProducts->JSON.Encode.array),
+        ("requested_products", selectedProducts->Array.map(ProductUtils.getProductStringName)->JSON.Encode.array),
         ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
         ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
       ]->LogicUtils.getJsonFromArrayOfJson
@@ -48,12 +49,13 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     updateProdDetails(values)
   }
 
-  let handleProductToggle = (productKey: string, isSelected: bool) => {
+  let handleProductToggle = (product: ProductTypes.productTypes) => {
     setSelectedProducts(prev => {
-      if isSelected {
-        prev->Array.concat([productKey])
+      let exists = prev->Array.some(p => p == product)
+      if exists {
+        prev->Array.filter(p => p != product)
       } else {
-        prev->Array.filter(p => p != productKey)
+        prev->Array.concat([product])
       }
     })
   }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -27,7 +27,16 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
         ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
         ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
       ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(err => {
+        Console.error("Failed to send production intent email notification:")
+        Console.error(err)
+        showToast(
+          ~toastType=ToastWarning,
+          ~message="Request submitted, but email notification failed. Our team will still process your request.",
+          ~autoClose=true,
+        )
+        Promise.resolve(JSON.Encode.null)
+      })
 
       showToast(
         ~toastType=ToastSuccess,

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,26 +11,23 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
 
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
-
-  let toggleProduct = (product: ProductTypes.productTypes) => {
-    setSelectedProducts(current => {
-      let exists = current->Array.some(p => p == product)
-      if exists {
-        current->Array.filter(p => p != product)
-      } else {
-        current->Array.concat([product])
-      }
-    })
-  }
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
 
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let selectedProductStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
-      let bodyValues = values->getBody(~selectedProducts=selectedProductStrings)->JSON.Encode.object
+      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
+
+      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
+      let emailBody = [
+        ("requested_products", selectedProducts->JSON.Encode.array),
+        ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
+        ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
+      ]->LogicUtils.getJsonFromArrayOfJson
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -49,6 +46,16 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
+  }
+
+  let handleProductToggle = (productKey: string, isSelected: bool) => {
+    setSelectedProducts(prev => {
+      if isSelected {
+        prev->Array.concat([productKey])
+      } else {
+        prev->Array.filter(p => p != productKey)
+      }
+    })
   }
 
   let modalBody = {
@@ -78,7 +85,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
                   <div className="flex flex-col gap-6">
                     <ProdIntentProductSelection
                       selectedProducts
-                      onProductToggle=toggleProduct
+                      onProductToggle=handleProductToggle
                     />
                     <div className="grid grid-cols-2 gap-5">
                       {formFields

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,50 +11,17 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
-
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
-
-  let toggleProduct = (product: ProductTypes.productTypes) => {
-    setSelectedProducts(prev => {
-      let exists = prev->Array.some(p => p == product)
-      if exists {
-        prev->Array.filter(p => p != product)
-      } else {
-        prev->Array.concat([product])
-      }
-    })
-  }
+  
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
 
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
       let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
-      bodyValues
-      ->LogicUtils.getDictFromJsonObject
-      ->Dict.set(
-        "product_type",
-        activeProduct->ProductUtils.getProductStringName->JSON.Encode.string,
-      )
+      
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
-
-      // Trigger email notification
-      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_EMAIL, ~methodType=Post)
-      let emailBody = [
-        ("recipient_email", "biz@hyperswitch.io"->JSON.Encode.string),
-        (
-          "subject",
-          "New Production Access Request"->JSON.Encode.string,
-        ),
-        (
-          "body",
-          `A new production access request has been submitted.\n\nSelected Products: ${selectedProducts
-            ->Array.map(ProductUtils.getProductStringName)
-            ->Array.join(", ")}`->JSON.Encode.string,
-        ),
-      ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
-
+      
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -70,12 +37,23 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   }
 
   let onSubmit = (values, _) => {
-    values
-    ->LogicUtils.getDictFromJsonObject
-    ->Dict.set("product_type", activeProduct->ProductUtils.getProductStringName->JSON.Encode.string)
     mixpanelEvent(~eventName="create_get_production_access_request", ~metadata=values)
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
+  }
+  
+  let handleProductToggle = (productKey, isSelected) => {
+    setSelectedProducts(prev => {
+      if isSelected {
+        if prev->Array.includes(productKey) {
+          prev
+        } else {
+          prev->Array.concat([productKey])
+        }
+      } else {
+        prev->Array.filter(p => p !== productKey)
+      }
+    })
   }
 
   let modalBody = {
@@ -101,25 +79,25 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
               <div className="flex flex-col gap-8 w-full">
+                <div className="px-3">
+                  <h3 className="text-sm font-medium text-nd_gray-700 mb-3">
+                    {"Select Products"->React.string}
+                  </h3>
+                  <ProdIntentProductSelection selectedProducts onProductToggle={handleProductToggle} />
+                </div>
                 <FormRenderer.DesktopRow>
-                  <div className="flex flex-col gap-6">
-                    <ProdIntentProductSelection
-                      selectedProducts={selectedProducts}
-                      onProductToggle={toggleProduct}
-                    />
-                    <div className="grid grid-cols-2 gap-4">
-                      {formFields
-                      ->Array.mapWithIndex((column, index) =>
-                        <FormRenderer.FieldRenderer
-                          key={index->Int.toString}
-                          fieldWrapperClass="w-full"
-                          field={column->getFormField}
-                          errorClass
-                          labelClass="!text-black font-medium !-ml-[0.5px]"
-                        />
-                      )
-                      ->React.array}
-                    </div>
+                  <div className="flex flex-col gap-5">
+                    {formFields
+                    ->Array.mapWithIndex((column, index) =>
+                      <FormRenderer.FieldRenderer
+                        key={index->Int.toString}
+                        fieldWrapperClass="w-full"
+                        field={column->getFormField}
+                        errorClass
+                        labelClass="!text-black font-medium !-ml-[0.5px]"
+                      />
+                    )
+                    ->React.array}
                   </div>
                 </FormRenderer.DesktopRow>
                 <div className="flex justify-end w-full pr-5 pb-3">
@@ -139,7 +117,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setShowModal
     childClass="p-0"
     borderBottom=true
-    modalClass="w-full max-w-3xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
+    modalClass="w-full max-w-2xl mx-auto my-auto dark:!bg-jp-gray-lightgray_background">
     modalBody
   </Modal>
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,7 +11,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
 
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => [ProductTypes.Orchestration(V1)])
 
   let updateProdDetails = async values => {
     try {

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -11,28 +11,24 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
   let {setShowProdIntentForm} = React.useContext(GlobalProvider.defaultContext)
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {activeProduct} = React.useContext(ProductSelectionProvider.defaultContext)
-  
-  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
 
-  let stringToProductType = (productKey: string): ProductTypes.productTypes => {
-    switch productKey {
-    | "orchestration" => Orchestration(V1)
-    | "recon" => Recon(V1)
-    | "recovery" => Recovery
-    | "cost_observability" => CostObservability
-    | _ => Orchestration(V1)
-    }
-  }
+  let (selectedProducts, setSelectedProducts) = React.useState(_ => ["orchestration"])
 
   let updateProdDetails = async values => {
     try {
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let productTypes = selectedProducts->Array.map(stringToProductType)
-      let bodyValues = values->getBody(~selectedProducts=productTypes)->JSON.Encode.object
-      
+      let bodyValues = values->getBody(~selectedProducts)->JSON.Encode.object
       let body = [("ProdIntent", bodyValues)]->LogicUtils.getJsonFromArrayOfJson
       let _ = await updateDetails(url, body, Post)
-      
+
+      let emailUrl = getURL(~entityName=V1(USERS), ~userType=#SEND_PROD_INTENT_EMAIL, ~methodType=Post)
+      let emailBody = [
+        ("requested_products", selectedProducts->JSON.Encode.array),
+        ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
+        ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
+      ]->LogicUtils.getJsonFromArrayOfJson
+      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+
       showToast(
         ~toastType=ToastSuccess,
         ~message="Successfully sent for verification!",
@@ -52,15 +48,11 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
     setScreenState(_ => PageLoaderWrapper.Loading)
     updateProdDetails(values)
   }
-  
+
   let handleProductToggle = (productKey, isSelected) => {
     setSelectedProducts(prev => {
       if isSelected {
-        if prev->Array.includes(productKey) {
-          prev
-        } else {
-          prev->Array.concat([productKey])
-        }
+        prev->Array.concat([productKey])
       } else {
         prev->Array.filter(p => p !== productKey)
       }
@@ -90,25 +82,27 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
               validate={values => values->validateForm(~fieldsToValidate=formFields)}
               onSubmit>
               <div className="flex flex-col gap-8 w-full">
-                <div className="px-3">
-                  <h3 className="text-sm font-medium text-nd_gray-700 mb-3">
-                    {"Select Products"->React.string}
-                  </h3>
-                  <ProdIntentProductSelection selectedProducts onProductToggle={handleProductToggle} />
-                </div>
                 <FormRenderer.DesktopRow>
-                  <div className="flex flex-col gap-5">
-                    {formFields
-                    ->Array.mapWithIndex((column, index) =>
-                      <FormRenderer.FieldRenderer
-                        key={index->Int.toString}
-                        fieldWrapperClass="w-full"
-                        field={column->getFormField}
-                        errorClass
-                        labelClass="!text-black font-medium !-ml-[0.5px]"
-                      />
-                    )
-                    ->React.array}
+                  <div className="flex flex-col gap-6">
+                    <div className="flex flex-col gap-3">
+                      <span className="text-sm font-medium text-black">
+                        {"Select Products"->React.string}
+                      </span>
+                      <ProdIntentProductSelection selectedProducts onProductToggle=handleProductToggle />
+                    </div>
+                    <div className="flex flex-col gap-5">
+                      {formFields
+                      ->Array.mapWithIndex((column, index) =>
+                        <FormRenderer.FieldRenderer
+                          key={index->Int.toString}
+                          fieldWrapperClass="w-full"
+                          field={column->getFormField}
+                          errorClass
+                          labelClass="!text-black font-medium !-ml-[0.5px]"
+                        />
+                      )
+                      ->React.array}
+                    </div>
                   </div>
                 </FormRenderer.DesktopRow>
                 <div className="flex justify-end w-full pr-5 pb-3">

--- a/src/screens/Home/ProdIntent/ProdVerifyModal.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModal.res
@@ -27,7 +27,7 @@ let make = (~showModal, ~setShowModal, ~initialValues=Dict.make(), ~getProdVerif
         ("poc_email", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_email", "")->JSON.Encode.string),
         ("poc_name", values->LogicUtils.getDictFromJsonObject->LogicUtils.getString("poc_name", "")->JSON.Encode.string),
       ]->LogicUtils.getJsonFromArrayOfJson
-      let _ = await updateDetails(emailUrl, emailBody, Post)->catch(_ => Promise.resolve(JSON.Encode.null))
+      let _ = await updateDetails(emailUrl, emailBody, Post)->Promise.catch(_ => Promise.resolve(JSON.Encode.null))
 
       showToast(
         ~toastType=ToastSuccess,

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -10,7 +10,6 @@ type prodFormColumnType =
   | Designation
   | MonthlyPaymentVolume
   | Industry
-  | SelectedProducts
 
 let getStringFromVariant = key => {
   switch key {
@@ -23,7 +22,6 @@ let getStringFromVariant = key => {
   | Designation => "designation"
   | MonthlyPaymentVolume => "monthly_payment_volume"
   | Industry => "industry"
-  | SelectedProducts => "requested_products"
   }
 }
 
@@ -67,45 +65,29 @@ let designation = FormRenderer.makeFieldInfo(
   ~isRequired=true,
 )
 
-let countryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
-  <ProdIntentHelper.CountryField fieldsArray />
-}
-
-let countryField = FormRenderer.makeMultiInputFieldInfoOld(
-  ~label="Organization Country",
-  ~comboCustomInput=countryFieldInput(),
-  ~inputFields=[
-    FormRenderer.makeInputFieldInfo(~name=`business_location`),
-    FormRenderer.makeInputFieldInfo(~name=`business_country_name`),
-  ],
-  ~isRequired=true,
-  (),
-)
-
 let monthlyPaymentVolumeOptions = [
-  ("< $10K", "Less than $10,000"),
-  ("$10K - $50K", "$10,000 - $50,000"),
-  ("$50K - $100K", "$50,000 - $100,000"),
-  ("$100K - $500K", "$100,000 - $500,000"),
-  ("$500K - $1M", "$500,000 - $1,000,000"),
-  ("> $1M", "More than $1,000,000"),
+  "Less than $10K",
+  "$10K - $50K",
+  "$50K - $100K",
+  "$100K - $500K",
+  "$500K - $1M",
+  "More than $1M",
 ]
 
 let industryOptions = [
-  ("e_commerce", "E-commerce"),
-  ("saas", "SaaS"),
-  ("retail", "Retail"),
-  ("gaming", "Gaming"),
-  ("fintech", "Fintech"),
-  ("healthcare", "Healthcare"),
-  ("education", "Education"),
-  ("travel", "Travel & Hospitality"),
-  ("food", "Food & Beverage"),
-  ("media", "Media & Entertainment"),
-  ("other", "Other"),
+  "E-commerce",
+  "SaaS",
+  "Retail",
+  "Gaming",
+  "Financial Services",
+  "Travel & Hospitality",
+  "Healthcare",
+  "Education",
+  "Media & Entertainment",
+  "Other",
 ]
 
-let monthlyVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+let monthlyPaymentVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
   let field = fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
 
   let input: ReactFinalForm.fieldRenderPropsInput = {
@@ -125,8 +107,11 @@ let monthlyVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRend
     buttonText="Select Monthly Volume"
     customButtonStyle="!rounded-md !py-5"
     input
-    options={monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
-      SelectBox.dropDownOption(~value, ~label)
+    options={monthlyPaymentVolumeOptions->Array.map(opt => {
+      SelectBox.dropDownOption={
+        label: opt,
+        value: opt,
+      }
     })}
     hideMultiSelectButtons=true
     fullLength=true
@@ -137,9 +122,9 @@ let monthlyVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRend
   />
 }
 
-let monthlyVolumeField = FormRenderer.makeMultiInputFieldInfoOld(
+let monthlyPaymentVolumeField = FormRenderer.makeMultiInputFieldInfoOld(
   ~label="Monthly Payment Volume",
-  ~comboCustomInput=monthlyVolumeFieldInput(),
+  ~comboCustomInput=monthlyPaymentVolumeFieldInput(),
   ~inputFields=[FormRenderer.makeInputFieldInfo(~name=`monthly_payment_volume`)],
   ~isRequired=true,
   (),
@@ -165,8 +150,11 @@ let industryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderPro
     buttonText="Select Industry"
     customButtonStyle="!rounded-md !py-5"
     input
-    options={industryOptions->Array.map(((value, label)) => {
-      SelectBox.dropDownOption(~value, ~label)
+    options={industryOptions->Array.map(opt => {
+      SelectBox.dropDownOption={
+        label: opt,
+        value: opt,
+      }
     })}
     hideMultiSelectButtons=true
     fullLength=true
@@ -185,20 +173,35 @@ let industryField = FormRenderer.makeMultiInputFieldInfoOld(
   (),
 )
 
+let countryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+  <ProdIntentHelper.CountryField fieldsArray />
+}
+
+let countryField = FormRenderer.makeMultiInputFieldInfoOld(
+  ~label="Organization Country",
+  ~comboCustomInput=countryFieldInput(),
+  ~inputFields=[
+    FormRenderer.makeInputFieldInfo(~name=`business_location`),
+    FormRenderer.makeInputFieldInfo(~name=`business_country_name`),
+  ],
+  ~isRequired=true,
+  (),
+)
+
 let validateEmptyValue = (key, errors) => {
   switch key {
   | POCemail =>
     Dict.set(
       errors,
       key->getStringFromVariant,
-      "Please enter your Email ID"->JSON.Encode.string,
+      "Please enter a Point of Contact Email"->JSON.Encode.string,
     )
   | BusinessName =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter Organization Name"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter an Organization Name"->JSON.Encode.string)
   | Country =>
     Dict.set(errors, key->getStringFromVariant, "Please select a Country"->JSON.Encode.string)
   | Website =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter Organization Website"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter a Website"->JSON.Encode.string)
   | POCName =>
     Dict.set(
       errors,
@@ -206,11 +209,7 @@ let validateEmptyValue = (key, errors) => {
       "Please enter your Full Name"->JSON.Encode.string,
     )
   | Designation =>
-    Dict.set(
-      errors,
-      key->getStringFromVariant,
-      "Please enter your Designation"->JSON.Encode.string,
-    )
+    Dict.set(errors, key->getStringFromVariant, "Please enter your Designation"->JSON.Encode.string)
   | MonthlyPaymentVolume =>
     Dict.set(
       errors,
@@ -218,11 +217,7 @@ let validateEmptyValue = (key, errors) => {
       "Please select Monthly Payment Volume"->JSON.Encode.string,
     )
   | Industry =>
-    Dict.set(
-      errors,
-      key->getStringFromVariant,
-      "Please select your Industry"->JSON.Encode.string,
-    )
+    Dict.set(errors, key->getStringFromVariant, "Please select your Industry"->JSON.Encode.string)
   | _ => ()
   }
 }
@@ -234,7 +229,7 @@ let getFormField = columnType => {
   | Website => website
   | POCName => pocName
   | Designation => designation
-  | MonthlyPaymentVolume => monthlyVolumeField
+  | MonthlyPaymentVolume => monthlyPaymentVolumeField
   | Industry => industryField
   | _ => countryField
   }
@@ -242,7 +237,7 @@ let getFormField = columnType => {
 
 let formFields = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
 
-let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
+let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
 
 let validateCustom = (key, errors, value) => {
   switch key {
@@ -253,7 +248,7 @@ let validateCustom = (key, errors, value) => {
   | Website =>
     if (
       !RegExp.test(
-        %re("/^(https?:\/\/)?([A-Za-z0-9-]+\.)*[A-Za-z0-9-]{1,63}\.[A-Za-z]{2,6}$/i"),
+        %re("/^(https?:\\/\/)?([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]{1,63}\\.[A-Za-z]{2,6}$/i"),
         value,
       ) ||
       value->String.includes("localhost")
@@ -283,7 +278,7 @@ let getJsonString = (valueDict, key) => {
   valueDict->getString(key->getStringFromVariant, "")->JSON.Encode.string
 }
 
-let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
+let getBody = (values: JSON.t, ~selectedProducts: array<string>) => {
   open LogicUtils
   let valuesDict = values->getDictFromJsonObject
 
@@ -329,13 +324,9 @@ let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
     Industry->getStringFromVariant,
     valuesDict->getOptionString(Industry->getStringFromVariant),
   )
-
-  if selectedProducts->Array.length > 0 {
-    prodOnboardingpayload->Dict.set(
-      SelectedProducts->getStringFromVariant,
-      selectedProducts->JSON.Encode.array,
-    )
-  }
-
+  prodOnboardingpayload->setOptionArray(
+    "requested_products",
+    Some(selectedProducts->Array.map(JSON.Encode.string)),
+  )
   prodOnboardingpayload
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -190,7 +190,7 @@ let getFormField = columnType => {
   }
 }
 
-let formFields = [POCName, POCemail, Designation, BusinessName, countryField, Website, MonthlyPaymentVolume, Industry]
+let formFields = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
 
 let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
 

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -28,7 +28,7 @@ let getStringFromVariant = key => {
 }
 
 let businessName = FormRenderer.makeFieldInfo(
-  ~label="Organization Name",
+  ~label="Legal Business Name",
   ~name=BusinessName->getStringFromVariant,
   ~placeholder="Eg: HyperSwitch Pvt Ltd",
   ~customInput=InputFields.textInput(),
@@ -36,7 +36,7 @@ let businessName = FormRenderer.makeFieldInfo(
 )
 
 let website = FormRenderer.makeFieldInfo(
-  ~label="Organization Website",
+  ~label="Business Website",
   ~name=Website->getStringFromVariant,
   ~placeholder="Enter a website",
   ~customInput=InputFields.textInput(),
@@ -62,7 +62,7 @@ let pocEmail = FormRenderer.makeFieldInfo(
 let designation = FormRenderer.makeFieldInfo(
   ~label="Designation",
   ~name=Designation->getStringFromVariant,
-  ~placeholder="Eg: Product Manager",
+  ~placeholder="Eg: CTO",
   ~customInput=InputFields.textInput(),
   ~isRequired=true,
 )
@@ -98,10 +98,9 @@ let industryOptions = [
   ("Gaming", "Gaming"),
   ("Financial Services", "Financial Services"),
   ("Healthcare", "Healthcare"),
-  ("Education", "Education"),
   ("Travel & Hospitality", "Travel & Hospitality"),
-  ("Food & Beverage", "Food & Beverage"),
-  ("Technology", "Technology"),
+  ("Education", "Education"),
+  ("Media & Entertainment", "Media & Entertainment"),
   ("Other", "Other"),
 ]
 
@@ -111,9 +110,14 @@ let monthlyPaymentVolumeField = FormRenderer.makeFieldInfo(
   ~placeholder="Select monthly volume",
   ~customInput=InputFields.selectInput(
     ~options=monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
-      SelectBox.dropdownOption(~label, ~value)
+      let option: SelectBox.dropdownOption = {
+        label,
+        value,
+        icon: None,
+        iconPosition: None,
+      }
+      option
     }),
-    ~buttonText="Select monthly volume",
     ~deselectDisable=true,
     (),
   ),
@@ -126,9 +130,14 @@ let industryField = FormRenderer.makeFieldInfo(
   ~placeholder="Select industry",
   ~customInput=InputFields.selectInput(
     ~options=industryOptions->Array.map(((value, label)) => {
-      SelectBox.dropdownOption(~label, ~value)
+      let option: SelectBox.dropdownOption = {
+        label,
+        value,
+        icon: None,
+        iconPosition: None,
+      }
+      option
     }),
-    ~buttonText="Select industry",
     ~deselectDisable=true,
     (),
   ),
@@ -190,9 +199,9 @@ let getFormField = columnType => {
   }
 }
 
-let formFields = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
+let formFields = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
 
-let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
+let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
 
 let validateCustom = (key, errors, value) => {
   switch key {
@@ -233,7 +242,7 @@ let getJsonString = (valueDict, key) => {
   valueDict->getString(key->getStringFromVariant, "")->JSON.Encode.string
 }
 
-let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
+let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productTypes>) => {
   open LogicUtils
   let valuesDict = values->getDictFromJsonObject
 
@@ -279,13 +288,12 @@ let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
     Industry->getStringFromVariant,
     valuesDict->getOptionString(Industry->getStringFromVariant),
   )
-  
-  if selectedProducts->Array.length > 0 {
-    prodOnboardingpayload->Dict.set(
-      SelectedProducts->getStringFromVariant,
-      selectedProducts->JSON.Encode.array,
-    )
-  }
-  
+
+  let productStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
+  prodOnboardingpayload->Dict.set(
+    SelectedProducts->getStringFromVariant,
+    productStrings->JSON.Encode.array,
+  )
+
   prodOnboardingpayload
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -232,6 +232,30 @@ let validateCustom = (key, errors, value) => {
     ) {
       Dict.set(errors, key->getStringFromVariant, "Please Enter Valid URL"->JSON.Encode.string)
     }
+  | Designation =>
+    if value->String.length < 2 || value->String.length > 100 {
+      Dict.set(
+        errors,
+        key->getStringFromVariant,
+        "Designation must be between 2 and 100 characters"->JSON.Encode.string,
+      )
+    }
+  | MonthlyPaymentVolume =>
+    if !monthlyPaymentVolumeOptions->Array.some(opt => opt == value) {
+      Dict.set(
+        errors,
+        key->getStringFromVariant,
+        "Please select a valid monthly payment volume option"->JSON.Encode.string,
+      )
+    }
+  | Industry =>
+    if !industryOptions->Array.some(opt => opt == value) {
+      Dict.set(
+        errors,
+        key->getStringFromVariant,
+        "Please select a valid industry option"->JSON.Encode.string,
+      )
+    }
   | _ => ()
   }
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -62,7 +62,7 @@ let pocEmail = FormRenderer.makeFieldInfo(
 let designation = FormRenderer.makeFieldInfo(
   ~label="Designation",
   ~name=Designation->getStringFromVariant,
-  ~placeholder="Eg: CTO",
+  ~placeholder="Eg: Product Manager",
   ~customInput=InputFields.textInput(),
   ~isRequired=true,
 )
@@ -105,81 +105,33 @@ let industryOptions = [
   ("Other", "Other"),
 ]
 
-let monthlyVolumeFieldInput = () => (props: ReactFinalForm.fieldRenderProps) => {
-  let input = props.input
-
-  let selectInput: ReactFinalForm.fieldRenderPropsInput = {
-    name: input.name,
-    onBlur: _ => (),
-    onChange: ev => {
-      let stringVal = ev->Identity.formReactEventToString
-      input.onChange(stringVal->Identity.anyTypeToReactEvent)
-    },
-    onFocus: _ => (),
-    value: input.value,
-    checked: true,
-  }
-
-  <SelectBox.BaseDropdown
-    allowMultiSelect=false
-    buttonText="Select Monthly Volume"
-    customButtonStyle="!rounded-md !py-5"
-    input={selectInput}
-    options={monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
-      SelectBox.dropdownOption(~value, ~label, ())
-    })}
-    hideMultiSelectButtons=true
-    fullLength=true
-    dropdownClassName={`h-64 overflow-scroll`}
-    dropdownCustomWidth="!w-full"
-    addButton=false
-    deselectDisable=true
-  />
-}
-
-let monthlyVolumeField = FormRenderer.makeFieldInfo(
+let monthlyPaymentVolumeField = FormRenderer.makeFieldInfo(
   ~label="Monthly Payment Volume",
   ~name=MonthlyPaymentVolume->getStringFromVariant,
-  ~customInput=monthlyVolumeFieldInput(),
+  ~placeholder="Select monthly volume",
+  ~customInput=InputFields.selectInput(
+    ~options=monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
+      SelectBox.dropdownOption(~label, ~value)
+    }),
+    ~buttonText="Select monthly volume",
+    ~deselectDisable=true,
+    (),
+  ),
   ~isRequired=true,
 )
-
-let industryFieldInput = () => (props: ReactFinalForm.fieldRenderProps) => {
-  let input = props.input
-
-  let selectInput: ReactFinalForm.fieldRenderPropsInput = {
-    name: input.name,
-    onBlur: _ => (),
-    onChange: ev => {
-      let stringVal = ev->Identity.formReactEventToString
-      input.onChange(stringVal->Identity.anyTypeToReactEvent)
-    },
-    onFocus: _ => (),
-    value: input.value,
-    checked: true,
-  }
-
-  <SelectBox.BaseDropdown
-    allowMultiSelect=false
-    buttonText="Select Industry"
-    customButtonStyle="!rounded-md !py-5"
-    input={selectInput}
-    options={industryOptions->Array.map(((value, label)) => {
-      SelectBox.dropdownOption(~value, ~label, ())
-    })}
-    hideMultiSelectButtons=true
-    fullLength=true
-    dropdownClassName={`h-64 overflow-scroll`}
-    dropdownCustomWidth="!w-full"
-    addButton=false
-    deselectDisable=true
-  />
-}
 
 let industryField = FormRenderer.makeFieldInfo(
   ~label="Your Industry",
   ~name=Industry->getStringFromVariant,
-  ~customInput=industryFieldInput(),
+  ~placeholder="Select industry",
+  ~customInput=InputFields.selectInput(
+    ~options=industryOptions->Array.map(((value, label)) => {
+      SelectBox.dropdownOption(~label, ~value)
+    }),
+    ~buttonText="Select industry",
+    ~deselectDisable=true,
+    (),
+  ),
   ~isRequired=true,
 )
 
@@ -192,11 +144,11 @@ let validateEmptyValue = (key, errors) => {
       "Please enter your Email ID"->JSON.Encode.string,
     )
   | BusinessName =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter your Organization Name"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter Organization Name"->JSON.Encode.string)
   | Country =>
     Dict.set(errors, key->getStringFromVariant, "Please select a Country"->JSON.Encode.string)
   | Website =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter your Organization Website"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter Organization Website"->JSON.Encode.string)
   | POCName =>
     Dict.set(
       errors,
@@ -213,7 +165,7 @@ let validateEmptyValue = (key, errors) => {
     Dict.set(
       errors,
       key->getStringFromVariant,
-      "Please select your Monthly Payment Volume"->JSON.Encode.string,
+      "Please select Monthly Payment Volume"->JSON.Encode.string,
     )
   | Industry =>
     Dict.set(
@@ -232,15 +184,15 @@ let getFormField = columnType => {
   | Website => website
   | POCName => pocName
   | Designation => designation
-  | MonthlyPaymentVolume => monthlyVolumeField
+  | MonthlyPaymentVolume => monthlyPaymentVolumeField
   | Industry => industryField
   | _ => countryField
   }
 }
 
-let formFields = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
+let formFields = [POCName, POCemail, Designation, BusinessName, countryField, Website, MonthlyPaymentVolume, Industry]
 
-let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
+let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
 
 let validateCustom = (key, errors, value) => {
   switch key {
@@ -281,7 +233,7 @@ let getJsonString = (valueDict, key) => {
   valueDict->getString(key->getStringFromVariant, "")->JSON.Encode.string
 }
 
-let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productTypes>) => {
+let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
   open LogicUtils
   let valuesDict = values->getDictFromJsonObject
 
@@ -327,12 +279,13 @@ let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productType
     Industry->getStringFromVariant,
     valuesDict->getOptionString(Industry->getStringFromVariant),
   )
-
-  let productStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
-  prodOnboardingpayload->Dict.set(
-    SelectedProducts->getStringFromVariant,
-    productStrings->JSON.Encode.array,
-  )
-
+  
+  if selectedProducts->Array.length > 0 {
+    prodOnboardingpayload->Dict.set(
+      SelectedProducts->getStringFromVariant,
+      selectedProducts->JSON.Encode.array,
+    )
+  }
+  
   prodOnboardingpayload
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -87,11 +87,11 @@ let industryOptions = [
   "Other",
 ]
 
-let monthlyPaymentVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+let dropdownFieldInput = (~fieldName: string, ~buttonText: string, ~options: array<string>) => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
   let field = fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
 
   let input: ReactFinalForm.fieldRenderPropsInput = {
-    name: "monthly_payment_volume",
+    name: fieldName,
     onBlur: _ => (),
     onChange: ev => {
       let stringVal = ev->Identity.formReactEventToString
@@ -104,10 +104,10 @@ let monthlyPaymentVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fi
 
   <SelectBox.BaseDropdown
     allowMultiSelect=false
-    buttonText="Select Monthly Volume"
+    buttonText
     customButtonStyle="!rounded-md !py-5"
     input
-    options={monthlyPaymentVolumeOptions->Array.map(opt => {
+    options={options->Array.map(opt => {
       SelectBox.dropDownOption={
         label: opt,
         value: opt,
@@ -121,6 +121,12 @@ let monthlyPaymentVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fi
     deselectDisable=true
   />
 }
+
+let monthlyPaymentVolumeFieldInput = () => dropdownFieldInput(
+  ~fieldName="monthly_payment_volume",
+  ~buttonText="Select Monthly Volume",
+  ~options=monthlyPaymentVolumeOptions
+)
 
 let monthlyPaymentVolumeField = FormRenderer.makeMultiInputFieldInfoOld(
   ~label="Monthly Payment Volume",
@@ -130,40 +136,11 @@ let monthlyPaymentVolumeField = FormRenderer.makeMultiInputFieldInfoOld(
   (),
 )
 
-let industryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
-  let field = fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
-
-  let input: ReactFinalForm.fieldRenderPropsInput = {
-    name: "industry",
-    onBlur: _ => (),
-    onChange: ev => {
-      let stringVal = ev->Identity.formReactEventToString
-      field.input.onChange(stringVal->Identity.anyTypeToReactEvent)
-    },
-    onFocus: _ => (),
-    value: field.input.value,
-    checked: true,
-  }
-
-  <SelectBox.BaseDropdown
-    allowMultiSelect=false
-    buttonText="Select Industry"
-    customButtonStyle="!rounded-md !py-5"
-    input
-    options={industryOptions->Array.map(opt => {
-      SelectBox.dropDownOption={
-        label: opt,
-        value: opt,
-      }
-    })}
-    hideMultiSelectButtons=true
-    fullLength=true
-    dropdownClassName={`h-48 overflow-scroll`}
-    dropdownCustomWidth="!w-full"
-    addButton=false
-    deselectDisable=true
-  />
-}
+let industryFieldInput = () => dropdownFieldInput(
+  ~fieldName="industry",
+  ~buttonText="Select Industry",
+  ~options=industryOptions
+)
 
 let industryField = FormRenderer.makeMultiInputFieldInfoOld(
   ~label="Your Industry",

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -7,6 +7,10 @@ type prodFormColumnType =
   | Country
   | Website
   | POCName
+  | Designation
+  | MonthlyPaymentVolume
+  | Industry
+  | SelectedProducts
 
 let getStringFromVariant = key => {
   switch key {
@@ -16,11 +20,15 @@ let getStringFromVariant = key => {
   | Country => "business_location"
   | Website => "business_website"
   | POCName => "poc_name"
+  | Designation => "designation"
+  | MonthlyPaymentVolume => "monthly_payment_volume"
+  | Industry => "industry"
+  | SelectedProducts => "requested_products"
   }
 }
 
 let businessName = FormRenderer.makeFieldInfo(
-  ~label="Legal Business Name",
+  ~label="Organization Name",
   ~name=BusinessName->getStringFromVariant,
   ~placeholder="Eg: HyperSwitch Pvt Ltd",
   ~customInput=InputFields.textInput(),
@@ -28,7 +36,7 @@ let businessName = FormRenderer.makeFieldInfo(
 )
 
 let website = FormRenderer.makeFieldInfo(
-  ~label="Business Website",
+  ~label="Organization Website",
   ~name=Website->getStringFromVariant,
   ~placeholder="Enter a website",
   ~customInput=InputFields.textInput(),
@@ -36,7 +44,7 @@ let website = FormRenderer.makeFieldInfo(
 )
 
 let pocName = FormRenderer.makeFieldInfo(
-  ~label="Contact Name",
+  ~label="Your Full Name",
   ~name=POCName->getStringFromVariant,
   ~placeholder="Eg: Jack Ryan",
   ~customInput=InputFields.textInput(),
@@ -44,9 +52,17 @@ let pocName = FormRenderer.makeFieldInfo(
 )
 
 let pocEmail = FormRenderer.makeFieldInfo(
-  ~label="Contact Email",
+  ~label="Email ID",
   ~name=POCemail->getStringFromVariant,
   ~placeholder="Eg: jackryan@hyperswitch.io",
+  ~customInput=InputFields.textInput(),
+  ~isRequired=true,
+)
+
+let designation = FormRenderer.makeFieldInfo(
+  ~label="Designation",
+  ~name=Designation->getStringFromVariant,
+  ~placeholder="Eg: CTO",
   ~customInput=InputFields.textInput(),
   ~isRequired=true,
 )
@@ -56,7 +72,7 @@ let countryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProp
 }
 
 let countryField = FormRenderer.makeMultiInputFieldInfoOld(
-  ~label="Business country",
+  ~label="Organization Country",
   ~comboCustomInput=countryFieldInput(),
   ~inputFields=[
     FormRenderer.makeInputFieldInfo(~name=`business_location`),
@@ -66,25 +82,144 @@ let countryField = FormRenderer.makeMultiInputFieldInfoOld(
   (),
 )
 
+let monthlyPaymentVolumeOptions = [
+  ("< $10K", "Less than $10,000"),
+  ("$10K - $50K", "$10,000 - $50,000"),
+  ("$50K - $100K", "$50,000 - $100,000"),
+  ("$100K - $500K", "$100,000 - $500,000"),
+  ("$500K - $1M", "$500,000 - $1,000,000"),
+  ("> $1M", "More than $1,000,000"),
+]
+
+let industryOptions = [
+  ("E-commerce", "E-commerce"),
+  ("SaaS", "SaaS"),
+  ("Retail", "Retail"),
+  ("Gaming", "Gaming"),
+  ("Financial Services", "Financial Services"),
+  ("Healthcare", "Healthcare"),
+  ("Education", "Education"),
+  ("Travel & Hospitality", "Travel & Hospitality"),
+  ("Food & Beverage", "Food & Beverage"),
+  ("Technology", "Technology"),
+  ("Other", "Other"),
+]
+
+let monthlyVolumeFieldInput = () => (props: ReactFinalForm.fieldRenderProps) => {
+  let input = props.input
+
+  let selectInput: ReactFinalForm.fieldRenderPropsInput = {
+    name: input.name,
+    onBlur: _ => (),
+    onChange: ev => {
+      let stringVal = ev->Identity.formReactEventToString
+      input.onChange(stringVal->Identity.anyTypeToReactEvent)
+    },
+    onFocus: _ => (),
+    value: input.value,
+    checked: true,
+  }
+
+  <SelectBox.BaseDropdown
+    allowMultiSelect=false
+    buttonText="Select Monthly Volume"
+    customButtonStyle="!rounded-md !py-5"
+    input={selectInput}
+    options={monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
+      SelectBox.dropdownOption(~value, ~label, ())
+    })}
+    hideMultiSelectButtons=true
+    fullLength=true
+    dropdownClassName={`h-64 overflow-scroll`}
+    dropdownCustomWidth="!w-full"
+    addButton=false
+    deselectDisable=true
+  />
+}
+
+let monthlyVolumeField = FormRenderer.makeFieldInfo(
+  ~label="Monthly Payment Volume",
+  ~name=MonthlyPaymentVolume->getStringFromVariant,
+  ~customInput=monthlyVolumeFieldInput(),
+  ~isRequired=true,
+)
+
+let industryFieldInput = () => (props: ReactFinalForm.fieldRenderProps) => {
+  let input = props.input
+
+  let selectInput: ReactFinalForm.fieldRenderPropsInput = {
+    name: input.name,
+    onBlur: _ => (),
+    onChange: ev => {
+      let stringVal = ev->Identity.formReactEventToString
+      input.onChange(stringVal->Identity.anyTypeToReactEvent)
+    },
+    onFocus: _ => (),
+    value: input.value,
+    checked: true,
+  }
+
+  <SelectBox.BaseDropdown
+    allowMultiSelect=false
+    buttonText="Select Industry"
+    customButtonStyle="!rounded-md !py-5"
+    input={selectInput}
+    options={industryOptions->Array.map(((value, label)) => {
+      SelectBox.dropdownOption(~value, ~label, ())
+    })}
+    hideMultiSelectButtons=true
+    fullLength=true
+    dropdownClassName={`h-64 overflow-scroll`}
+    dropdownCustomWidth="!w-full"
+    addButton=false
+    deselectDisable=true
+  />
+}
+
+let industryField = FormRenderer.makeFieldInfo(
+  ~label="Your Industry",
+  ~name=Industry->getStringFromVariant,
+  ~customInput=industryFieldInput(),
+  ~isRequired=true,
+)
+
 let validateEmptyValue = (key, errors) => {
   switch key {
   | POCemail =>
     Dict.set(
       errors,
       key->getStringFromVariant,
-      "Please enter a Point of Contact Email"->JSON.Encode.string,
+      "Please enter your Email ID"->JSON.Encode.string,
     )
   | BusinessName =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter a Business Name"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter your Organization Name"->JSON.Encode.string)
   | Country =>
     Dict.set(errors, key->getStringFromVariant, "Please select a Country"->JSON.Encode.string)
   | Website =>
-    Dict.set(errors, key->getStringFromVariant, "Please enter a Website"->JSON.Encode.string)
+    Dict.set(errors, key->getStringFromVariant, "Please enter your Organization Website"->JSON.Encode.string)
   | POCName =>
     Dict.set(
       errors,
       key->getStringFromVariant,
-      "Please enter a Point of Contact Name"->JSON.Encode.string,
+      "Please enter your Full Name"->JSON.Encode.string,
+    )
+  | Designation =>
+    Dict.set(
+      errors,
+      key->getStringFromVariant,
+      "Please enter your Designation"->JSON.Encode.string,
+    )
+  | MonthlyPaymentVolume =>
+    Dict.set(
+      errors,
+      key->getStringFromVariant,
+      "Please select your Monthly Payment Volume"->JSON.Encode.string,
+    )
+  | Industry =>
+    Dict.set(
+      errors,
+      key->getStringFromVariant,
+      "Please select your Industry"->JSON.Encode.string,
     )
   | _ => ()
   }
@@ -96,13 +231,16 @@ let getFormField = columnType => {
   | BusinessName => businessName
   | Website => website
   | POCName => pocName
+  | Designation => designation
+  | MonthlyPaymentVolume => monthlyVolumeField
+  | Industry => industryField
   | _ => countryField
   }
 }
 
-let formFields = [BusinessName, Country, Website, POCName, POCemail]
+let formFields = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
 
-let formFieldsForQuickStart = [BusinessName, Country, Website, POCName, POCemail]
+let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
 
 let validateCustom = (key, errors, value) => {
   switch key {
@@ -143,7 +281,7 @@ let getJsonString = (valueDict, key) => {
   valueDict->getString(key->getStringFromVariant, "")->JSON.Encode.string
 }
 
-let getBody = (values: JSON.t) => {
+let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productTypes>) => {
   open LogicUtils
   let valuesDict = values->getDictFromJsonObject
 
@@ -177,5 +315,24 @@ let getBody = (values: JSON.t) => {
     "business_country_name",
     valuesDict->getOptionString("business_country_name"),
   )
+  prodOnboardingpayload->setOptionString(
+    Designation->getStringFromVariant,
+    valuesDict->getOptionString(Designation->getStringFromVariant),
+  )
+  prodOnboardingpayload->setOptionString(
+    MonthlyPaymentVolume->getStringFromVariant,
+    valuesDict->getOptionString(MonthlyPaymentVolume->getStringFromVariant),
+  )
+  prodOnboardingpayload->setOptionString(
+    Industry->getStringFromVariant,
+    valuesDict->getOptionString(Industry->getStringFromVariant),
+  )
+
+  let productStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
+  prodOnboardingpayload->Dict.set(
+    SelectedProducts->getStringFromVariant,
+    productStrings->JSON.Encode.array,
+  )
+
   prodOnboardingpayload
 }

--- a/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
+++ b/src/screens/Home/ProdIntent/ProdVerifyModalUtils.res
@@ -28,7 +28,7 @@ let getStringFromVariant = key => {
 }
 
 let businessName = FormRenderer.makeFieldInfo(
-  ~label="Legal Business Name",
+  ~label="Organization Name",
   ~name=BusinessName->getStringFromVariant,
   ~placeholder="Eg: HyperSwitch Pvt Ltd",
   ~customInput=InputFields.textInput(),
@@ -36,7 +36,7 @@ let businessName = FormRenderer.makeFieldInfo(
 )
 
 let website = FormRenderer.makeFieldInfo(
-  ~label="Business Website",
+  ~label="Organization Website",
   ~name=Website->getStringFromVariant,
   ~placeholder="Enter a website",
   ~customInput=InputFields.textInput(),
@@ -62,7 +62,7 @@ let pocEmail = FormRenderer.makeFieldInfo(
 let designation = FormRenderer.makeFieldInfo(
   ~label="Designation",
   ~name=Designation->getStringFromVariant,
-  ~placeholder="Eg: CTO",
+  ~placeholder="Eg: Product Manager",
   ~customInput=InputFields.textInput(),
   ~isRequired=true,
 )
@@ -92,56 +92,97 @@ let monthlyPaymentVolumeOptions = [
 ]
 
 let industryOptions = [
-  ("E-commerce", "E-commerce"),
-  ("SaaS", "SaaS"),
-  ("Retail", "Retail"),
-  ("Gaming", "Gaming"),
-  ("Financial Services", "Financial Services"),
-  ("Healthcare", "Healthcare"),
-  ("Travel & Hospitality", "Travel & Hospitality"),
-  ("Education", "Education"),
-  ("Media & Entertainment", "Media & Entertainment"),
-  ("Other", "Other"),
+  ("e_commerce", "E-commerce"),
+  ("saas", "SaaS"),
+  ("retail", "Retail"),
+  ("gaming", "Gaming"),
+  ("fintech", "Fintech"),
+  ("healthcare", "Healthcare"),
+  ("education", "Education"),
+  ("travel", "Travel & Hospitality"),
+  ("food", "Food & Beverage"),
+  ("media", "Media & Entertainment"),
+  ("other", "Other"),
 ]
 
-let monthlyPaymentVolumeField = FormRenderer.makeFieldInfo(
+let monthlyVolumeFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+  let field = fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
+
+  let input: ReactFinalForm.fieldRenderPropsInput = {
+    name: "monthly_payment_volume",
+    onBlur: _ => (),
+    onChange: ev => {
+      let stringVal = ev->Identity.formReactEventToString
+      field.input.onChange(stringVal->Identity.anyTypeToReactEvent)
+    },
+    onFocus: _ => (),
+    value: field.input.value,
+    checked: true,
+  }
+
+  <SelectBox.BaseDropdown
+    allowMultiSelect=false
+    buttonText="Select Monthly Volume"
+    customButtonStyle="!rounded-md !py-5"
+    input
+    options={monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
+      SelectBox.dropDownOption(~value, ~label)
+    })}
+    hideMultiSelectButtons=true
+    fullLength=true
+    dropdownClassName={`h-48 overflow-scroll`}
+    dropdownCustomWidth="!w-full"
+    addButton=false
+    deselectDisable=true
+  />
+}
+
+let monthlyVolumeField = FormRenderer.makeMultiInputFieldInfoOld(
   ~label="Monthly Payment Volume",
-  ~name=MonthlyPaymentVolume->getStringFromVariant,
-  ~placeholder="Select monthly volume",
-  ~customInput=InputFields.selectInput(
-    ~options=monthlyPaymentVolumeOptions->Array.map(((value, label)) => {
-      let option: SelectBox.dropdownOption = {
-        label,
-        value,
-        icon: None,
-        iconPosition: None,
-      }
-      option
-    }),
-    ~deselectDisable=true,
-    (),
-  ),
+  ~comboCustomInput=monthlyVolumeFieldInput(),
+  ~inputFields=[FormRenderer.makeInputFieldInfo(~name=`monthly_payment_volume`)],
   ~isRequired=true,
+  (),
 )
 
-let industryField = FormRenderer.makeFieldInfo(
+let industryFieldInput = () => (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+  let field = fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
+
+  let input: ReactFinalForm.fieldRenderPropsInput = {
+    name: "industry",
+    onBlur: _ => (),
+    onChange: ev => {
+      let stringVal = ev->Identity.formReactEventToString
+      field.input.onChange(stringVal->Identity.anyTypeToReactEvent)
+    },
+    onFocus: _ => (),
+    value: field.input.value,
+    checked: true,
+  }
+
+  <SelectBox.BaseDropdown
+    allowMultiSelect=false
+    buttonText="Select Industry"
+    customButtonStyle="!rounded-md !py-5"
+    input
+    options={industryOptions->Array.map(((value, label)) => {
+      SelectBox.dropDownOption(~value, ~label)
+    })}
+    hideMultiSelectButtons=true
+    fullLength=true
+    dropdownClassName={`h-48 overflow-scroll`}
+    dropdownCustomWidth="!w-full"
+    addButton=false
+    deselectDisable=true
+  />
+}
+
+let industryField = FormRenderer.makeMultiInputFieldInfoOld(
   ~label="Your Industry",
-  ~name=Industry->getStringFromVariant,
-  ~placeholder="Select industry",
-  ~customInput=InputFields.selectInput(
-    ~options=industryOptions->Array.map(((value, label)) => {
-      let option: SelectBox.dropdownOption = {
-        label,
-        value,
-        icon: None,
-        iconPosition: None,
-      }
-      option
-    }),
-    ~deselectDisable=true,
-    (),
-  ),
+  ~comboCustomInput=industryFieldInput(),
+  ~inputFields=[FormRenderer.makeInputFieldInfo(~name=`industry`)],
   ~isRequired=true,
+  (),
 )
 
 let validateEmptyValue = (key, errors) => {
@@ -193,15 +234,15 @@ let getFormField = columnType => {
   | Website => website
   | POCName => pocName
   | Designation => designation
-  | MonthlyPaymentVolume => monthlyPaymentVolumeField
+  | MonthlyPaymentVolume => monthlyVolumeField
   | Industry => industryField
   | _ => countryField
   }
 }
 
-let formFields = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
+let formFields = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
 
-let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Website, Country, MonthlyPaymentVolume, Industry]
+let formFieldsForQuickStart = [POCName, POCemail, Designation, BusinessName, Country, Website, MonthlyPaymentVolume, Industry]
 
 let validateCustom = (key, errors, value) => {
   switch key {
@@ -242,7 +283,7 @@ let getJsonString = (valueDict, key) => {
   valueDict->getString(key->getStringFromVariant, "")->JSON.Encode.string
 }
 
-let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productTypes>) => {
+let getBody = (values: JSON.t, ~selectedProducts: array<string>=[]) => {
   open LogicUtils
   let valuesDict = values->getDictFromJsonObject
 
@@ -289,11 +330,12 @@ let getBody = (values: JSON.t, ~selectedProducts: array<ProductTypes.productType
     valuesDict->getOptionString(Industry->getStringFromVariant),
   )
 
-  let productStrings = selectedProducts->Array.map(ProductUtils.getProductStringName)
-  prodOnboardingpayload->Dict.set(
-    SelectedProducts->getStringFromVariant,
-    productStrings->JSON.Encode.array,
-  )
+  if selectedProducts->Array.length > 0 {
+    prodOnboardingpayload->Dict.set(
+      SelectedProducts->getStringFromVariant,
+      selectedProducts->JSON.Encode.array,
+    )
+  }
 
   prodOnboardingpayload
 }


### PR DESCRIPTION
## Summary
- Added multi-product selection to the production access request flow — users can now select Orchestration, Reconciliation, Revenue Recovery, and Cost Observability from a card-based UI (`ProdIntentProductSelection` component)
- Extended the production intent form with new fields: Designation, Monthly Payment Volume (dropdown), and Industry (dropdown), and updated labels (e.g., "Legal Business Name" → "Organization Name")
- Restricted the "Get Production Access" banner to Orchestration V1 only and added email notification on form submission with graceful error handling

## Test plan
- [ ] Verify the production access banner only appears for Orchestration V1 product
- [ ] Verify the multi-product selection UI renders with all 4 products, Orchestration pre-selected and disabled
- [ ] Test toggling products on/off and ensure form submission includes selected products
- [ ] Verify new form fields (Designation, Monthly Payment Volume, Industry) render with correct dropdowns and validation
- [ ] Test form submission end-to-end and confirm email notification fires (or shows warning toast on failure)
- [ ] Verify keyboard accessibility on product selection cards (Enter/Space to toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added product selection interface during production verification process
  * Introduced new form fields: Designation, Monthly Payment Volume, and Industry
  * Email notifications now sent with production access requests

* **Changes**
  * Production verification modal expanded to support product selection with improved layout
  * Production access availability refined for specific products
<!-- end of auto-generated comment: release notes by coderabbit.ai -->