### PR TITLE
fix: prevent recon bulk actions card from overlapping table rows and pagination

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
@@ -64,7 +64,7 @@ let make = (
         rowData: entriesWithUniqueId->Array.map(entry => entry->Identity.genericTypeToJson),
       }
     })
-  }, (groupedEntries, accountInfoMap, detailsFields, currentExceptionDetails.transaction_status))
+  }, (groupedEntries, accountInfoMap, currentExceptionDetails.transaction_status))
 
   let onSubmit = async (values, _form: ReactFinalForm.formApi) => {
     try {
@@ -144,7 +144,7 @@ let make = (
     />
     <ReconEngineCustomExpandableSelectionTable
       title=""
-      heading={detailsFields->Array.map(getHeading)}
+      heading={getDetailFieldsForTableSections->Array.map(getHeading)}
       getSectionRowDetails=sectionDetails
       showScrollBar=true
       showOptions={exceptionStage == ResolvingException(EditEntry) ||

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionEntries.res
@@ -161,7 +161,7 @@ let make = (
       exceptionStage == ConfirmResolution(MarkAsReceived) ||
       exceptionStage == ConfirmResolution(LinkStagingEntriesToTransaction)}>
       <div
-        className="flex flex-row items-center gap-3 absolute right-1/2 bottom-10 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
+        className="flex flex-row items-center gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
         <div className="flex gap-3">
           <Button
             text="Discard"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
@@ -867,7 +867,7 @@ let make = (
           </div>
           <RenderIf condition={exceptionStage == ShowResolutionOptions(FixEntries)}>
             <div
-              className="flex flex-row gap-3 absolute right-1/2 bottom-10 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl px-3 py-4">
+              className="flex flex-row gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl px-3 py-4">
               <Button
                 buttonState=Normal
                 buttonSize=Medium
@@ -916,7 +916,7 @@ let make = (
       {switch bottomBarConfig {
       | Some(config) =>
         <div
-          className="flex flex-row items-center gap-3 absolute right-1/2 bottom-10 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
+          className="flex flex-row items-center gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
           <Button
             buttonType=Secondary
             buttonSize=Medium

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryBulkActions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryBulkActions.res
@@ -88,7 +88,7 @@ let make = (~selectedRows, ~setSelectedRows, ~refreshList) => {
 
   <div>
     <div
-      className="flex flex-row items-center gap-3 absolute right-1/2 bottom-8 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
+      className="flex flex-row items-center gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
       <p className={`${body.md.semibold} text-nd_gray-500`}>
         {`${selectedRows->Array.length->Int.toString} Selected`->React.string}
       </p>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionEntry.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionEntry.res
@@ -144,7 +144,7 @@ let make = (
     />
     <RenderIf condition={exceptionStage == ConfirmTransformedEntryResolution(EditTransformedEntry)}>
       <div
-        className="flex flex-row items-center gap-3 absolute right-1/2 bottom-10 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
+        className="flex flex-row items-center gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
         <div className="flex gap-3">
           <Button
             text="Discard"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionComponents/ReconEngineTransactionsBulkActions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionComponents/ReconEngineTransactionsBulkActions.res
@@ -128,7 +128,7 @@ let make = (
 
   <div>
     <div
-      className="flex flex-row items-center gap-3 absolute right-1/2 bottom-8 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
+      className="flex flex-row items-center gap-3 fixed left-1/2 -translate-x-1/2 bottom-4 z-50 border border-nd_gray-200 bg-nd_gray-0 shadow-lg rounded-2xl p-3">
       <p className={`${body.md.semibold} text-nd_gray-500`}>
         {`${selectedRows->Array.length->Int.toString} Selected`->React.string}
       </p>


### PR DESCRIPTION
## Type of Change

  - [x] Bugfix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description

  Fixed the floating bulk actions card in the Recon Engine Transactions and Transformed Entry Exceptions screens.

  - Switched the card from `absolute` to `fixed` positioning so it stays pinned to the viewport instead of scrolling out of view when the table has many
  rows.
  - Replaced `right-1/2` with `left-1/2 -translate-x-1/2` to properly horizontally center the card.
  - Added `z-50` so the card stays above table rows instead of overlapping behind them.
  - Adjusted the bottom offset so the card no longer collides with the pagination controls on smaller screens.

  Files changed:
  - `src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngi
  neTransformedEntryBulkActions.res`
  - `src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionComponents/ReconEngineTransactionsBulkActions.res`
  

  ## Motivation and Context

  The bulk actions card was positioned with `absolute bottom-8`, which made it relative to the nearest positioned ancestor. When the table grew with more
  rows, the card got pushed down with the content and became inaccessible. On smaller screens it also overlapped the pagination controls, blocking page
  navigation.

  ## How did you test it?

  Locally
  

  ## Where to test it?

  - [ ] INTEG
  - [x] SANDBOX
  - [x] PROD

  ## Checklist

  - [x] I ran `npm run re:build`
  - [x] I reviewed submitted code
  - [ ] I added unit tests for my changes where possible