### PR TITLE
feat(routing): improve UX for routing tab labels and empty states

### DIFF
--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -27,20 +27,21 @@ let make = (~remainingPath, ~previewOnly=false) => {
     let hasWorkflowsManageAccess = userHasAccess(~groupAccess=WorkflowsManage) === Access
     let baseTabs = [
       {
-        title: "Active configuration",
+        title: "Current Routing Setup",
         renderContent: () => <ActiveRouting routingType />,
       },
     ]
     hasWorkflowsManageAccess
       ? baseTabs->Array.concat([
           {
-            title: "Manage rules",
+            title: "Custom Routing Rules",
             renderContent: () => {
               records->Array.length > 0
                 ? <History records activeRoutingIds />
                 : <DefaultLandingPage
                     height="90%"
-                    title="No Routing Rule Configured!"
+                    title="No Custom Rules Configured"
+                    subtitle="Custom routing rules you create will appear here. Your payments are currently using system defaults visible in the Current Routing Setup tab."
                     customStyle="py-16"
                     overridingStylesTitle="text-3xl font-semibold"
                   />


### PR DESCRIPTION
## Summary

Improves the UX of the Smart Routing tabs to clearly distinguish between system-managed routing and user-created custom rules.

## Problem

Users were confused seeing the **"Manage rules"** tab showing _"No Routing Rule Configured!"_ even when routing was active. The root cause:

- **"Active configuration"** shows ALL active routing including system defaults (Default Fallback, Dynamic/LCR routing stored in `business_profile` table)
- **"Manage rules"** only shows custom user-created rules from the `routing_algorithm` table

The tab names didn't communicate this distinction, leading to the false impression that routing was broken.

## Changes

**File:** `src/screens/Routing/RoutingStack.res` — 4 line changes, 1 file only

| Before | After |
|--------|-------|
| Tab: `"Active configuration"` | Tab: `"Current Routing Setup"` |
| Tab: `"Manage rules"` | Tab: `"Custom Routing Rules"` |
| Empty state: `"No Routing Rule Configured!"` | Empty state: `"No Custom Rules Configured"` |
| Empty state: *(no subtitle)* | Subtitle explaining system defaults are visible in the other tab |

## Test Evidence

- ✅ `npm run re:build` — 1,283 files compiled, no errors
- ✅ `npm run build` — bundle generated successfully

## Type of Change

- [x] UX/copy improvement — no functional changes, no API changes, no schema changes

## Checklist

- [x] Single file changed
- [x] Build passes
- [x] No functional logic modified — UI text only