### PR TITLE
feat: gate saved views UI behind dev_saved_views feature flag

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -90,6 +90,7 @@ dev_vault=true
 dev_users=true
 dev_blend_enabled=false
 dev_sort_enabled=false
+dev_saved_views=true
 [default.connector_list_for_live]
 paymentProcessors = ["adyen","authorizedotnet","archipel","airwallex","bankofamerica","bluesnap","bambora","braintree","calida","checkout","cryptopay","cashtocode","cybersource","coingate","datatrans","fiuu","gigadat","iatapay","klarna","loonio","mifinity","mollie","nexixpay","nmi","novalnet","nuvei","paypal","paybox","payme","peachpayments","redsys","stripe","trustpay","volt","worldpay","worldpayxml","zift","zsl","zen","worldpaymodular","payjustnow","payjustnowinstore","payload","finix"]
 threedsAuthProcessors = ["netcetera","juspaythreedsserver","ctp_visa"]

--- a/config/config.toml
+++ b/config/config.toml
@@ -90,7 +90,7 @@ dev_vault=true
 dev_users=true
 dev_blend_enabled=false
 dev_sort_enabled=false
-dev_saved_views=true
+dev_saved_views=false
 [default.connector_list_for_live]
 paymentProcessors = ["adyen","authorizedotnet","archipel","airwallex","bankofamerica","bluesnap","bambora","braintree","calida","checkout","cryptopay","cashtocode","cybersource","coingate","datatrans","fiuu","gigadat","iatapay","klarna","loonio","mifinity","mollie","nexixpay","nmi","novalnet","nuvei","paypal","paybox","payme","peachpayments","redsys","stripe","trustpay","volt","worldpay","worldpayxml","zift","zsl","zen","worldpaymodular","payjustnow","payjustnowinstore","payload","finix"]
 threedsAuthProcessors = ["netcetera","juspaythreedsserver","ctp_visa"]

--- a/playwright-tests/start_hyperswitch.sh
+++ b/playwright-tests/start_hyperswitch.sh
@@ -47,11 +47,11 @@ for tag in $(git tag --sort=-creatordate); do
   sed '/^\[network_tokenization_service\]/,/^\[.*\]/d' "$toml_file" > temp.toml
   mv temp.toml "$toml_file"
 
-  # Use sed to update the backup_file_path from relative to absolute path
-  # Portable sed in-place editing (works on both BSD and GNU sed)
-  sed "s|backup_file_path = \"./config/superposition_seed.toml\"|backup_file_path = \"/local/config/superposition_seed.toml\"|g" "$toml_file" > "${toml_file}.tmp"
-  mv "${toml_file}.tmp" "$toml_file"
-  
+  # Upstream seed_superposition.sh uses bash-only `for ((...))` syntax but is
+  # invoked via `sh` (busybox/ash) inside alpine. Install bash and run with bash.
+  sed 's|apk add --no-cache curl jq yq && sh /seed_superposition.sh|apk add --no-cache curl jq yq bash \&\& bash /seed_superposition.sh|g' docker-compose.yml > docker-compose.tmp
+  mv docker-compose.tmp docker-compose.yml
+
   echo "Starting docker compose..."
   
   # Start Docker Compose services in detached mode
@@ -63,6 +63,8 @@ for tag in $(git tag --sort=-creatordate); do
     docker rm -f hyperswitch-hyperswitch-server-1 || true
     docker rm -f hyperswitch-redis-standalone-1 || true
     docker rm -f hyperswitch-pg-1 || true
