### PR TITLE
feat: add Itaubank as payout processor for Pix

### DIFF
--- a/src/screens/Connectors/ConnectorTypes.res
+++ b/src/screens/Connectors/ConnectorTypes.res
@@ -145,6 +145,7 @@ type payoutProcessorTypes =
   | ADYENPLATFORM
   | CYBERSOURCE
   | EBANX
+  | ITAUBANK
   | PAYPAL
   | STRIPE
   | WISE

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -23,6 +23,7 @@ let payoutConnectorList: array<connectorTypes> = [
   PayoutProcessor(ADYENPLATFORM),
   PayoutProcessor(CYBERSOURCE),
   PayoutProcessor(EBANX),
+  PayoutProcessor(ITAUBANK),
   PayoutProcessor(PAYPAL),
   PayoutProcessor(STRIPE),
   PayoutProcessor(WISE),
@@ -1002,6 +1003,7 @@ let getPayoutProcessorNameString = (payoutProcessor: payoutProcessorTypes) =>
   | ADYENPLATFORM => "adyenplatform"
   | CYBERSOURCE => "cybersource"
   | EBANX => "ebanx"
+  | ITAUBANK => "itaubank"
   | PAYPAL => "paypal"
   | STRIPE => "stripe"
   | WISE => "wise"
@@ -1201,6 +1203,7 @@ let getConnectorNameTypeFromString = (connector, ~connectorType=ConnectorTypes.P
     | "adyenplatform" => PayoutProcessor(ADYENPLATFORM)
     | "cybersource" => PayoutProcessor(CYBERSOURCE)
     | "ebanx" => PayoutProcessor(EBANX)
+    | "itaubank" => PayoutProcessor(ITAUBANK)
     | "paypal" => PayoutProcessor(PAYPAL)
     | "stripe" => PayoutProcessor(STRIPE)
     | "wise" => PayoutProcessor(WISE)
@@ -1379,6 +1382,7 @@ let getPayoutProcessorInfo = (payoutconnector: ConnectorTypes.payoutProcessorTyp
   | ADYENPLATFORM => adyenPlatformInfo
   | CYBERSOURCE => cybersourceInfo
   | EBANX => ebanxInfo
+  | ITAUBANK => itauBankInfo
   | PAYPAL => paypalInfo
   | STRIPE => stripeInfo
   | WISE => wiseInfo
@@ -2359,6 +2363,7 @@ let getDisplayNameForPayoutProcessor = (payoutProcessor: ConnectorTypes.payoutPr
   | ADYENPLATFORM => "Adyen Platform"
   | CYBERSOURCE => "Cybersource"
   | EBANX => "Ebanx"
+  | ITAUBANK => "Itaubank"
   | PAYPAL => "PayPal"
   | STRIPE => "Stripe"
   | WISE => "Wise"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD



https://github.com/user-attachments/assets/9369dcac-52f4-4186-9583-7b49bb5b41c0


## Description

Adds Itaubank as a PayoutProcessor connector type to enable payout via Pix. This integration reuses the existing Itaubank payment processor's icon and description.

### Changes Made:

**ConnectorTypes.res:**
- Added `ITAUBANK` to `payoutProcessorTypes` enum

**ConnectorUtils.res:**
- Added `PayoutProcessor(ITAUBANK)` to `payoutConnectorList`
- Added `ITAUBANK => "itaubank"` to `getPayoutProcessorNameString`
- Added `"itaubank" => PayoutProcessor(ITAUBANK)` to `getConnectorNameTypeFromString`
- Added `ITAUBANK => itauBankInfo` to `getPayoutProcessorInfo` (reuses existing Itaubank description)
- Added `ITAUBANK => "Itaubank"` to `getDisplayNameForPayoutProcessor`

## Motivation and Context

New connector integration for payout via Pix using Itaubank. This follows the same pattern as the existing Itaubank payment processor integration.

## How did you test it?

- Ran `npm run re:build` successfully
- Verified all ReScript compilation passes
- Code follows existing connector integration patterns

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
