### PR TITLE
feat: add per-record deep link icon to transaction tables

### DIFF
--- a/src/entryPoints/OMPSwitch/OMPPermaLinkButton.res
+++ b/src/entryPoints/OMPSwitch/OMPPermaLinkButton.res
@@ -34,7 +34,7 @@ let make = (~permaLinkFor=?) => {
   | _ => None
   }
   <ToolTip
-    description="Copy link to this exact view for this current Organization -> Merchant -> Profile hierarchy"
+    description="This link encodes the current Organization → Merchant → Profile context and will send recipients directly to the same page and navigation hierarchy"
     toolTipFor={<HelperComponents.CopyTextCustomComp
       copyValue={Some(permaLink)}
       displayValue=Some("")

--- a/src/screens/Transaction/Order/HSwitchOrderUtils.res
+++ b/src/screens/Transaction/Order/HSwitchOrderUtils.res
@@ -266,6 +266,9 @@ module CopyLinkTableCell = {
   ) => {
     let (isTextVisible, setIsTextVisible) = React.useState(_ => false)
     let showToast = ToastState.useShowToast()
+    let {orgId, merchantId, profileId, version} = React.useContext(
+      UserInfoProvider.defaultContext,
+    ).getCommonSessionDetails()
     let handleClick = ev => {
       ev->ReactEvent.Mouse.stopPropagation
       setIsTextVisible(_ => true)
@@ -280,6 +283,18 @@ module CopyLinkTableCell = {
       Clipboard.writeText(copyVal)
       customOnCopyClick()
       showToast(~message="Copied to Clipboard!", ~toastType=ToastSuccess)
+    }
+
+    let onDeepLinkClick = ev => {
+      ev->ReactEvent.Mouse.stopPropagation
+      let version = (version :> string)
+      let deepLinkUrl = Window.URL.make(
+        `${Window.Location.origin}/${orgId}/${merchantId}/${profileId}/${version}/switch/user`,
+        `${Window.Location.origin}`,
+      )
+      deepLinkUrl->Window.URL.searchParams->Window.URL.append("path", url)
+      Clipboard.writeText(deepLinkUrl->Window.URL.href)
+      showToast(~message="Deep link copied to Clipboard!", ~toastType=ToastSuccess)
     }
 
     <div className="flex items-center">
@@ -321,6 +336,15 @@ module CopyLinkTableCell = {
             target="_blank">
             <Icon size={14} name="external-link-alt" />
           </a>
+          <ToolTip
+            description="Copy deep link to this specific record"
+            toolTipFor={<Icon
+              name="nd-permalink"
+              className="cursor-pointer opacity-0 group-hover:opacity-70 transition-opacity h-7 py-1"
+              onClick={ev => onDeepLinkClick(ev)}
+            />}
+            toolTipPosition=ToolTip.Top
+          />
         </div>
       } else {
         "NA"->React.string


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Adds a per-record **deep link** affordance to every transaction table (payments, refunds, disputes, payouts, recon transactions) and refines the copy on the existing global permalink tooltip.

**Per-record deep link (new)**

Hovering a row in any table that uses `HSwitchOrderUtils.CopyLinkTableCell` now reveals an `nd-permalink` icon next to the existing copy and external-link icons. Clicking it builds a deep link of the form:

```
<origin>/<orgId>/<merchantId>/<profileId>/<version>/switch/user?path=<record-url>
```

…and copies it to the clipboard. The recipient, after clicking, lands on the **same page** (e.g., a specific payment's detail view) within the **same Org → Merchant → Profile context**, going through the existing `OMPSwitchUserFromURL` switch flow.

Implementation notes:
- One change in `HSwitchOrderUtils.CopyLinkTableCell` — pulls `orgId / merchantId / profileId / version` from `UserInfoProvider` and reuses the row's existing `url` prop as the `path` query param. No changes to the call sites of `CopyLinkTableCell`, so the icon shows up everywhere it is rendered (payments, refunds, disputes, payouts, recon transactions, global search tables) without any per-screen edits.
- Icon is hidden by default (`opacity-0`) and revealed on row hover via `group-hover:opacity-70`. The row already has the `group` Tailwind class set in `Table.res`, so no row-level changes were required.
- A `ToolTip` ("Copy deep link to this specific record") wraps the icon for discoverability.
- A toast ("Deep link copied to Clipboard!") confirms the copy.

**Permalink tooltip copy (refined)**

Updated the tooltip on the existing OMP permalink button (`OMPPermaLinkButton`) from
`"Copy link to this exact view for this current Organization -> Merchant -> Profile hierarchy"`
to
`"This link encodes the current Organization → Merchant → Profile context and will send recipients directly to the same page and navigation hierarchy"` — clearer about what the link does for the recipient.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Today, the only way to share a link to a specific record in the dashboard is to copy the browser URL — which works only if the recipient is already in the same Org → Merchant → Profile context. The existing OMP permalink button addresses this for the **current page**, but to share a specific row from a list view, the user has to navigate into the record first, then copy the permalink. This adds a per-row deep link action so the same context-preserving share flow works directly from any list view.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Manually verified on the Payments list:
  - Icon is hidden by default and appears on row hover.
  - Clicking the icon copies a URL of the expected `<origin>/<org>/<merchant>/<profile>/<version>/switch/user?path=/payments/<id>/<profile>/<merchant>/<org>` shape.
  - Pasting the copied link into a fresh tab navigates through `OMPSwitchUserFromURL` and lands on the correct payment detail page.
  - Toast renders on copy.
- Spot-checked the same hover icon appears on Refunds, Disputes, Payouts, and Recon Transactions tables (they share `CopyLinkTableCell`).
- Ran `npm run re:build` — clean build, no warnings.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible