### PR TITLE
feat: payment method blocking support from dashboard

### DIFF
--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
@@ -60,6 +60,13 @@ type externalVaultConnectorDetails = {
   vault_token_selector: option<array<JSON.t>>,
 }
 
+type paymentMethodBlockingEntry = {card_types: option<array<string>>}
+
+type paymentMethodBlocking = {
+  card: option<paymentMethodBlockingEntry>,
+  wallet: option<paymentMethodBlockingEntry>,
+}
+
 type commonProfileEntity = {
   profile_id: string,
   merchant_id: string,
@@ -94,4 +101,5 @@ type commonProfileEntity = {
   split_txns_enabled: option<string>,
   is_external_vault_enabled: option<string>,
   external_vault_connector_details: option<externalVaultConnectorDetails>,
+  payment_method_blocking: option<paymentMethodBlocking>,
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV1.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV1.res
@@ -43,6 +43,7 @@ type profileEntityRequestType_v1 = {
   always_enable_overcapture: option<JSON.t>,
   is_external_vault_enabled: option<string>,
   external_vault_connector_details: option<externalVaultConnectorDetailsType_v1>,
+  payment_method_blocking: option<JSON.t>,
 }
 type webhookDetailsRequest_v1 = {webhook_url: option<JSON.t>}
 
@@ -119,4 +120,5 @@ type profileEntity_v1 = {
   payment_link_config: option<paymentLinkConfig_v1>,
   is_external_vault_enabled: option<string>,
   external_vault_connector_details: option<externalVaultConnectorDetailsType_v1>,
+  payment_method_blocking: option<BusinessProfileInterfaceTypes.paymentMethodBlocking>,
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV2.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV2.res
@@ -31,6 +31,7 @@ type profileEntityRequestType_v2 = {
   merchant_category_code: option<JSON.t>,
   is_network_tokenization_enabled: option<JSON.t>,
   split_txns_enabled: option<JSON.t>,
+  payment_method_blocking: option<JSON.t>,
 }
 type webhookDetailsRequest_v2 = {webhook_url: option<JSON.t>}
 
@@ -55,4 +56,5 @@ type profileEntity_v2 = {
   merchant_category_code: option<string>,
   is_network_tokenization_enabled: option<bool>,
   split_txns_enabled: option<string>,
+  payment_method_blocking: option<BusinessProfileInterfaceTypes.paymentMethodBlocking>,
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV2.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypesV2.res
@@ -31,7 +31,6 @@ type profileEntityRequestType_v2 = {
   merchant_category_code: option<JSON.t>,
   is_network_tokenization_enabled: option<JSON.t>,
   split_txns_enabled: option<JSON.t>,
-  payment_method_blocking: option<JSON.t>,
 }
 type webhookDetailsRequest_v2 = {webhook_url: option<JSON.t>}
 
@@ -56,5 +55,4 @@ type profileEntity_v2 = {
   merchant_category_code: option<string>,
   is_network_tokenization_enabled: option<bool>,
   split_txns_enabled: option<string>,
-  payment_method_blocking: option<BusinessProfileInterfaceTypes.paymentMethodBlocking>,
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -164,6 +164,21 @@ let paymentLinkConfigMapper = paymentLinkConfigDict => {
   }
 }
 
+let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEntry = entryDict => {
+  card_types: entryDict
+  ->Dict.get("card_types")
+  ->Option.map(json => json->getArrayFromJson([])->Array.map(item => item->getStringFromJson(""))),
+}
+
+let paymentMethodBlockingMapper: Dict.t<JSON.t> => paymentMethodBlocking = pmbDict => {
+  let cardDict = pmbDict->getDictfromDict("card")
+  let walletDict = pmbDict->getDictfromDict("wallet")
+  {
+    card: cardDict->isEmptyDict ? None : Some(cardDict->paymentMethodBlockingEntryMapper),
+    wallet: walletDict->isEmptyDict ? None : Some(walletDict->paymentMethodBlockingEntryMapper),
+  }
+}
+
 let externalVaultConnectorDetailsMapper = externalVaultConnectorDetailsDict => {
   vault_connector_id: externalVaultConnectorDetailsDict->getString("vault_connector_id", ""),
   vault_token_selector: externalVaultConnectorDetailsDict->getOptionalArrayFromDict(
@@ -178,6 +193,7 @@ let mapJsontoCommonType: JSON.t => commonProfileEntity = input => {
   let externalVaultConnectorDetails = jsonDict->getDictfromDict("external_vault_connector_details")
   let outgoingWebhookHeaders = getOptionalHeaders(jsonDict, "outgoing_webhook_custom_http_headers")
   let metadataHeaders = getOptionalHeaders(jsonDict, "metadata")
+  let paymentMethodBlockingDict = jsonDict->getDictfromDict("payment_method_blocking")
 
   {
     profile_id: jsonDict->getString("profile_id", ""),
@@ -233,5 +249,8 @@ let mapJsontoCommonType: JSON.t => commonProfileEntity = input => {
     external_vault_connector_details: externalVaultConnectorDetails->isEmptyDict
       ? None
       : Some(externalVaultConnectorDetails->externalVaultConnectorDetailsMapper),
+    payment_method_blocking: paymentMethodBlockingDict->isEmptyDict
+      ? None
+      : Some(paymentMethodBlockingDict->paymentMethodBlockingMapper),
   }
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -165,9 +165,7 @@ let paymentLinkConfigMapper = paymentLinkConfigDict => {
 }
 
 let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEntry = entryDict => {
-  card_types: entryDict
-  ->Dict.get("card_types")
-  ->Option.map(json => json->getArrayFromJson([])->Array.map(item => item->getStringFromJson(""))),
+  card_types: entryDict->getOptionStrArrayFromDict("card_types"),
 }
 
 let paymentMethodBlockingMapper: Dict.t<JSON.t> => paymentMethodBlocking = pmbDict => {

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV1.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV1.res
@@ -179,6 +179,7 @@ let mapJsonToBusinessProfileV1 = (values): profileEntity_v1 => {
 
   let paymentLinkConfig = jsonDict->getDictfromDict("payment_link_config")
   let externalVaultConnectorDetails = jsonDict->getDictfromDict("external_vault_connector_details")
+  let paymentMethodBlockingDict = jsonDict->getDictfromDict("payment_method_blocking")
   {
     profile_id: jsonDict->getString("profile_id", ""),
     merchant_id: jsonDict->getString("merchant_id", ""),
@@ -226,6 +227,9 @@ let mapJsonToBusinessProfileV1 = (values): profileEntity_v1 => {
     external_vault_connector_details: externalVaultConnectorDetails->isEmptyDict
       ? None
       : Some(externalVaultConnectorDetails->externalVaultConnectorDetailsMapper),
+    payment_method_blocking: paymentMethodBlockingDict->isEmptyDict
+      ? None
+      : Some(paymentMethodBlockingDict->paymentMethodBlockingMapper),
   }
 }
 
@@ -325,6 +329,7 @@ let mapV1toCommonType: profileEntity_v1 => BusinessProfileInterfaceTypes.commonP
     split_txns_enabled: None,
     is_external_vault_enabled: profileRecord.is_external_vault_enabled,
     external_vault_connector_details: profileRecord.external_vault_connector_details->mapV1ExternalVaultConnectorDetailsToCommonType,
+    payment_method_blocking: profileRecord.payment_method_blocking,
   }
 }
 
@@ -414,5 +419,6 @@ let commonTypeJsonToV1ForRequest: JSON.t => profileEntityRequestType_v1 = json =
     external_vault_connector_details: externalVaultConnectorDetails->isEmptyDict
       ? None
       : Some(externalVaultConnectorDetails->externalVaultConnectorDetailsMapper),
+    payment_method_blocking: dict->Dict.get("payment_method_blocking"),
   }
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV2.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV2.res
@@ -46,6 +46,7 @@ let mapJsonToBusinessProfileV2 = (values): profileEntity_v2 => {
   let outgoingWebhookHeaders = getOptionalHeaders(jsonDict, "outgoing_webhook_custom_http_headers")
 
   let metadataHeaders = getOptionalHeaders(jsonDict, "metadata")
+  let paymentMethodBlockingDict = jsonDict->getDictfromDict("payment_method_blocking")
 
   {
     profile_id: jsonDict->getString("profile_id", ""),
@@ -82,6 +83,9 @@ let mapJsonToBusinessProfileV2 = (values): profileEntity_v2 => {
     merchant_category_code: jsonDict->getOptionString("merchant_category_code"),
     is_network_tokenization_enabled: jsonDict->getOptionBool("is_network_tokenization_enabled"),
     split_txns_enabled: jsonDict->getOptionString("split_txns_enabled"),
+    payment_method_blocking: paymentMethodBlockingDict->isEmptyDict
+      ? None
+      : Some(paymentMethodBlockingDict->paymentMethodBlockingMapper),
   }
 }
 let mapV2WebhookDetailsToCommonType: webhookDetails_v2 => BusinessProfileInterfaceTypes.webhookDetails = webhookDetailsRecord => {
@@ -131,6 +135,7 @@ let mapV2toCommonType: profileEntity_v2 => BusinessProfileInterfaceTypes.commonP
     payment_link_config: None,
     is_external_vault_enabled: None,
     external_vault_connector_details: None,
+    payment_method_blocking: profileRecord.payment_method_blocking,
   }
 }
 
@@ -199,5 +204,6 @@ let commonTypeJsonToV2ForRequest: JSON.t => profileEntityRequestType_v2 = json =
     split_txns_enabled: dict
     ->getOptionString("split_txns_enabled")
     ->convertOptionalStringToOptionalJson,
+    payment_method_blocking: dict->Dict.get("payment_method_blocking"),
   }
 }

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV2.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtilsV2.res
@@ -46,7 +46,6 @@ let mapJsonToBusinessProfileV2 = (values): profileEntity_v2 => {
   let outgoingWebhookHeaders = getOptionalHeaders(jsonDict, "outgoing_webhook_custom_http_headers")
 
   let metadataHeaders = getOptionalHeaders(jsonDict, "metadata")
-  let paymentMethodBlockingDict = jsonDict->getDictfromDict("payment_method_blocking")
 
   {
     profile_id: jsonDict->getString("profile_id", ""),
@@ -83,9 +82,6 @@ let mapJsonToBusinessProfileV2 = (values): profileEntity_v2 => {
     merchant_category_code: jsonDict->getOptionString("merchant_category_code"),
     is_network_tokenization_enabled: jsonDict->getOptionBool("is_network_tokenization_enabled"),
     split_txns_enabled: jsonDict->getOptionString("split_txns_enabled"),
-    payment_method_blocking: paymentMethodBlockingDict->isEmptyDict
-      ? None
-      : Some(paymentMethodBlockingDict->paymentMethodBlockingMapper),
   }
 }
 let mapV2WebhookDetailsToCommonType: webhookDetails_v2 => BusinessProfileInterfaceTypes.webhookDetails = webhookDetailsRecord => {
@@ -135,7 +131,7 @@ let mapV2toCommonType: profileEntity_v2 => BusinessProfileInterfaceTypes.commonP
     payment_link_config: None,
     is_external_vault_enabled: None,
     external_vault_connector_details: None,
-    payment_method_blocking: profileRecord.payment_method_blocking,
+    payment_method_blocking: None,
   }
 }
 
@@ -204,6 +200,5 @@ let commonTypeJsonToV2ForRequest: JSON.t => profileEntityRequestType_v2 = json =
     split_txns_enabled: dict
     ->getOptionString("split_txns_enabled")
     ->convertOptionalStringToOptionalJson,
-    payment_method_blocking: dict->Dict.get("payment_method_blocking"),
   }
 }

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
@@ -190,10 +190,10 @@ module PaymentMethodBlocking = {
   let make = () => {
     open FormRenderer
 
-    let cardTypeOptions: array<SelectBox.dropdownOption> = [
-      {label: "Credit", value: "credit"},
-      {label: "Debit", value: "debit"},
-    ]
+    let cardTypeOptions: array<SelectBox.dropdownOption> = ["credit", "debit"]->Array.map(item => {
+      SelectBox.label: item->LogicUtils.snakeToTitle,
+      value: item,
+    })
 
     let blocklistCardTypes = makeFieldInfo(
       ~label="Card Types",
@@ -565,8 +565,10 @@ let make = () => {
       </RenderIf>
       <ClickToPaySection />
       <hr />
-      <PaymentMethodBlocking />
-      <hr />
+      <RenderIfVersion visibleForVersion=V1>
+        <PaymentMethodBlocking />
+        <hr />
+      </RenderIfVersion>
       <ReturnUrl />
       <WebHook />
       <DesktopRow wrapperClass="mt-8">

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
@@ -185,6 +185,73 @@ module ClickToPaySection = {
   }
 }
 
+module PaymentMethodBlocking = {
+  @react.component
+  let make = () => {
+    open FormRenderer
+
+    let cardTypeOptions: array<SelectBox.dropdownOption> = [
+      {label: "Credit", value: "credit"},
+      {label: "Debit", value: "debit"},
+    ]
+
+    let blocklistCardTypes = makeFieldInfo(
+      ~label="Card Types",
+      ~name="payment_method_blocking.card.card_types",
+      ~customInput=InputFields.multiSelectInput(
+        ~options=cardTypeOptions,
+        ~buttonText="Select Card Types",
+        ~showSelectionAsChips=false,
+        ~customButtonStyle="!rounded-lg",
+        ~fixedDropDownDirection=BottomRight,
+        ~searchable=true,
+      ),
+    )
+
+    let blocklistWalletTypes = makeFieldInfo(
+      ~label="Card Types",
+      ~name="payment_method_blocking.wallet.card_types",
+      ~customInput=InputFields.multiSelectInput(
+        ~options=cardTypeOptions,
+        ~buttonText="Select Card Types",
+        ~showSelectionAsChips=false,
+        ~customButtonStyle="!rounded-lg",
+        ~fixedDropDownDirection=BottomRight,
+        ~searchable=true,
+      ),
+    )
+
+    <DesktopRow itemWrapperClass="mx-1">
+      <div className="w-full py-8 flex flex-col gap-6">
+        <div>
+          <p className={`${body.lg.semibold} text-nd_gray-700`}>
+            {"Payment Method Blocking"->React.string}
+          </p>
+          <p className={`${body.md.medium} text-nd_gray-400 pt-2`}>
+            {"Block specific card types for card and wallet payment methods"->React.string}
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <p className={`${body.md.semibold} text-nd_gray-700`}> {"Card"->React.string} </p>
+          <FieldRenderer
+            field={blocklistCardTypes}
+            labelClass={`!${body.md.medium} !text-nd-gray-600`}
+            fieldWrapperClass="max-w-xl"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <p className={`${body.md.semibold} text-nd_gray-700`}> {"Wallet"->React.string} </p>
+          <FieldRenderer
+            field={blocklistWalletTypes}
+            labelClass={`!${body.md.medium} !text-nd-gray-600`}
+            fieldWrapperClass="max-w-xl"
+          />
+        </div>
+      </div>
+    </DesktopRow>
+  }
+}
+
 module WebHook = {
   @react.component
   let make = () => {
@@ -497,6 +564,8 @@ let make = () => {
         <hr />
       </RenderIf>
       <ClickToPaySection />
+      <hr />
+      <PaymentMethodBlocking />
       <hr />
       <ReturnUrl />
       <WebHook />

--- a/src/screens/Settings/MerchantAccountUtils.res
+++ b/src/screens/Settings/MerchantAccountUtils.res
@@ -774,6 +774,7 @@ let defaultValueForBusinessProfile: BusinessProfileInterfaceTypesV1.profileEntit
   payment_link_config: None,
   is_external_vault_enabled: None,
   external_vault_connector_details: None,
+  payment_method_blocking: None,
 }
 
 let getValueFromBusinessProfile = businessProfileValue => {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a new **Payment Method Blocking** configuration section under Developer → Payment Settings → Payment Behaviour, allowing merchants to block specific card types on card and wallet payment methods from the dashboard.

> **Note:** This feature is only applicable to **Orchestration V1**. The section is gated behind `RenderIfVersion visibleForVersion=V1` and no changes are made to the V2 business profile types, mappers, or request payload.

**UI changes** (`PaymentSettingsPaymentBehaviour.res`)
- New `PaymentMethodBlocking` module rendered in the Payment Behaviour form, wrapped in `RenderIfVersion visibleForVersion=V1`
- Top-level "Payment Method Blocking" heading with a short description
- Two sub-sections — **Card** and **Wallet** — each with a multi-select dropdown (Credit / Debit) bound to `payment_method_blocking.card.card_types` and `payment_method_blocking.wallet.card_types` respectively
- Selections are persisted via the existing profile **Update** submit

**Type & mapper changes** (`BusinessProfileInterface/…`)
- New `paymentMethodBlockingEntry` and `paymentMethodBlocking` types in `BusinessProfileInterfaceTypes.res`
- Added `payment_method_blocking` field to `commonProfileEntity`, `profileEntity_v1`, and the V1 request type
- V1 JSON → typed parser (`mapJsonToBusinessProfileV1`) and typed → common mapper (`mapV1toCommonType`) wired to read/forward the new field
- V1 request mapper (`commonTypeJsonToV1ForRequest`) forwards `payment_method_blocking` on the update request
- V2 mapper (`mapV2toCommonType`) sets `payment_method_blocking: None` since the field is not supported on V2

The serialized shape sent on update / received on fetch (V1 only):

```json
{
  "payment_method_blocking": {
    "card":   { "card_types": ["credit", "debit"] },
    "wallet": { "card_types": ["credit", "debit"] }
  }
}
```

https://github.com/user-attachments/assets/3445a593-2d3e-44ba-bdda-9fa389b12d59


<img width="1716" height="1024" alt="Screenshot 2026-04-13 at 5 25 21 PM" src="https://github.com/user-attachments/assets/4b67b9bd-ce2c-4bc2-87ad-7dd765ef58b6" />




## Motivation and Context

Merchants on Orchestration V1 need a self-serve way to block specific card types (credit / debit) for card and wallet payment methods on a business profile. Today this is only possible via the API. This PR surfaces the configuration in the dashboard alongside other payment behaviour settings.

Closes #4700

## How did you test it?

Manual testing (V1):
- Ran `npm run re:build` — compiles cleanly
- Opened Developer → Payment Settings → Payment Behaviour on a V1 profile and verified the **Payment Method Blocking** section renders with Card and Wallet sub-sections
- Selected different combinations of credit / debit in both dropdowns and clicked **Update** — verified the payload contains the `payment_method_blocking` object with the expected shape
- Reloaded the page and verified the dropdowns hydrate from the saved `payment_method_blocking` response
- Verified that on a V2 profile, the Payment Method Blocking section is not rendered

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible