### PR TITLE
docs: replace Cypress test suite section with Playwright in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,9 +500,9 @@ Welcome to the standard process for raising a Pull Request (PR) directly from a 
 - Include relevant tests, documentation updates, or screenshots, if applicable.
 - Collaborate and communicate effectively with other contributors and maintainers throughout the review process.
 
-## Cypress Test Suite
+## Playwright Test Suite
 
-This guide walks you through running Cypress tests locally for the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center) project. The tests simulate real user workflows on the dashboard UI and require a working Hyperswitch backend environment.
+This guide walks you through running Playwright tests locally for the [Hyperswitch Control Center](https://github.com/juspay/hyperswitch-control-center) project. The tests simulate real user workflows on the dashboard UI and require a working Hyperswitch backend environment.
 
 ---
 
@@ -512,7 +512,7 @@ This guide walks you through running Cypress tests locally for the [Hyperswitch 
 
 - [Node.js](https://nodejs.org/)
 - [npm](https://www.npmjs.com/)
-- [Cypress](https://docs.cypress.io/app/get-started/install-cypress)
+- [Playwright](https://playwright.dev/docs/intro)
 
 ---
 
@@ -529,34 +529,42 @@ cd hyperswitch-control-center
 npm install
 ```
 
-### 3. Start the local dashboard server
+### 3. Install Playwright browsers
+
+```bash
+npx playwright install
+```
+
+### 4. Start the local dashboard server
 
 ```
 npm run build:test && npm run test:start
 ```
 
-### 4. Running Cypress Tests
+### 5. Running Playwright Tests
 
 Open a second terminal and run the following commands
 
-#### Set environment variables for cypress
+#### Set environment variables for Playwright
 
 ```
-export CYPRESS_USERNAME="cypress@test.com"
-export CYPRESS_PASSWORD="Cypress00#"
+export PLAYWRIGHT_USERNAME="playwright@test.com"
+export PLAYWRIGHT_PASSWORD="Playwright00#"
 ```
 
-#### To run tests interactively in Cypress Test Runner:
+#### To run tests interactively in Playwright UI mode:
 
 ```
-npm run cy:open
+npx playwright test --ui
 ```
 
 #### To run tests in headless mode (CI/CD):
 
 ```
-npm run cy:run
+npx playwright test
 ```
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary

- Replaced the outdated "Cypress Test Suite" section in README.md with a new "Playwright Test Suite" section
- Updated prerequisites to reference Playwright instead of Cypress
- Added step for installing Playwright browsers (`npx playwright install`)
- Updated environment variables from `CYPRESS_USERNAME`/`CYPRESS_PASSWORD` to `PLAYWRIGHT_USERNAME`/`PLAYWRIGHT_PASSWORD`
- Replaced `npm run cy:open` / `npm run cy:run` commands with `npx playwright test --ui` / `npx playwright test`
- Renumbered steps accordingly (now 5 steps instead of 4)

## Files Changed

- `README.md` — replaced Cypress section with Playwright section

## Context

The project has fully migrated from Cypress to Playwright for end-to-end testing. This PR updates the README to reflect that completed migration.

Discussion thread: https://slack.com/archives/C09TQPJB5B2/p1776415933997969