### PR TITLE
feat(payment-ops): add Last Viewed column to Payment Operations table

### DIFF
--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -313,6 +313,7 @@ let defaultColumns: array<colType> = [
   Metadata,
   Created,
   Modified,
+  LastViewed,
 ]
 //Columns array for V1 Orders page
 let allColumnsV1 = [
@@ -340,6 +341,7 @@ let allColumnsV1 = [
   AttemptCount,
   CardNetwork,
   ErrorMessage,
+  LastViewed,
 ]
 
 //Columns array for V2 Orders page
@@ -368,6 +370,7 @@ let allColumnsV2 = [
   CardNetwork,
   PaymentType,
   ErrorMessage,
+  LastViewed,
 ]
 
 let getHeading = (~devSortEnabled, colType: colType) => {
@@ -425,6 +428,7 @@ let getHeading = (~devSortEnabled, colType: colType) => {
     Table.makeHeaderInfo(~key="merchant_order_reference_id", ~title="Merchant Order Reference Id")
   | AttemptCount => Table.makeHeaderInfo(~key="attempt_count", ~title="Attempt count")
   | PaymentType => Table.makeHeaderInfo(~key="payment_type", ~title="Payment Type")
+  | LastViewed => Table.makeHeaderInfo(~key="last_viewed", ~title="Last Viewed")
   }
 }
 
@@ -832,6 +836,12 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
     | Some(true) => Text("Split")
     | Some(false) => Text("Standard")
     | None => Text("N/A")
+    }
+  | LastViewed =>
+    let key = "last_viewed_" ++ order.payment_id
+    switch LocalStorage.getItem(key)->Nullable.toOption {
+    | Some(v) => Date(v)
+    | None => Text("Never")
     }
   }
 }

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -96,6 +96,7 @@ type colType =
   | MerchantOrderReferenceId
   | AttemptCount
   | PaymentType
+  | LastViewed
 
 type summaryColType =
   | Created

--- a/src/screens/Transaction/Order/ShowOrder.res
+++ b/src/screens/Transaction/Order/ShowOrder.res
@@ -687,6 +687,13 @@ let make = (~id, ~profileId, ~merchantId, ~orgId) => {
     None
   }, [id])
 
+  React.useEffect(() => {
+    let key = "last_viewed_" ++ id
+    let now = Date.make()->Date.toISOString
+    LocalStorage.setItem(key, now)
+    None
+  }, [id])
+
   let isRefundDataAvailable = orderData.refunds->Array.length !== 0
 
   let isDisputeDataVisible = orderData.disputes->Array.length !== 0


### PR DESCRIPTION
## Summary

- Adds a **Last Viewed** column to the Payment Operations (Orders) table that shows when the current user last opened a payment's detail page
- Records the current timestamp in `localStorage` when a payment detail page is opened (`ShowOrder.res`)
- Reads and displays the stored timestamp in the Orders table cell; shows `"Never"` if the payment has not been viewed yet
- Column is included in `defaultColumns` and both `allColumnsV1` / `allColumnsV2` so it appears by default for all table versions

## Files Changed

- `src/screens/Transaction/Order/OrderTypes.res` — added `| LastViewed` to `colType` variant
- `src/screens/Transaction/Order/OrderEntity.res` — added `LastViewed` to column arrays, heading, and cell renderer
- `src/screens/Transaction/Order/ShowOrder.res` — added `React.useEffect` to write `last_viewed_<paymentId>` into `localStorage` on page load

## Implementation Notes

- Purely frontend — no backend API changes
- Uses the existing `LocalStorage` module (`LocalStorage.getItem` / `LocalStorage.setItem`) consistent with the rest of the codebase
- Per-user, per-browser tracking via `localStorage` key pattern: `last_viewed_<payment_id>`

## Discussion Thread

https://slack.com/archives/C0A2J8R6Z3N/p1777238326102799