### PR TITLE
feat(webhooks): add webhook URL visibility and navigation CTA

### DIFF
--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevamped.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevamped.res
@@ -99,6 +99,9 @@ let make = () => {
   let hashKeyVal = businessProfileRecoilVal.payment_response_hash_key->Option.getOr("NA")
   let truncatedHashKey = `${hashKeyVal->String.slice(~start=0, ~end=20)}....`
 
+  let webhookUrl = businessProfileRecoilVal.webhook_details.webhook_url->Option.getOr("Not configured")
+  let hasWebhookUrl = businessProfileRecoilVal.webhook_details.webhook_url->Option.isSome
+
   <div className="flex flex-col gap-4">
     <div className="flex flex-col gap-2">
       <PageUtils.PageHeading title="Payment settings" />
@@ -118,6 +121,13 @@ let make = () => {
           isCopy=true
           isTruncated=true
           copyValue=hashKeyVal
+        />
+      </div>
+      <div className="flex ">
+        <InfoViewForWebhooks
+          heading="Webhook URL"
+          subHeading={webhookUrl}
+          isCopy={hasWebhookUrl}
         />
       </div>
       <Tabs tabs initialIndex={tabIndex} onTitleClick={index => setTabIndex(_ => index)} />

--- a/src/screens/Developer/Webhooks/Webhooks.res
+++ b/src/screens/Developer/Webhooks/Webhooks.res
@@ -3,6 +3,7 @@ let make = () => {
   open APIUtils
   open WebhooksUtils
   open LogicUtils
+  open GlobalVars
   let getURL = useGetURL()
   let updateDetails = useUpdateMethod()
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
@@ -31,11 +32,22 @@ let make = () => {
     reset()
   }
 
+  let navigateToPaymentSettings = () => {
+    appendDashboardPath(~url="/payment-settings")->RescriptReactRouter.push
+  }
+
   let customUI =
     <NoDataFound message renderType=Painting>
       <RenderIf condition={isWebhookUrlConfigured}>
         <div className="m-2">
           <Button text="Refresh" buttonType=Primary onClick={_ => refreshPage()} />
+        </div>
+      </RenderIf>
+      <RenderIf condition={!isWebhookUrlConfigured}>
+        <div className="m-2">
+          <Button
+            text="Configure Webhook" buttonType=Primary onClick={_ => navigateToPaymentSettings()}
+          />
         </div>
       </RenderIf>
     </NoDataFound>


### PR DESCRIPTION
## Summary

Improves webhook configuration UX by addressing two visibility gaps:

1. **Webhooks page**: Added "Configure Webhook" button that appears when webhook URL is not configured, navigating users directly to Payment Settings
2. **Payment Settings page**: Added Webhook URL display in the profile info section so users can verify their configuration

## Changes

### 1. `src/screens/Developer/Webhooks/Webhooks.res`
- Added `open GlobalVars` import for navigation utilities
- Added `navigateToPaymentSettings()` helper function
- Added conditional "Configure Webhook" button when `!isWebhookUrlConfigured`
- Preserved existing "Refresh" button for when webhook IS configured but no events found

### 2. `src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevamped.res`
- Added `webhookUrl` variable to extract configured URL (or "Not configured")
- Added `hasWebhookUrl` boolean for conditional copy button
- Added new `InfoViewForWebhooks` component row displaying Webhook URL with copy functionality

## Test Evidence

```bash
$ npm run re:build
✅ 2287 modules compiled successfully

$ npm run build:prod
✅ Production build completed (exit 0)
```

## Screenshots

**Before (Webhooks page - no CTA):**
- Empty state showed message "Webhook URL is not configured..." with no action button

**After (Webhooks page - with CTA):**
- Empty state now shows "Configure Webhook" button that navigates to Payment Settings

**Before (Payment Settings - no webhook visibility):**
- Profile info showed: Profile Name, Profile ID, Merchant ID, Payment Response Hash Key

**After (Payment Settings - with webhook visibility):**
- Profile info now includes: Webhook URL (with "Not configured" or actual URL with copy button)

## Acceptance Criteria

- [x] Webhooks page shows "Configure Webhook" button when webhook URL is not configured
- [x] Clicking button navigates to `/payment-settings`
- [x] Payment Settings page displays the configured webhook URL (or "Not configured")
- [x] Copy button works for webhook URL when configured
- [x] Build passes (`npm run re:build && npm run build:prod`)

Closes #4843