+    docker rm -f hyperswitch-superposition-1 || true
+    docker rm -f hyperswitch-init-1 || true
     docker network rm hyperswitch_router_net || true
     attempt=$((attempt+1))
     continue 

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -79,7 +79,7 @@ type featureFlag = {
   devBlendEnabled: bool,
   devSortEnabled: bool,
   reconEnginePermissions: bool,
-  savedViews: bool,
+  devSavedViews: bool,
 }
 
 let featureFlagType = (featureFlags: JSON.t) => {
@@ -161,7 +161,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     devBlendEnabled: dict->getBool("dev_blend_enabled", false),
     devSortEnabled: dict->getBool("dev_sort_enabled", false),
     reconEnginePermissions: dict->getBool("recon_engine_permissions", false),
-    savedViews: dict->getBool("dev_saved_views", false),
+    devSavedViews: dict->getBool("dev_saved_views", false),
   }
 }
 

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -79,6 +79,7 @@ type featureFlag = {
   devBlendEnabled: bool,
   devSortEnabled: bool,
   reconEnginePermissions: bool,
+  savedViews: bool,
 }
 
 let featureFlagType = (featureFlags: JSON.t) => {
@@ -160,6 +161,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     devBlendEnabled: dict->getBool("dev_blend_enabled", false),
     devSortEnabled: dict->getBool("dev_sort_enabled", false),
     reconEnginePermissions: dict->getBool("recon_engine_permissions", false),
+    savedViews: dict->getBool("dev_saved_views", false),
   }
 }
 

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -6,7 +6,8 @@ let make = (~previewOnly=false) => {
 
   let fetchOrdersHook = OrdersHook.useFetchOrdersHook()
   let fetchAnalyticsOrdersHook = AnalyticsOrdersHook.useFetchAnalyticsOrdersHook()
-  let {devOpensearch, savedViews} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {devOpensearch, devSavedViews} =
+    HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
   let {getCommonSessionDetails, getResolvedUserInfo, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -6,7 +6,7 @@ let make = (~previewOnly=false) => {
 
   let fetchOrdersHook = OrdersHook.useFetchOrdersHook()
   let fetchAnalyticsOrdersHook = AnalyticsOrdersHook.useFetchAnalyticsOrdersHook()
-  let {devOpensearch} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+  let {devOpensearch, savedViews} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
   let {getCommonSessionDetails, getResolvedUserInfo, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
@@ -193,7 +193,9 @@ let make = (~previewOnly=false) => {
       customLeftView={<SearchBarFilter
         placeholder="Search for payment ID" setSearchVal=setSearchText searchVal=searchText
       />}
-      customFilterActions={<SavedViewsComponent version entity=SavedViewTypes.Payment />}
+      customFilterActions={savedViews
+        ? <SavedViewsComponent version entity=SavedViewTypes.Payment />
+        : React.null}
       entityName={switch version {
       | V1 => V1(ORDER_FILTERS)
       | V2 => V2(V2_ORDER_FILTERS)

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -194,7 +194,7 @@ let make = (~previewOnly=false) => {
       customLeftView={<SearchBarFilter
         placeholder="Search for payment ID" setSearchVal=setSearchText searchVal=searchText
       />}
-      customFilterActions={savedViews
+      customFilterActions={devSavedViews
         ? <SavedViewsComponent version entity=SavedViewTypes.Payment />
         : React.null}
       entityName={switch version {

--- a/src/screens/Transaction/SavedViews/SavedViewsComponent.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsComponent.res
@@ -53,18 +53,14 @@ let make = (~version: UserInfoTypes.version=V1, ~entity: SavedViewTypes.entity=P
   let performDeleteHook = SavedViewsHooks.useDeleteSavedView(~entity, ~fetchSavedViews)
   let performDelete = async (view_id, viewName) => {
     await performDeleteHook(view_id, viewName, ~onSuccess=() => {
-      if activeViewName === viewName {
-        setActiveViewName(_ => "")
-      }
+      activeViewName === viewName ? setActiveViewName(_ => "") : ()
     })
   }
 
   let performRenameHook = SavedViewsHooks.useRenameSavedView(~entity, ~version, ~fetchSavedViews)
   let performRename = async (view: SavedViewTypes.savedView, newName) => {
     await performRenameHook(view, newName, ~onSuccess=() => {
-      if activeViewName === view.view_name {
-        setActiveViewName(_ => newName)
-      }
+      activeViewName === view.view_name ? setActiveViewName(_ => newName) : ()
     })
   }
 

--- a/src/screens/Transaction/SavedViews/SavedViewsHooks.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsHooks.res
@@ -15,11 +15,11 @@ let useFetchSavedViews = (~entity, ~version) => {
         ~methodType=Get,
         ~queryParameters=Some(SavedViewsUtils.savedViewsQueryParam(entity)),
       )
-      let res = await fetchDetails(url, ~version)
-      let mappedRes = res->SavedViewsUtils.savedViewsResponseMapper(entity)
-      setSavedViews(_ => mappedRes.views)
+      let response = await fetchDetails(url, ~version)
+      let parsedResponse = response->SavedViewsUtils.savedViewsResponseMapper(entity)
+      setSavedViews(_ => parsedResponse.views)
       switch setViewCount {
-      | Some(setCount) => setCount(_ => mappedRes.count)
+      | Some(setCount) => setCount(_ => parsedResponse.count)
       | None => ()
       }
     } catch {
@@ -45,7 +45,7 @@ let useDeleteSavedView = (~entity, ~fetchSavedViews) => {
       showToast(~message=`'${viewName}' has been deleted successfully!`, ~toastType=ToastSuccess)
 
       switch onSuccess {
-      | Some(cb) => cb()
+      | Some(callback) => callback()
       | None => ()
       }
 
@@ -77,7 +77,7 @@ let useRenameSavedView = (~entity, ~version, ~fetchSavedViews) => {
       showToast(~message=`View renamed to '${newName}' successfully!`, ~toastType=ToastSuccess)
 
       switch onSuccess {
-      | Some(cb) => cb()
+      | Some(callback) => callback()
       | None => ()
       }
 
@@ -109,8 +109,8 @@ let useCreateSavedView = (~entity, ~version, ~onViewsUpdated, ~setShowModal) => 
         ~version,
       )
       let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-      let res = await updateDetails(url, payload, Post)
-      onViewsUpdated(res, Some(trimmedName))
+      let response = await updateDetails(url, payload, Post)
+      onViewsUpdated(response, Some(trimmedName))
       showToast(~message=`New View '${trimmedName}' created successfully!`, ~toastType=ToastSuccess)
       setShowModal(_ => false)
     } catch {
@@ -146,8 +146,8 @@ let useOverwriteSavedView = (~entity, ~version, ~onViewsUpdated, ~setShowModal, 
           ~version,
         )
         let url = getURL(~entityName=V1(USERS), ~userType=#USER_DATA, ~methodType=Post)
-        let res = await updateDetails(url, payload, Post)
-        onViewsUpdated(res, Some(viewToOverwrite))
+        let response = await updateDetails(url, payload, Post)
+        onViewsUpdated(response, Some(viewToOverwrite))
         showToast(
           ~message=`'${viewToOverwrite}' has been overwritten successfully!`,
           ~toastType=ToastSuccess,


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR builds on top of #4739 (Saved Views) and adds a **remote-controlled feature flag (`dev_saved_views`)** so the UI can be rolled out incrementally instead of going to all merchants the moment #4739 merges. It also includes a small code-quality pass on the Saved Views module.

### Feature flag — `dev_saved_views`

- **New flag:** `savedViews` (config key `dev_saved_views`, default `false`).
- Wired into `FeatureFlagUtils.res` (`featureFlag` record + `featureFlagType` parser).
- Default in `config/config.toml` is `false` — the Saved Views UI is **off by default** in every environment, including dev/sandbox/integ. Operators flip it on through the feature-config service when they're ready.
- `Orders.res` now reads the flag from `HyperswitchAtom.featureFlagAtom` and renders `<SavedViewsComponent />` only when it's on (falls back to `React.null`).
- Mirrors the existing `devOpensearch` pattern (`Orders.res:9` / `Orders.res:19`).

### Code-quality improvements

`SavedViewsHooks.res`

- More descriptive identifiers for response/callback bindings — `mappedRes` → `parsedResponse`, inner `res` → `response`, `cb` → `callback` — so the data flow reads cleanly at every call site.

`SavedViewsComponent.res`

- Replaced two single-branch `if` blocks inside the delete/rename `onSuccess` callbacks with idiomatic ternary expressions, keeping the callbacks compact and consistent with the rest of the file.

## Motivation and Context

Currently #4739 ships the Saved Views UI unconditionally — there is no remote off-switch. If a regression surfaces in prod we'd have to revert the code. Putting it behind the `dev_saved_views` feature flag gives us:

- Off-by-default in every env (`config/config.toml` ships `dev_saved_views=false`).
- Per-merchant / per-env toggling through the existing feature-config service (same plumbing as `dev_opensearch`, `dev_blend_enabled`, `dev_sort_enabled`).
- Instant remote rollback without a deploy.

The code-quality pass keeps the new module consistent with the surrounding codebase conventions before it lands.

Closes #4793

## How did you test it?

- dev_saved_views=False
<img width="2539" height="1235" alt="Screenshot 2026-05-07 at 7 24 29 PM" src="https://github.com/user-attachments/assets/893f6036-8f1b-4a24-b457-9d484da2fb9f" />
- dev_saved_views=True
<img width="2023" height="869" alt="Screenshot 2026-05-07 at 7 26 45 PM" src="https://github.com/user-attachments/assets/a0669c59-777f-4a52-8255-7b9bfa143d91" />


## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD


## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
