### PR TITLE
perf(table): add @react.memo to table components and memoize nullableRows

### DIFF
--- a/src/components/LoadedTable.res
+++ b/src/components/LoadedTable.res
@@ -565,7 +565,7 @@ let make = (
 
   let sNoArr = Dict.get(columnFilter, "s_no")->Option.getOr([])
   // filtering for SNO
-  let nullableRows = filteredData->Array.mapWithIndex((nullableItem, index) => {
+  let nullableRows = React.useMemo(() => filteredData->Array.mapWithIndex((nullableItem, index) => {
     let actualRows = switch nullableItem->Nullable.toOption {
     | Some(item) => {
         let visibleCell =
@@ -633,7 +633,7 @@ let make = (
     }
 
     actualRows
-  })
+  }), (filteredData, visibleColumns, columnFilter, showSerialNumber, checkBoxProps.selectedData))
 
   let rows = if allowNullableRows {
     nullableRows

--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -1,5 +1,6 @@
 include TableUtils
 module TableFilterRow = {
+  @react.memo
   @react.component
   let make = (
     ~item: array<filterRow>,
@@ -53,6 +54,7 @@ module TableFilterRow = {
 }
 
 module TableRow = {
+  @react.memo
   @react.component
   let make = (
     ~title,
@@ -328,6 +330,7 @@ module SortAction = {
 }
 
 module TableHeadingCell = {
+  @react.memo
   @react.component
   let make = (
     ~item,


### PR DESCRIPTION
## Summary

- Added `@react.memo` decorator to `TableFilterRow`, `TableRow`, and `TableHeadingCell` modules in `src/components/Table.res` to prevent unnecessary re-renders when parent components re-render with unchanged props
- Wrapped the `nullableRows` transformation in `src/components/LoadedTable.res` with `React.useMemo` to avoid recomputing the row data array on every render; dependencies: `filteredData`, `visibleColumns`, `columnFilter`, `showSerialNumber`, `checkBoxProps.selectedData`

## Files Changed

- `src/components/Table.res` — added `@react.memo` before `@react.component` on `TableFilterRow`, `TableRow`, and `TableHeadingCell`
- `src/components/LoadedTable.res` — wrapped `nullableRows` computation with `React.useMemo`

## References

- GitHub Issue: #4444
- Discussion thread: https://slack.com/archives/C09TQPJB5B2/p1776845206687869