### PR TITLE
refactor: deepen API/state interfaces and consolidate ArrayUtils

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,100 @@
+# Hyperswitch Control Center
+
+The dashboard for [Hyperswitch](https://github.com/juspay/hyperswitch) — an open-source payments switch. The Control Center is the operator-facing UI for managing payment flows, processor integrations, routing, analytics, and reconciliation.
+
+## Language
+
+### Core domain
+
+**Merchant**:
+The business entity using Hyperswitch to accept payments. Owns one or more **Profiles** and configures **Connectors**.
+_Avoid_: Customer, account, tenant, organization (all overloaded — pick "Merchant" when referring to the Hyperswitch tenant).
+
+**Profile**:
+A logical grouping under a **Merchant** representing a business unit, brand, or product line. Connectors and routing rules are scoped to a Profile.
+_Avoid_: Sub-merchant, business profile.
+
+**Connector**:
+An adapter to an external payment processor (Stripe, Adyen, Braintree, etc.). The unit of integration.
+_Avoid_: Processor, gateway, PSP, provider — use "Connector" when referring to the configured adapter inside Hyperswitch; "processor" only when speaking generically about the external system.
+
+**Payment**:
+A single payment attempt initiated by a **Merchant** on behalf of an end-customer. May proceed through several statuses (requires_payment_method, processing, succeeded, failed, etc.) and may produce a **Refund** or a **Dispute**.
+_Avoid_: Transaction, charge, order — these collide with processor-specific terminology.
+
+**Refund**:
+A reversal of all or part of a captured **Payment**.
+_Avoid_: Reversal (reserved for auth-only reversals), credit.
+
+**Dispute**:
+A chargeback or pre-arbitration raised by the cardholder against a **Payment**. Has its own lifecycle (challenged, won, lost).
+_Avoid_: Chargeback (use "Dispute" — covers chargebacks plus pre-arbitration and inquiries).
+
+**Payout**:
+A disbursement of funds from the **Merchant** to a third party (refund-to-card, vendor payout, marketplace split).
+_Avoid_: Withdrawal, transfer.
+
+### Routing & decisioning
+
+**Routing Rule**:
+A configured policy that decides which **Connector** handles a given **Payment**. Two flavours: **Volume-based** (split by percentages) and **Rule-based** (conditional on payment fields).
+_Avoid_: Decision tree, route.
+
+**Surcharge**:
+An additional amount added to a **Payment** based on payment-method or other conditions.
+
+**FRM**:
+Fraud and Risk Management — pre-authorisation screening of a **Payment** through providers like Riskified or Signifyd.
+_Avoid_: Fraud check, risk check.
+
+### Operations
+
+**Recon**:
+Reconciliation — matching processor-reported settlements against the **Merchant**'s ledger and Hyperswitch's record of **Payments**.
+_Avoid_: Reconciliation (the long form is fine in prose; in code/UI use "Recon").
+
+**Audit Trail**:
+The append-only history of state changes on a **Payment**, **Refund**, or **Dispute**.
+
+**Test mode / Live mode**:
+The environment a session is operating in. Test-mode traffic uses sandbox **Connectors** and never moves real funds.
+
+### Platform / UI shell
+
+**Dashboard**:
+The Control Center UI as a whole.
+_Avoid_: App, console, portal.
+
+**Screen**:
+A top-level route in the **Dashboard** (e.g. Payments screen, Connectors screen). Lives under `src/screens/`.
+_Avoid_: Page, view (page implies static content; view is overloaded).
+
+**Embeddable**:
+A version of a Hyperswitch UI surface designed to be embedded inside a host application (e.g. inside a partner's own dashboard).
+
+**Vault**:
+The PCI-scoped surface that handles sensitive payment-method data (card numbers, etc.). Distinct from the rest of the **Dashboard** because of compliance requirements.
+
+## Relationships
+
+- A **Merchant** owns one or more **Profiles**
+- A **Profile** owns one or more **Connectors** and zero or more **Routing Rules**
+- A **Routing Rule** chooses which **Connector** processes a **Payment**
+- A **Payment** belongs to a **Profile** and is processed by exactly one **Connector** at a time (retries can change this)
+- A **Payment** may produce zero or more **Refunds** and zero or more **Disputes**
+- An **FRM** decision precedes the **Connector** call for a **Payment**
+- **Recon** reconciles **Connector**-reported settlements with **Payment** records
+
+## Example dialogue
+
+> **Dev:** "When the user lands on the Payments screen, how do we know which **Profile** they're scoped to?"
+> **Domain expert:** "The session carries the active **Profile** id. The Payments **Screen** filters by that **Profile** before calling the list endpoint — a **Merchant** with three **Profiles** sees three separate Payments screens, not a merged one."
+
+> **Dev:** "If a **Routing Rule** sends a **Payment** to a Connector that's down, do we automatically retry on a different **Connector**?"
+> **Domain expert:** "Only if the rule has a fallback chain configured. Otherwise the **Payment** fails and surfaces in the Audit Trail."
+
+## Flagged ambiguities
+
+- **"Customer"** is heavily overloaded. In this codebase: the **Merchant** is the Hyperswitch tenant; their customers (end-shoppers) are usually called "the customer" in prose but should not be a top-level domain term in CONTEXT.md unless we're modelling them explicitly.
+- **"Connector" vs "Processor"**: a Connector is the configured adapter inside Hyperswitch; a processor is the external system. Stripe is a processor; the Stripe Connector is what Hyperswitch holds.
+- **"Profile" vs "Merchant"**: Routing, Connectors, and most operational data are Profile-scoped, not Merchant-scoped. New code should default to the Profile boundary.

--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -1632,18 +1632,10 @@ let catchHandler = (
   }
 }
 
-let useGetMethod = (~showErrorToast=true) => {
-  let {merchantId, profileId} = React.useContext(
-    UserInfoProvider.defaultContext,
-  ).getCommonSessionDetails()
-  let {isEmbeddableSession} = React.useContext(UserInfoProvider.defaultContext)
-  let fetchApi = AuthHooks.useApiFetcher()
-  let showToast = ToastState.useShowToast()
+let useSignUpPopUp = () => {
   let showPopUp = PopUpState.useShowPopUp()
   let handleLogout = useHandleLogout()
-  let sendEvent = MixpanelHook.useSendEvent()
-  let isPlayground = HSLocalStorage.getIsPlaygroundFromLocalStorage()
-  let popUpCallBack = () =>
+  () =>
     showPopUp({
       popUpType: (Warning, WithIcon),
       heading: "Sign Up to Access All Features!",
@@ -1657,6 +1649,18 @@ let useGetMethod = (~showErrorToast=true) => {
         },
       },
     })
+}
+
+let useGetMethod = (~showErrorToast=true) => {
+  let {merchantId, profileId} = UserInfoProvider.useActiveSession()
+  let {isEmbeddableSession} = React.useContext(UserInfoProvider.defaultContext)
+  let fetchApi = AuthHooks.useApiFetcher()
+  let showToast = ToastState.useShowToast()
+  let showPopUp = PopUpState.useShowPopUp()
+  let handleLogout = useHandleLogout()
+  let sendEvent = MixpanelHook.useSendEvent()
+  let isPlayground = HSLocalStorage.getIsPlaygroundFromLocalStorage()
+  let popUpCallBack = useSignUpPopUp()
   let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   async (url, ~version=UserInfoTypes.V1) => {
@@ -1692,9 +1696,7 @@ let useGetMethod = (~showErrorToast=true) => {
 }
 
 let useUpdateMethod = (~showErrorToast=true) => {
-  let {merchantId, profileId} = React.useContext(
-    UserInfoProvider.defaultContext,
-  ).getCommonSessionDetails()
+  let {merchantId, profileId} = UserInfoProvider.useActiveSession()
   let {isEmbeddableSession} = React.useContext(UserInfoProvider.defaultContext)
   let fetchApi = AuthHooks.useApiFetcher()
   let showToast = ToastState.useShowToast()
@@ -1703,20 +1705,7 @@ let useUpdateMethod = (~showErrorToast=true) => {
   let sendEvent = MixpanelHook.useSendEvent()
   let isPlayground = HSLocalStorage.getIsPlaygroundFromLocalStorage()
 
-  let popUpCallBack = () =>
-    showPopUp({
-      popUpType: (Warning, WithIcon),
-      heading: "Sign Up to Access All Features!",
-      description: {
-        "To unlock the potential and experience the full range of capabilities, simply sign up today. Join our community of explorers and gain access to an enhanced world of possibilities"->React.string
-      },
-      handleConfirm: {
-        text: "Sign up Now",
-        onClick: {
-          _ => handleLogout()->ignore
-        },
-      },
-    })
+  let popUpCallBack = useSignUpPopUp()
   let {xFeatureRoute, forceCookies} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   async (

--- a/src/components/DynamicTable.res
+++ b/src/components/DynamicTable.res
@@ -128,7 +128,7 @@ let make = (
   let fetchApi = AuthHooks.useApiFetcher()
   let url = RescriptReactRouter.useUrl()
   let searchParams = disableURIdecode ? url.search : url.search->decodeURI
-  let (refreshData, _setRefreshData) = React.useContext(RefreshStateContext.refreshStateContext)
+  let refreshData = RefreshStateContext.useRefreshTrigger()
   let (offset, setOffset) = React.useState(() => 0)
   let remoteFilters = initialFilters->Array.filter(item => item.localFilter->Option.isNone)
   let filtersFromUrl = getDictFromUrlSearchParams(searchParams)

--- a/src/context/RefreshStateContext.res
+++ b/src/context/RefreshStateContext.res
@@ -3,3 +3,8 @@ let defaultSetter = (_: int => int) => ()
 let refreshStateContext = React.createContext((0, defaultSetter))
 
 let make = React.Context.provider(refreshStateContext)
+
+let useRefreshTrigger = () => {
+  let (refreshData, _) = React.useContext(refreshStateContext)
+  refreshData
+}

--- a/src/entryPoints/AuthModule/UserInfo/UserInfoProvider.res
+++ b/src/entryPoints/AuthModule/UserInfo/UserInfoProvider.res
@@ -4,6 +4,9 @@ module Provider = {
   let make = React.Context.provider(defaultContext)
 }
 
+let useActiveSession = (): UserInfoTypes.commonInfoType =>
+  React.useContext(defaultContext).getCommonSessionDetails()
+
 type userInfoScreenState = Loading | Success | Error
 @react.component
 let make = (~children, ~isEmbeddableApp=false) => {

--- a/src/screens/Analytics/AnalyticsUtils.res
+++ b/src/screens/Analytics/AnalyticsUtils.res
@@ -205,7 +205,7 @@ let getFilterRequestBody = (
         body,
         "groupByNames",
         groupByNames
-        ->ArrayUtils.getUniqueStrArray
+        ->LogicUtils.getUniqueArray
         ->Belt.Array.keepMap(item => Some(item->JSON.Encode.string))
         ->JSON.Encode.array,
       )
@@ -264,7 +264,7 @@ let getFilterRequestBody = (
         body,
         "metrics",
         metrics
-        ->ArrayUtils.getUniqueStrArray
+        ->LogicUtils.getUniqueArray
         ->Belt.Array.keepMap(item => Some(item->JSON.Encode.string))
         ->JSON.Encode.array,
       )

--- a/src/utils/ArrayUtils.res
+++ b/src/utils/ArrayUtils.res
@@ -1,8 +1,0 @@
-let getUniqueStrArray = (arr: array<string>) => {
-  arr
-  ->Array.map(item => {
-    (item, 0)
-  })
-  ->Dict.fromArray
-  ->Dict.keysToArray
-}


### PR DESCRIPTION
## Summary

Four small, low-risk architecture passes from the [improve-codebase-architecture](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md) skill — applying the "deep modules" principle (high leverage at the interface, low duplication, locality of change). No behaviour change.

| Pass | Layer | Change |
|---|---|---|
| 1 | API | Extract `useSignUpPopUp` hook to dedupe the identical "Sign Up to Access All Features" popup callback shared by `useGetMethod` and `useUpdateMethod`. |
| 2 | utils | `ArrayUtils.getUniqueStrArray` duplicated `LogicUtils.getUniqueArray` (which is generic). Migrate the two callers in `AnalyticsUtils.res` and delete `src/utils/ArrayUtils.res`. |
| 3 | state | Add `useRefreshTrigger` hook to `RefreshStateContext` returning just the trigger int; migrate `DynamicTable.res`'s single caller off the raw context tuple. |
| 4 | cross-cutting | Add `useActiveSession` hook to `UserInfoProvider` over the existing `React.useContext(...).getCommonSessionDetails()` pattern (~134 callers). Migrate the two API hooks as the first adopters; remaining callers can migrate incrementally. |

Also bootstrap a top-level `CONTEXT.md` with the Hyperswitch domain glossary (Merchant, Profile, Connector, Payment, Refund, Dispute, Payout, Routing Rule, Recon, etc.) so future architecture passes have a shared vocabulary.

### Out of scope (deliberately deferred)

The skill also surfaced several larger candidates that are higher-risk and need test coverage before landing — leaving them for follow-ups:
- Consolidating the seven near-identical Connector processor directories (Billing, 3DS, FRM, Payout, Tax, Vault, PMAuth) behind a single processor factory.
- Unifying the four `SelectBox` variants and five `Modal` variants behind a config-driven primitive.
- Unifying Orders / Refunds / Disputes screens (~80% shared list/filter/paginate skeleton).
- Reconciling Merchant/Profile state between Recoil atoms and `UserInfoProvider` (atoms appear to mirror context state in places).
- Splitting `LogicUtils` (719 lines, 113 functions) along domain seams (e.g., a `Money` module absorbing `CurrencyFormatUtils` + `CurrencyUtils` + `NumericUtils`).
- A `ResponseMapper` / `HeaderAdapter` extraction in `APIUtils` to centralise status-code handling and feature-header injection.

## Files

- `CONTEXT.md` (new) — domain glossary
- `src/APIUtils/APIUtils.res` — `useSignUpPopUp` extraction; `useGetMethod` / `useUpdateMethod` adopt `useActiveSession` and `useSignUpPopUp`
- `src/entryPoints/AuthModule/UserInfo/UserInfoProvider.res` — `useActiveSession` hook
- `src/context/RefreshStateContext.res` — `useRefreshTrigger` hook
- `src/components/DynamicTable.res` — adopt `useRefreshTrigger`
- `src/screens/Analytics/AnalyticsUtils.res` — adopt `LogicUtils.getUniqueArray`
- `src/utils/ArrayUtils.res` — deleted

## Test plan
- [x] `npm run re:build` — clean (1785/1785)
- [ ] Smoke-test the Analytics screen (touched `AnalyticsUtils.res`)
- [ ] Smoke-test any DynamicTable screen with the refresh button (touched `DynamicTable.res`)
- [ ] Smoke-test a sandbox session that triggers the "Sign Up to Access All Features" popup (touched `useGetMethod` / `useUpdateMethod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)