### PR TITLE
fix: disable 3DS authentication by default in SDK payment module

### DIFF
--- a/src/screens/SDKPayment/SDKProvider/SDKProvider.res
+++ b/src/screens/SDKPayment/SDKProvider/SDKProvider.res
@@ -15,7 +15,7 @@ let defaultValue = {
   setPaymentResult: _ => (),
   showSetupFutureUsage: false,
   setShowSetupFutureUsage: _ => (),
-  sendAuthType: true,
+  sendAuthType: false,
   setSendAuthType: _ => (),
   errorMessage: "",
   setErrorMessage: _ => (),
@@ -48,7 +48,7 @@ let make = (~children) => {
   let (paymentStatus, setPaymentStatus) = React.useState(_ => INCOMPLETE)
   let (clientSecretStatus, setClientSecretStatus) = React.useState(_ => InitialPreview)
   let (showSetupFutureUsage, setShowSetupFutureUsage) = React.useState(_ => false)
-  let (sendAuthType, setSendAuthType) = React.useState(_ => true)
+  let (sendAuthType, setSendAuthType) = React.useState(_ => false)
   let {profileId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
 
   let (paymentResult, setPaymentResult) = React.useState(_ => JSON.Encode.null)

--- a/src/screens/SDKPayment/SDKUtils/SDKPaymentUtils.res
+++ b/src/screens/SDKPayment/SDKUtils/SDKPaymentUtils.res
@@ -79,7 +79,7 @@ let labels = ["Above", "Floating"]
 
 let initialValueForForm = (
   ~showSetupFutureUsage=false,
-  ~sendAuthType=true,
+  ~sendAuthType=false,
   ~customCustomerId="hyperswitch_sdk_demo_id",
   ~profileId,
 ): SDKPaymentTypes.paymentType => {
@@ -143,7 +143,7 @@ let getTypedPaymentData = (
   ~showBillingAddress,
   ~isGuestMode,
   ~showSetupFutureUsage=false,
-  ~sendAuthType=true,
+  ~sendAuthType=false,
 ) => {
   open LogicUtils
   open SDKPaymentTypes


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The dummy SDK in the control center currently has 3DS (3D Secure) authentication enabled by default. This change disables it by default so that `no_three_ds` is the default authentication type. Users can still manually enable 3DS via the "Edit Checkout Details" modal.

Changed the default `sendAuthType` from `true` to `false` in:
- `SDKPaymentUtils.res` — `initialValueForForm` and `getFormattedBodyForSDKPayment` default parameters
- `SDKProvider.res` — context default value and React useState initializer

## How did you test it?

- Verified SDK payment page loads with 3DS toggle defaulting to OFF
- Verified toggling 3DS ON via "Edit Checkout Details" modal still works and sends `three_ds` authentication type
- Verified no regression in other SDK payment form fields

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)