### PR TITLE
fix: amount filter triggers single API call on Apply and stays in sync with form state

### DIFF
--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
@@ -66,10 +66,26 @@ let make = (~options) => {
   let formState = ReactFinalForm.useFormState(
     ReactFinalForm.useFormSubscription(["values"])->Nullable.make,
   )
-  let (selectedOption, setSelectedOption) = React.useState(_ => AmountFilterTypes.UnknownRange(
-    "Select Amount",
-  ))
+  let (selectedOption, setSelectedOption) = React.useState(_ => {
+    let dict = formState.values->getDictFromJsonObject
+    let amount_option = dict->getString("amount_option", "")
+    if amount_option->isNonEmptyString {
+      amount_option->stringRangetoTypeAmount
+    } else {
+      AmountFilterTypes.UnknownRange("Select Amount")
+    }
+  })
   let (isAmountRangeVisible, setIsAmountRangeVisible) = React.useState(_ => true)
+
+  let effectiveSelectedOption = React.useMemo(() => {
+    let dict = formState.values->getDictFromJsonObject
+    let amountOptionFromForm = dict->getString("amount_option", "")
+    if amountOptionFromForm->isNonEmptyString {
+      amountOptionFromForm->stringRangetoTypeAmount
+    } else {
+      selectedOption
+    }
+  }, (formState.values, selectedOption))
 
   let isApplyButtonDisabled = React.useMemo(() => {
     validateAmount(formState.values->getDictFromJsonObject)
@@ -97,7 +113,7 @@ let make = (~options) => {
       handleInputChange(ev->Identity.formReactEventToString)
     },
     onFocus: _ => (),
-    value: selectedOption->mapRangeTypetoString->JSON.Encode.string,
+    value: effectiveSelectedOption->mapRangeTypetoString->JSON.Encode.string,
     checked: true,
   }
 
@@ -107,7 +123,7 @@ let make = (~options) => {
   }
 
   let renderFields = () =>
-    switch selectedOption {
+    switch effectiveSelectedOption {
     | GreaterThanOrEqualTo =>
       <div className="flex gap-5 items-center justify-center w-28">
         <FormRenderer.FieldRenderer field={startamountField} />
@@ -137,7 +153,7 @@ let make = (~options) => {
     let start = dict->getOptionFloat("start_amount")
     let end = dict->getOptionFloat("end_amount")
 
-    switch (selectedOption, start, end) {
+    switch (effectiveSelectedOption, start, end) {
     | (GreaterThanOrEqualTo, Some(start), _) => (true, `More or Equal to ${start->Float.toString}`)
     | (EqualTo, Some(start), _) => (true, `Exactly ${start->Float.toString}`)
     | (LessThanOrEqualTo, _, Some(end)) => (true, `Less or Equal to ${end->Float.toString}`)
@@ -165,7 +181,8 @@ let make = (~options) => {
       fullLength=true
       customButtonStyle="bg-white rounded-md !px-4 !py-2 !h-10"
     />
-    <RenderIf condition={selectedOption != UnknownRange("Select Amount") && isAmountRangeVisible}>
+    <RenderIf
+      condition={effectiveSelectedOption != UnknownRange("Select Amount") && isAmountRangeVisible}>
       <div
         className="border border-jp-gray-940 border-opacity-50 bg-white rounded-md py-1.5 gap-2.5 flex justify-between px-2.5 pb-4 border-t-0 items-center">
         {renderFields()}

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
@@ -77,15 +77,22 @@ let make = (~options) => {
   })
   let (isAmountRangeVisible, setIsAmountRangeVisible) = React.useState(_ => true)
 
-  let effectiveSelectedOption = React.useMemo(() => {
-    let dict = formState.values->getDictFromJsonObject
-    let amountOptionFromForm = dict->getString("amount_option", "")
-    if amountOptionFromForm->isNonEmptyString {
-      amountOptionFromForm->stringRangetoTypeAmount
-    } else {
-      selectedOption
+  // Sync local state when amount_option changes from outside (e.g. saved view load),
+  // so the UI reflects the externally applied filter without round-tripping through form.
+  let amountOptionFromForm = React.useMemo(() => {
+    formState.values->getDictFromJsonObject->getString("amount_option", "")
+  }, [formState.values])
+
+  React.useEffect(() => {
+    let parsed =
+      amountOptionFromForm->isNonEmptyString
+        ? amountOptionFromForm->stringRangetoTypeAmount
+        : AmountFilterTypes.UnknownRange("Select Amount")
+    if parsed !== selectedOption {
+      setSelectedOption(_ => parsed)
     }
-  }, (formState.values, selectedOption))
+    None
+  }, [amountOptionFromForm])
 
   let isApplyButtonDisabled = React.useMemo(() => {
     validateAmount(formState.values->getDictFromJsonObject)
@@ -93,17 +100,12 @@ let make = (~options) => {
 
   let handleInputChange = newValue => {
     if newValue->isNonEmptyString {
-      let mappedRange = newValue->mapStringToRange
-
-      form.change("start_amount", JSON.Encode.null)
-      form.change("end_amount", JSON.Encode.null)
-      form.change("amount_option", mappedRange->Identity.genericTypeToJson)
-
-      setSelectedOption(_ => {newValue->mapStringToRange})
-      setIsAmountRangeVisible(_ => true)
-    } else {
-      setIsAmountRangeVisible(_ => true)
+      // Keep the selection local until the user clicks Apply. Writing to the
+      // form here triggers the filter subscription and fires the list API
+      // before the user has entered an amount.
+      setSelectedOption(_ => newValue->mapStringToRange)
     }
+    setIsAmountRangeVisible(_ => true)
   }
 
   let input: ReactFinalForm.fieldRenderPropsInput = {
@@ -113,17 +115,28 @@ let make = (~options) => {
       handleInputChange(ev->Identity.formReactEventToString)
     },
     onFocus: _ => (),
-    value: effectiveSelectedOption->mapRangeTypetoString->JSON.Encode.string,
+    value: selectedOption->mapRangeTypetoString->JSON.Encode.string,
     checked: true,
   }
 
   let handleApply = _ => {
+    // Commit the selected option and clear any stale amount fields that don't
+    // apply to the chosen range, then submit exactly once.
+    switch selectedOption {
+    | GreaterThanOrEqualTo => form.change("end_amount", JSON.Encode.null)
+    | LessThanOrEqualTo => form.change("start_amount", JSON.Encode.null)
+    // EqualTo: CustomAmountEqualField mirrors start_amount into end_amount, so both remain.
+    // InBetween: user enters both explicitly.
+    // UnknownRange: nothing to commit.
+    | _ => ()
+    }
+    form.change("amount_option", selectedOption->Identity.genericTypeToJson)
     form.submit()->ignore
     setIsAmountRangeVisible(_ => false)
   }
 
   let renderFields = () =>
-    switch effectiveSelectedOption {
+    switch selectedOption {
     | GreaterThanOrEqualTo =>
       <div className="flex gap-5 items-center justify-center w-28">
         <FormRenderer.FieldRenderer field={startamountField} />
@@ -153,7 +166,7 @@ let make = (~options) => {
     let start = dict->getOptionFloat("start_amount")
     let end = dict->getOptionFloat("end_amount")
 
-    switch (effectiveSelectedOption, start, end) {
+    switch (selectedOption, start, end) {
     | (GreaterThanOrEqualTo, Some(start), _) => (true, `More or Equal to ${start->Float.toString}`)
     | (EqualTo, Some(start), _) => (true, `Exactly ${start->Float.toString}`)
     | (LessThanOrEqualTo, _, Some(end)) => (true, `Less or Equal to ${end->Float.toString}`)
@@ -181,8 +194,7 @@ let make = (~options) => {
       fullLength=true
       customButtonStyle="bg-white rounded-md !px-4 !py-2 !h-10"
     />
-    <RenderIf
-      condition={effectiveSelectedOption != UnknownRange("Select Amount") && isAmountRangeVisible}>
+    <RenderIf condition={selectedOption != UnknownRange("Select Amount") && isAmountRangeVisible}>
       <div
         className="border border-jp-gray-940 border-opacity-50 bg-white rounded-md py-1.5 gap-2.5 flex justify-between px-2.5 pb-4 border-t-0 items-center">
         {renderFields()}

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
@@ -69,11 +69,9 @@ let make = (~options) => {
   let (selectedOption, setSelectedOption) = React.useState(_ => {
     let dict = formState.values->getDictFromJsonObject
     let amount_option = dict->getString("amount_option", "")
-    if amount_option->isNonEmptyString {
-      amount_option->stringRangetoTypeAmount
-    } else {
-      AmountFilterTypes.UnknownRange("Select Amount")
-    }
+    amount_option->isNonEmptyString
+      ? amount_option->stringRangetoTypeAmount
+      : AmountFilterTypes.UnknownRange("Select Amount")
   })
   let (isAmountRangeVisible, setIsAmountRangeVisible) = React.useState(_ => true)
 
@@ -86,9 +84,7 @@ let make = (~options) => {
       amountOptionFromForm->isNonEmptyString
         ? amountOptionFromForm->stringRangetoTypeAmount
         : AmountFilterTypes.UnknownRange("Select Amount")
-    if parsed !== selectedOption {
-      setSelectedOption(_ => parsed)
-    }
+    parsed !== selectedOption ? setSelectedOption(_ => parsed) : ()
     None
   }, [amountOptionFromForm])
 

--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilter.res
@@ -77,8 +77,6 @@ let make = (~options) => {
   })
   let (isAmountRangeVisible, setIsAmountRangeVisible) = React.useState(_ => true)
 
-  // Sync local state when amount_option changes from outside (e.g. saved view load),
-  // so the UI reflects the externally applied filter without round-tripping through form.
   let amountOptionFromForm = React.useMemo(() => {
     formState.values->getDictFromJsonObject->getString("amount_option", "")
   }, [formState.values])
@@ -100,9 +98,6 @@ let make = (~options) => {
 
   let handleInputChange = newValue => {
     if newValue->isNonEmptyString {
-      // Keep the selection local until the user clicks Apply. Writing to the
-      // form here triggers the filter subscription and fires the list API
-      // before the user has entered an amount.
       setSelectedOption(_ => newValue->mapStringToRange)
     }
     setIsAmountRangeVisible(_ => true)
@@ -120,14 +115,9 @@ let make = (~options) => {
   }
 
   let handleApply = _ => {
-    // Commit the selected option and clear any stale amount fields that don't
-    // apply to the chosen range, then submit exactly once.
     switch selectedOption {
     | GreaterThanOrEqualTo => form.change("end_amount", JSON.Encode.null)
     | LessThanOrEqualTo => form.change("start_amount", JSON.Encode.null)
-    // EqualTo: CustomAmountEqualField mirrors start_amount into end_amount, so both remain.
-    // InBetween: user enters both explicitly.
-    // UnknownRange: nothing to commit.
     | _ => ()
     }
     form.change("amount_option", selectedOption->Identity.genericTypeToJson)


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- **Fixed duplicate list API call on amount option selection**: Previously, picking any amount option (`In Between`, `Greater than or Equal to`, `Less than or Equal to`, `Equal to`) from the dropdown wrote `amount_option` to form state immediately. The parent `Filter` component's subscription treated this as a filter change and fired the list API with no amount values, then a **second** API call fired on Apply with the real values.

- **Deferred form writes to Apply**: `amount_option`, `start_amount` and `end_amount` mutations are now held in local component state while the user is picking and typing. They are committed to form state only when the user clicks **Apply**, and the filter API fires exactly once with the final values.

- **Stale-value cleanup at Apply time**: When the user switches from one option to another (e.g. `In Between` → `Less than or Equal to`), the irrelevant amount field is cleared on Apply, so no leftover value leaks into the query.

- **Synchronised selection with external form state**: Replaced the previous `effectiveSelectedOption` useMemo with a `useEffect` that syncs local state whenever `amount_option` in form state changes from outside (e.g. navigation, saved view / deep link). The dropdown button and range panel now stay in sync with the actually applied filter.

## Motivation and Context

A merchant reported that every interaction with the amount filter sent an unnecessary request to the backend and caused a brief table flicker before they had even entered a value (see issue #4736). Root cause: `form.change` was being called inside `handleInputChange` the moment an option was picked, which the filter subscription treated as a real filter update.

This PR:

- Removes the redundant network call — one amount filter interaction now results in exactly one list API call.
- Prevents the list from clearing/flickering before the user finishes input.
- Keeps the AmountFilter UI consistent with the actual active filter, including filters set from saved views, deep links, or browser back/forward navigation.

Closes #4736

## How did you test it?

- Opened the Payments page and verified only a **single** list API call fires after clicking Apply for each of the four amount options (`In Between`, `Greater than or Equal to`, `Less than or Equal to`, `Equal to`). Network tab no longer shows a request fired when the option is first picked.
- Switched between options without clicking Apply — confirmed no API call is sent and the inputs reset correctly.
- Applied an amount filter, navigated away, came back — the dropdown correctly shows the currently active option and values.
- Applied an amount filter via a saved view — the dropdown button text and range panel reflect the saved selection.
- Ran `npm run re:build` — clean build, no warnings.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible