### PR TITLE
fix: recon engine append `match_force` when `match_manual` filter is applied

### DIFF
--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -102,7 +102,7 @@ let getTransactionStatusGroupedValueAndLabel = (status: domainTransactionStatus)
   | Missing => ("missing", "Missing", "Others")
   | Expected => ("expected", "Expected", "Others")
   | Void => ("void", "Void", "Others")
-  | Matched(Force)
+  | Matched(Force) => ("matched_force", "", "")
   | Archived
   | Matched(UnknownDomainTransactionMatchedStatus)
   | Posted(UnknownDomainTransactionPostedStatus)


### PR DESCRIPTION


## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Send matched_force along with matched_manual, when matched_manual is sent via filters.
Matched Force should n't be shown in the filters only when applying the matched manual this should be appended. 

<!-- Describe your changes in detail -->

## Motivation and Context

Fixes: #4717 

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally applied matched manual filter and checked the api request appending both matched_manual and matched_force
And the Matched Force shouldn't be shown in the filters (intended)

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
