### PR TITLE
fix: prevent disabled View checkbox from being selected when Write is toggled

### DIFF
--- a/src/screens/UserManagement/UserRevamp/CreateCustomRoleV2.res
+++ b/src/screens/UserManagement/UserRevamp/CreateCustomRoleV2.res
@@ -35,22 +35,22 @@ module RenderPermissionModule = {
       parentGroupsField.input.onChange(updatedGroups->Identity.arrayOfGenericTypeToFormReactEvent)
     }
 
+    let isReadAvailable =
+      scopes->Array.some(scope => scope === (Read :> string)->String.toLowerCase)
+    let isWriteAvailable =
+      scopes->Array.some(scope => scope === (Write :> string)->String.toLowerCase)
+
     let handleScopeChange = (scope, isSelected) => {
       let currentScopes = getCurrentScopes()
       let newScopes = updateScope(currentScopes, isSelected ? Add : Remove, scope)
 
       let finalScopes = switch (scope, isSelected) {
-      | (Write, true) => updateScope(newScopes, Add, Read)
+      | (Write, true) => isReadAvailable ? updateScope(newScopes, Add, Read) : newScopes
       | (Read, false) => updateScope(newScopes, Remove, Write)
       | _ => newScopes
       }
       updateScopes(finalScopes->Array.map(JSON.Encode.string))
     }
-
-    let isReadAvailable =
-      scopes->Array.some(scope => scope === (Read :> string)->String.toLowerCase)
-    let isWriteAvailable =
-      scopes->Array.some(scope => scope === (Write :> string)->String.toLowerCase)
     let currentScopes = getCurrentScopes()
     let isReadSelected = currentScopes->Array.includes("read")
     let isWriteSelected = currentScopes->Array.includes("write")


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

When the backend doesn't include the `read` scope for a permission module, the View checkbox is correctly shown as disabled. However, selecting the Write checkbox would still auto-select the disabled View checkbox.

The root cause was in `handleScopeChange` in `CreateCustomRoleV2.res` — the `(Write, true)` case unconditionally added `Read` to the scopes without checking if Read was actually available:

```rescript
// Before (bug)
| (Write, true) => updateScope(newScopes, Add, Read)

// After (fix)
| (Write, true) => isReadAvailable ? updateScope(newScopes, Add, Read) : newScopes
```

Moved `isReadAvailable` / `isWriteAvailable` above `handleScopeChange` so the availability check is accessible inside the handler.

## Motivation and Context

Fixes #4694

On the Create Custom Roles page, each permission module has View and Write checkboxes. If the backend omits a scope (e.g., `read`), the corresponding checkbox is disabled. The bug caused a disabled View checkbox to become selected when Write was toggled on, which is incorrect — disabled checkboxes should never change state.

## How did you test it?

- Ran `npm run re:build` — compiles successfully with no errors
- Locally on UI

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible