### PR TITLE
fix: remove empty chart area in recon overview cards when no transactions

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryComponents/ReconEngineOverviewSummaryStackedBarGraphs.res
@@ -78,23 +78,70 @@ module RuleWiseStackedBarGraph = {
       customLoader={<Shimmer styleClass="h-44 w-full rounded-xl" />}>
       <div
         key={rule.rule_id}
-        className="flex flex-col space-y-2 items-start border rounded-xl border-nd_gray-150 px-4 pt-3 pb-4">
+        className="flex flex-col gap-3 items-start border rounded-xl border-nd_gray-150 px-4 pt-3 pb-4">
         <p className={`text-nd_gray-500 ${body.sm.medium}`}> {rule.rule_name->React.string} </p>
         <p className={`text-nd_gray-800 ${heading.md.semibold}`}>
           {`${reconciliationPercentage->valueFormatter(Rate)}`->React.string}
         </p>
-        <div className="w-full">
-          <StackedBarGraph
-            options={StackedBarGraphUtils.getStackedBarGraphOptions(
-              stackedBarGraphData,
-              ~yMax=totalTransactions,
-              ~labelItemDistance={isMiniLaptopView ? 45 : 80},
-              ~pointWidth=12,
-              ~onPointClick=seriesName =>
-                ReconEngineOverviewUtils.handleBarClick(~rule, seriesName),
-            )}
-          />
-        </div>
+        {if totalTransactions > 0 {
+          <div className="w-full">
+            <StackedBarGraph
+              options={StackedBarGraphUtils.getStackedBarGraphOptions(
+                stackedBarGraphData,
+                ~yMax=totalTransactions,
+                ~labelItemDistance={isMiniLaptopView ? 45 : 80},
+                ~pointWidth=12,
+                ~onPointClick=seriesName =>
+                  ReconEngineOverviewUtils.handleBarClick(~rule, seriesName),
+              )}
+            />
+          </div>
+        } else {
+          <div className="flex gap-4 flex-wrap">
+            <div className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={ReactDOM.Style.make(~backgroundColor=ReconEngineOverviewUtils.matchedColor, ())}
+              />
+              <span className={`text-nd_gray-500 ${body.sm.medium}`}>
+                {"Matched"->React.string}
+              </span>
+              <span className="text-nd_gray-400 mx-0.5"> {"|"->React.string} </span>
+              <span className={`text-nd_gray-700 ${body.sm.semibold}`}>
+                {matchedCount->Int.toString->React.string}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={ReactDOM.Style.make(~backgroundColor=ReconEngineOverviewUtils.expectedColor, ())}
+              />
+              <span className={`text-nd_gray-500 ${body.sm.medium}`}>
+                {"Expected"->React.string}
+              </span>
+              <span className="text-nd_gray-400 mx-0.5"> {"|"->React.string} </span>
+              <span className={`text-nd_gray-700 ${body.sm.semibold}`}>
+                {expectedCount->Int.toString->React.string}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className="inline-block w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={ReactDOM.Style.make(
+                  ~backgroundColor=ReconEngineOverviewUtils.mismatchedColor,
+                  (),
+                )}
+              />
+              <span className={`text-nd_gray-500 ${body.sm.medium}`}>
+                {"Mismatched"->React.string}
+              </span>
+              <span className="text-nd_gray-400 mx-0.5"> {"|"->React.string} </span>
+              <span className={`text-nd_gray-700 ${body.sm.semibold}`}>
+                {mismatchedCount->Int.toString->React.string}
+              </span>
+            </div>
+          </div>
+        }}
       </div>
     </PageLoaderWrapper>
   }


### PR DESCRIPTION
## Summary
- When all transaction counts are zero, the Highcharts stacked bar chart rendered an 80px empty area between the reconciliation percentage and the legend, making the overview cards look broken and sparse
- Now shows a compact colored stat row (Matched | Expected | Mismatched) directly below the percentage when `totalTransactions === 0`
- The full stacked bar chart only mounts when there is actual data to display

## Screenshots
**Before**: Large empty space between `0.00%` and the legend due to blank Highcharts chart area

**After**: Clean compact stat row sits immediately below the percentage with no wasted space

## Test plan
- [ ] Navigate to Recon Overview with no transaction data — cards should show compact stat row with `Matched | 0`, `Expected | 0`, `Mismatched | 0`
- [ ] Navigate to Recon Overview with transaction data — cards should still show the full stacked bar chart with legend
- [ ] Verify no visual regressions on other tabs (Life3 ↔ GDPP, GDPP ↔ Adyen Settlement, etc.)