### PR TITLE
fix: hide not known connectors from lists

### DIFF
--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -2438,6 +2438,26 @@ let getDisplayNameForConnector = (~connectorType=ConnectorTypes.Processor, conne
   }
 }
 
+let getConnectorFilterOptions = (
+  ~connectorType=ConnectorTypes.Processor,
+  values: array<string>,
+): array<FilterSelectBox.dropdownOption> => {
+  values->Array.filterMap(str => {
+    switch str->String.toLowerCase->getConnectorNameTypeFromString(~connectorType) {
+    | UnknownConnector(_) => None
+    | _ =>
+      Some(
+        (
+          {
+            label: getDisplayNameForConnector(~connectorType, str),
+            value: str,
+          }: FilterSelectBox.dropdownOption
+        ),
+      )
+    }
+  })
+}
+
 // Need to remove connector and merge connector and connectorTypeVariants
 let connectorTypeTuple = connectorType => {
   switch connectorType {

--- a/src/screens/Payouts/PayoutsUtils.res
+++ b/src/screens/Payouts/PayoutsUtils.res
@@ -147,21 +147,7 @@ let initialFilters = (json, _, _, _, _, _) => {
         ->getArrayFromJson([])
         ->Array.map(item => item->JSON.Decode.string->Option.getOr(""))
       let options = switch key->getFilterTypeFromString {
-      | #connector =>
-        items->Array.filterMap(str => {
-          switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
-          | UnknownConnector(_) => None
-          | _ =>
-            Some(
-              (
-                {
-                  label: ConnectorUtils.getDisplayNameForConnector(str),
-                  value: str,
-                }: FilterSelectBox.dropdownOption
-              ),
-            )
-          }
-        })
+      | #connector => items->ConnectorUtils.getConnectorFilterOptions
       | _ => items->FilterSelectBox.makeOptions
       }
 

--- a/src/screens/Payouts/PayoutsUtils.res
+++ b/src/screens/Payouts/PayoutsUtils.res
@@ -149,11 +149,17 @@ let initialFilters = (json, _, _, _, _, _) => {
       let options = switch key->getFilterTypeFromString {
       | #connector =>
         items->Array.filterMap(str => {
-          let label = ConnectorUtils.getDisplayNameForConnector(str)
-          if label == "Not known" {
-            None
-          } else {
-            Some(({label, value: str}: FilterSelectBox.dropdownOption))
+          switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
+          | UnknownConnector(_) => None
+          | _ =>
+            Some(
+              (
+                {
+                  label: ConnectorUtils.getDisplayNameForConnector(str),
+                  value: str,
+                }: FilterSelectBox.dropdownOption
+              ),
+            )
           }
         })
       | _ => items->FilterSelectBox.makeOptions

--- a/src/screens/Payouts/PayoutsUtils.res
+++ b/src/screens/Payouts/PayoutsUtils.res
@@ -148,9 +148,13 @@ let initialFilters = (json, _, _, _, _, _) => {
         ->Array.map(item => item->JSON.Decode.string->Option.getOr(""))
       let options = switch key->getFilterTypeFromString {
       | #connector =>
-        items->Array.map((str): FilterSelectBox.dropdownOption => {
-          label: ConnectorUtils.getDisplayNameForConnector(str),
-          value: str,
+        items->Array.filterMap(str => {
+          let label = ConnectorUtils.getDisplayNameForConnector(str)
+          if label == "Not known" {
+            None
+          } else {
+            Some(({label, value: str}: FilterSelectBox.dropdownOption))
+          }
         })
       | _ => items->FilterSelectBox.makeOptions
       }

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -219,11 +219,17 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
     | #connector_label => getOptionsForDisputeFilters(filterDict, filtervalues)
     | #connector =>
       values->Array.filterMap(str => {
-        let label = ConnectorUtils.getDisplayNameForConnector(str)
-        if label == "Not known" {
-          None
-        } else {
-          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
+        | UnknownConnector(_) => None
+        | _ =>
+          Some(
+            (
+              {
+                label: ConnectorUtils.getDisplayNameForConnector(str),
+                value: str,
+              }: FilterSelectBox.dropdownOption
+            ),
+          )
         }
       })
     | _ => values->FilterSelectBox.makeOptions

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -217,21 +217,7 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
 
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForDisputeFilters(filterDict, filtervalues)
-    | #connector =>
-      values->Array.filterMap(str => {
-        switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
-        | UnknownConnector(_) => None
-        | _ =>
-          Some(
-            (
-              {
-                label: ConnectorUtils.getDisplayNameForConnector(str),
-                value: str,
-              }: FilterSelectBox.dropdownOption
-            ),
-          )
-        }
-      })
+    | #connector => values->ConnectorUtils.getConnectorFilterOptions
     | _ => values->FilterSelectBox.makeOptions
     }
 

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -218,9 +218,13 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForDisputeFilters(filterDict, filtervalues)
     | #connector =>
-      values->Array.map((str): FilterSelectBox.dropdownOption => {
-        label: ConnectorUtils.getDisplayNameForConnector(str),
-        value: str,
+      values->Array.filterMap(str => {
+        let label = ConnectorUtils.getDisplayNameForConnector(str)
+        if label == "Not known" {
+          None
+        } else {
+          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        }
       })
     | _ => values->FilterSelectBox.makeOptions
     }

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -364,30 +364,10 @@ let initialFilters = (json, filtervalues, removeKeys, filterKeys, setfilterKeys,
 
     let title = `Select ${key->snakeToTitle}`
 
-    let makeOptions = (options: array<string>): array<FilterSelectBox.dropdownOption> => {
-      options->Array.filterMap(str => {
-        switch key->getFilterTypeFromString {
-        | #connector =>
-          switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
-          | UnknownConnector(_) => None
-          | _ =>
-            Some(
-              (
-                {
-                  label: ConnectorUtils.getDisplayNameForConnector(str),
-                  value: str,
-                }: FilterSelectBox.dropdownOption
-              ),
-            )
-          }
-        | _ => Some(({label: str->snakeToTitle, value: str}: FilterSelectBox.dropdownOption))
-        }
-      })
-    }
-
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForOrderFilters(filterDict, filtervalues)
-    | _ => values->makeOptions
+    | #connector => values->ConnectorUtils.getConnectorFilterOptions
+    | _ => values->FilterSelectBox.makeOptions(~isTitle=true)
     }
 
     let customInput = switch key->getFilterTypeFromString {

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -366,14 +366,21 @@ let initialFilters = (json, filtervalues, removeKeys, filterKeys, setfilterKeys,
 
     let makeOptions = (options: array<string>): array<FilterSelectBox.dropdownOption> => {
       options->Array.filterMap(str => {
-        let label = switch key->getFilterTypeFromString {
-        | #connector => ConnectorUtils.getDisplayNameForConnector(str)
-        | _ => str->snakeToTitle
-        }
-        if label == "Not known" {
-          None
-        } else {
-          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        switch key->getFilterTypeFromString {
+        | #connector =>
+          switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
+          | UnknownConnector(_) => None
+          | _ =>
+            Some(
+              (
+                {
+                  label: ConnectorUtils.getDisplayNameForConnector(str),
+                  value: str,
+                }: FilterSelectBox.dropdownOption
+              ),
+            )
+          }
+        | _ => Some(({label: str->snakeToTitle, value: str}: FilterSelectBox.dropdownOption))
         }
       })
     }

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -365,13 +365,16 @@ let initialFilters = (json, filtervalues, removeKeys, filterKeys, setfilterKeys,
     let title = `Select ${key->snakeToTitle}`
 
     let makeOptions = (options: array<string>): array<FilterSelectBox.dropdownOption> => {
-      options->Array.map(str => {
+      options->Array.filterMap(str => {
         let label = switch key->getFilterTypeFromString {
         | #connector => ConnectorUtils.getDisplayNameForConnector(str)
         | _ => str->snakeToTitle
         }
-        let option: FilterSelectBox.dropdownOption = {label, value: str}
-        option
+        if label == "Not known" {
+          None
+        } else {
+          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        }
       })
     }
 

--- a/src/screens/Transaction/Refunds/RefundUtils.res
+++ b/src/screens/Transaction/Refunds/RefundUtils.res
@@ -224,11 +224,17 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
     | #connector_label => getOptionsForRefundFilters(filterDict, filtervalues)
     | #connector =>
       values->Array.filterMap(str => {
-        let label = ConnectorUtils.getDisplayNameForConnector(str)
-        if label == "Not known" {
-          None
-        } else {
-          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
+        | UnknownConnector(_) => None
+        | _ =>
+          Some(
+            (
+              {
+                label: ConnectorUtils.getDisplayNameForConnector(str),
+                value: str,
+              }: FilterSelectBox.dropdownOption
+            ),
+          )
         }
       })
     | _ => values->FilterSelectBox.makeOptions

--- a/src/screens/Transaction/Refunds/RefundUtils.res
+++ b/src/screens/Transaction/Refunds/RefundUtils.res
@@ -222,21 +222,7 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
 
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForRefundFilters(filterDict, filtervalues)
-    | #connector =>
-      values->Array.filterMap(str => {
-        switch str->String.toLowerCase->ConnectorUtils.getConnectorNameTypeFromString {
-        | UnknownConnector(_) => None
-        | _ =>
-          Some(
-            (
-              {
-                label: ConnectorUtils.getDisplayNameForConnector(str),
-                value: str,
-              }: FilterSelectBox.dropdownOption
-            ),
-          )
-        }
-      })
+    | #connector => values->ConnectorUtils.getConnectorFilterOptions
     | _ => values->FilterSelectBox.makeOptions
     }
     let customInput = switch key->getFilterTypeFromString {

--- a/src/screens/Transaction/Refunds/RefundUtils.res
+++ b/src/screens/Transaction/Refunds/RefundUtils.res
@@ -223,9 +223,13 @@ let initialFilters = (json, filtervalues, _, _, _, _) => {
     let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForRefundFilters(filterDict, filtervalues)
     | #connector =>
-      values->Array.map((str): FilterSelectBox.dropdownOption => {
-        label: ConnectorUtils.getDisplayNameForConnector(str),
-        value: str,
+      values->Array.filterMap(str => {
+        let label = ConnectorUtils.getDisplayNameForConnector(str)
+        if label == "Not known" {
+          None
+        } else {
+          Some(({label, value: str}: FilterSelectBox.dropdownOption))
+        }
       })
     | _ => values->FilterSelectBox.makeOptions
     }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Connectors that are not recognized (resolved as `"Not known"`) are filtered out from the dropdown list temporarily.

> **Note:** This is a **temporary fix**. The proper solution is for the backend to send the connector type along with the connector key in the filter response, so the frontend can resolve display names accurately for all connector types (Processors, Payout Processors, etc.). Until that backend change is done, we are inferring the connector type from the page context and hiding unrecognized connectors.

### Files changed:
- `src/screens/Transaction/Order/OrderUIUtils.res`
- `src/screens/Transaction/Refunds/RefundUtils.res`
- `src/screens/Transaction/Disputes/DisputesUtils.res`
- `src/screens/Payouts/PayoutsUtils.res`

## Motivation and Context

Improves UI consistency by showing user-friendly connector names in filter dropdowns, matching how connectors are displayed elsewhere in the dashboard. Unrecognized connectors are hidden until the backend provides connector type information in the filter API response.



## How did you test it?

- Verified connector filter dropdowns in Orders, Refunds, Disputes, and Payouts pages show display names instead of raw keys.
- Verified unrecognized connectors are filtered out from the dropdown.
- Ran `npm run re:build` to confirm no compilation errors.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible