### PR TITLE
fix: memoize default date range to prevent aggregate API call loop

### DIFF
--- a/src/screens/TransactionViews/TransactionView.res
+++ b/src/screens/TransactionViews/TransactionView.res
@@ -50,7 +50,10 @@ let make = (~entity=TransactionViewTypes.Orders, ~version: UserInfoTypes.version
     updateViewsFilterValue(view)
   }
 
-  let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
+  let defaultDate = React.useMemo(
+    () => HSwitchRemoteFilter.getDateFilteredObject(~range=30),
+    [],
+  )
   let startTime =
     filterValueJson->getString(OrderUIUtils.startTimeFilterKey(version), defaultDate.start_time)
   let endTime =


### PR DESCRIPTION
## Summary
- Fixes continuous aggregate API calls caused by `TransactionView` recomputing its fallback date range on every render
- `getDateFilteredObject(~range=30)` uses `Date.make()`, producing a new `end_time` on each render. When the filter context lacks an explicit `end_time`, the fallback keeps changing, retriggering the `getAggregate` useEffect in a render loop
- Wraps `defaultDate` in `React.useMemo(() => ..., [])` to stabilize the fallback value across re-renders

## Test plan
- [ ] Open Orders/Refunds/Disputes/Payouts pages and verify aggregate API is called once on mount, not continuously
- [ ] Verify aggregate counts still display correctly
- [ ] Change date filters and confirm aggregate re-fetches with new dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)