### PR TITLE
refactor: remove old recon resource-access permissions

### DIFF
--- a/src/screens/UserManagement/UserRevamp/UserManagementTypes.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementTypes.res
@@ -43,13 +43,6 @@ type resourceAccessType =
   | Routing
   | ThreeDsDecisionManager
   | SurchargeDecisionManager
-  | ReconToken
-  | ReconFiles
-  | ReconAndSettlementAnalytics
-  | ReconUpload
-  | ReconReports
-  | RunRecon
-  | ReconConfig
   | Account
   | ApiKey
   | User

--- a/src/utils/Mappers/GroupACLMapper.res
+++ b/src/utils/Mappers/GroupACLMapper.res
@@ -77,13 +77,6 @@ let mapStringToResourceAccessType = val =>
   | "webhook_event" => WebhookEvent
   | "payout" => Payout
   | "report" => Report
-  | "recon_token" => ReconToken
-  | "recon_files" => ReconFiles
-  | "recon_and_settlement_analytics" => ReconAndSettlementAnalytics
-  | "recon_upload" => ReconUpload
-  | "recon_reports" => ReconReports
-  | "run_recon" => RunRecon
-  | "recon_config" => ReconConfig
   | "theme" => Theme
   | "recon_ingestion" => ReconIngestion
   | "recon_transformation" => ReconTransformation


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removes the old recon resource-access permission variants and their string-to-variant mappings. With the V0 routes and `<ReconModule />` removed in #4786, these variants have no consumers — they were the last reference back to the legacy permission model.

**Variants removed from `resourceAccessType`:**
`ReconToken`, `ReconFiles`, `ReconAndSettlementAnalytics`, `ReconUpload`, `ReconReports`, `RunRecon`, `ReconConfig`

**Mapper entries removed from `GroupACLMapper`:**
`recon_token`, `recon_files`, `recon_and_settlement_analytics`, `recon_upload`, `recon_reports`, `run_recon`, `recon_config` — the string-to-variant cases for the above

Net: 14 deletions across 2 files.

## Motivation and Context

The new recon system uses a different permission model — `ReconIngestion`, `ReconTransformation`, `ReconException`, `ReconStagingEntry`, `ReconTransaction`, `ReconRule` — defined alongside the old ones. The old variants were left behind even though the legacy recon iframe module they gated has been disabled by Product.

**Stacked on #4786.** That PR removes the V0 UI, routes, feature flag, and URL plumbing that referenced these variants — so by the time this lands, they're orphan type cases. GitHub will auto-retarget this PR to `main` once #4786 merges.

## How did you test it?

- Full `npm run re:clean && npm run re:build` — clean, 3799/3799 modules, 0 warnings, 0 errors
- Verified the removed variants have no remaining references anywhere in `src/`
- The `ReconReports` symbol that still appears in `src/Recon/ReconContainer/ReconReportsContainer.res` is a React component for the V2 recon module, not the old permission variant, and is intentionally untouched

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible