### PR TITLE
fix: persist and restore amount filter correctly in saved views

### DIFF
--- a/src/screens/Transaction/SavedViews/SaveViewModalComp.res
+++ b/src/screens/Transaction/SavedViews/SaveViewModalComp.res
@@ -234,6 +234,7 @@ let make = (
       filtersDict->Dict.delete(OrderUIUtils.startTimeFilterKey(version))
       filtersDict->Dict.delete(OrderUIUtils.endTimeFilterKey(version))
     }
+    filtersDict->Dict.delete("amount_filter")
     SavedViewsUtils.foldAmountOption(filtersDict)
     filtersDict->JSON.Encode.object
   }

--- a/src/screens/Transaction/SavedViews/SavedViewTypes.res
+++ b/src/screens/Transaction/SavedViews/SavedViewTypes.res
@@ -75,8 +75,8 @@ type filterKeyKind =
   | FlattenRoot
   | Prefixed(string)
 
-let classifyFilterKey = (k: string): filterKeyKind =>
-  switch k {
+let classifyFilterKey = (filterKey: string): filterKeyKind =>
+  switch filterKey {
   | "amount_filter" | "" => FlattenRoot
-  | k => Prefixed(k)
+  | filterKey => Prefixed(filterKey)
   }

--- a/src/screens/Transaction/SavedViews/SavedViewTypes.res
+++ b/src/screens/Transaction/SavedViews/SavedViewTypes.res
@@ -70,3 +70,13 @@ type savedViewsResponse = {
   count: int,
   views: array<savedView>,
 }
+
+type filterKeyKind =
+  | FlattenRoot
+  | Prefixed(string)
+
+let classifyFilterKey = (k: string): filterKeyKind =>
+  switch k {
+  | "amount_filter" | "" => FlattenRoot
+  | k => Prefixed(k)
+  }

--- a/src/screens/Transaction/SavedViews/SavedViewsUtils.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsUtils.res
@@ -83,9 +83,9 @@ let flattenToDict = (dictToSet, key, value) => {
         dict
         ->Dict.toArray
         ->Array.forEach(((innerK, innerV)) => {
-          let newK = switch k {
-          | "amount_filter" | "" => innerK
-          | _ => `${k}.${innerK}`
+          let newK = switch SavedViewTypes.classifyFilterKey(k) {
+          | FlattenRoot => innerK
+          | Prefixed(prefix) => `${prefix}.${innerK}`
           }
           filtersToFlatten->Array.push((newK, innerV))->ignore
         })

--- a/src/screens/Transaction/SavedViews/SavedViewsUtils.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsUtils.res
@@ -82,12 +82,12 @@ let flattenToDict = (dictToSet, key, value) => {
       | Object(dict) =>
         dict
         ->Dict.toArray
-        ->Array.forEach(((innerK, innerV)) => {
-          let newK = switch SavedViewTypes.classifyFilterKey(k) {
-          | FlattenRoot => innerK
-          | Prefixed(prefix) => `${prefix}.${innerK}`
+        ->Array.forEach(((nestedKey, nestedValue)) => {
+          let flattenedKey = switch SavedViewTypes.classifyFilterKey(k) {
+          | FlattenRoot => nestedKey
+          | Prefixed(prefix) => `${prefix}.${nestedKey}`
           }
-          filtersToFlatten->Array.push((newK, innerV))->ignore
+          filtersToFlatten->Array.push((flattenedKey, nestedValue))->ignore
         })
       | _ =>
         let strVal = jsonValueToString(v)

--- a/src/screens/Transaction/SavedViews/SavedViewsUtils.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsUtils.res
@@ -83,7 +83,10 @@ let flattenToDict = (dictToSet, key, value) => {
         dict
         ->Dict.toArray
         ->Array.forEach(((innerK, innerV)) => {
-          let newK = k->isNonEmptyString ? `${k}.${innerK}` : innerK
+          let newK = switch k {
+          | "amount_filter" | "" => innerK
+          | _ => `${k}.${innerK}`
+          }
           filtersToFlatten->Array.push((newK, innerV))->ignore
         })
       | _ =>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Follow-up fix on top of #4739 (Saved Views). A saved view that included an **amount filter** did not work end-to-end:

- On **apply**, the amount filter was not restored — the chip never appeared and the list query went out with the amount bounds dropped.
- The **active view name** did not stay highlighted in the dropdown after applying such a view (it cleared immediately, and only "stuck" on a second click of the same view).

### Root cause

The amount filter round-trips through two representations that were out of sync:

- **Save** — `SaveViewModalComp.buildFilters` builds the view from `mergedFilters`, which includes `filterValueJson`. The query context carries an `amount_filter` object that `AmountFilterUtils.createAmountQuery` injects in **minor units** (`x100`). When `foldAmountOption` found no `amount_option` in form state it returned early, so that scaled object leaked straight into the saved view.
- **Apply** — `SavedViewsUtils.flattenToDict` flattens nested objects with a dotted prefix, so the saved `amount_filter` object became the key `amount_filter.start_amount`. Neither the `AmountFilter` form (which reads flat `start_amount` / `end_amount`) nor `findMatchingView` could read that key — so the filter never applied and the view never matched as "active".

### Changes

`SaveViewModalComp.res`

- `buildFilters` now drops the `amount_filter` query artifact before `foldAmountOption` runs, so a view is saved purely from the major-unit form values (`start_amount` / `end_amount` / `amount_option`) — as entered by the user.

`SavedViewsUtils.res`

- `flattenToDict` now un-nests `amount_filter` into flat `start_amount` / `end_amount` keys instead of emitting dotted `amount_filter.start_amount`. Every other nested object (e.g. `order`) keeps its dotted path. Because both `getApplyFilters` and `findMatchingView` go through `flattenToDict`, this fixes apply **and** view-name matching from a single place.

## Motivation and Context

#4739 shipped Saved Views, but the amount filter — the one filter stored as a nested object and scaled to minor units for the query — did not survive the save/apply round-trip. This made saved views unreliable for any merchant filtering on amount, and the disappearing view name made it look like the view had not been applied at all.

After this fix the round-trip is consistent in major units:

```
user enters 100
  -> saved as   amount_filter: { start_amount: 100 }
  -> applied as start_amount: "100"
  -> AmountFilter shows "More or Equal to 100", view name stays highlighted
```

Closes #4813

## How did you test it?

- Created saved views with each amount range type (Greater than or Equal to, Less than or Equal to,  In Between) and confirmed the filter is restored correctly on apply.
- Confirmed the active view name stays highlighted in the dropdown on the first click, and clears correctly when filters are subsequently changed.
- Verified non-amount views (status, connector, date range) continue to apply and match as before.

Uploading Screen Recording 2026-05-14 at 4.21.56 PM.mov…



## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
