### PR TITLE
fix: spacing inconsistencies in PaymentSettingsRevamped files

### DIFF
--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsCustomMetadataHeaders.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsCustomMetadataHeaders.res
@@ -133,7 +133,7 @@ module MetadataHeaders = {
     }, [])
 
     <div className="flex-1">
-      <div className="flex flex-row justify-between items-center gap-4 ">
+      <div className="flex flex-row justify-between items-center gap-4">
         <p
           className={`ml-1 ${body.lg.semibold} dark:text-jp-gray-text_darktheme dark:text-opacity-50 !text-nd_gray-700 mt-6 `}>
           {"Custom Metadata Headers"->React.string}

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsCustomWebhookHeaders.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsCustomWebhookHeaders.res
@@ -130,7 +130,7 @@ module WebHookAuthenticationHeaders = {
     }, [])
 
     <div className="flex-1">
-      <div className="flex flex-row justify-between items-center gap-4 ">
+      <div className="flex flex-row justify-between items-center gap-4">
         <p
           className={`${body.lg.semibold} dark:text-jp-gray-text_darktheme dark:text-opacity-50 !text-nd_gray-700 ml-1 mt-6`}>
           {"Custom Headers"->React.string}
@@ -144,7 +144,7 @@ module WebHookAuthenticationHeaders = {
           </div>
         </RenderIf>
       </div>
-      <div className="grid grid-cols-5 ">
+      <div className="grid grid-cols-5">
         {Array.fromInitializer(~length=4, i => i)
         ->Array.mapWithIndex((_, index) =>
           <div key={index->Int.toString} className="-ml-3 col-span-4">

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsDomainName.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsDomainName.res
@@ -32,7 +32,7 @@ module PaymentLinkDomainFields = {
 
     <>
       <div className="flex flex-row justify-between items-center gap-6">
-        <p className={`!text-nd_gray-700  !${heading.sm.semibold}`}>
+        <p className={`!text-nd_gray-700 !${heading.sm.semibold}`}>
           {"Payment Link Domain"->React.string}
         </p>
         <RenderIf condition={!(paymentLinkConfigDict->isEmptyDict) && isDisabled && !allowEdit}>

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsPaymentBehaviour.res
@@ -37,7 +37,7 @@ module CollectDetails = {
     }
 
     <DesktopRow itemWrapperClass="mx-1">
-      <div className="w-full py-8 ">
+      <div className="w-full py-8">
         <div className="flex justify-between items-center">
           <div className="flex-1 ">
             <p className={`${body.lg.semibold} text-nd_gray-700`}> {title->React.string} </p>
@@ -47,7 +47,7 @@ module CollectDetails = {
             isSelected={initValue}
             setIsSelected={handleToggle}
             isDisabled=false
-            boolCustomClass="rounded-lg  "
+            boolCustomClass="rounded-lg"
             toggleEnableColor="bg-nd_primary_blue-450"
           />
         </div>
@@ -57,13 +57,13 @@ module CollectDetails = {
             ->Array.mapWithIndex((option, index) =>
               <div
                 key={index->Int.toString}
-                className="flex gap-2  items-center cursor-pointer"
+                className="flex gap-2 items-center cursor-pointer"
                 onClick={_ => onClick(option.key)}>
                 <RadioIconAdapter
                   isSelected={valuesDict->getBool(option.key, false)}
                   fill="text-nd_primary_blue-450"
                 />
-                <div className={`${body.md.medium}text-nd_gray-700`}>
+                <div className={`${body.md.medium} text-nd_gray-700`}>
                   {option.name->LogicUtils.snakeToTitle->React.string}
                 </div>
               </div>
@@ -91,7 +91,7 @@ module AutoRetries = {
       <DesktopRow itemWrapperClass="mx-1">
         <FieldRenderer
           labelClass={`!${body.lg.semibold} !text-nd-gray-700`}
-          fieldWrapperClass="w-full flex justify-between items-center py-8 "
+          fieldWrapperClass="w-full flex justify-between items-center py-8"
           field={makeFieldInfo(
             ~name="is_auto_retries_enabled",
             ~label="Auto Retries",
@@ -145,7 +145,7 @@ module ClickToPaySection = {
           <div>
             <FieldRenderer
               labelClass={`!${body.lg.semibold} !text-nd-gray-700`}
-              fieldWrapperClass="w-full flex justify-between items-center pt-8 pb-8  "
+              fieldWrapperClass="w-full flex justify-between items-center pt-8 pb-8"
               field={makeFieldInfo(
                 ~name="is_click_to_pay_enabled",
                 ~label="Click to Pay",
@@ -304,7 +304,7 @@ module MerchantCategoryCode = {
         field={merchantCodeWithNameArray->DeveloperUtils.merchantCategoryCode}
         errorClass
         labelClass={`!${body.lg.semibold} !text-nd-gray-700`}
-        fieldWrapperClass="max-w-xl py-8 "
+        fieldWrapperClass="max-w-xl py-8"
       />
     </DesktopRow>
   }
@@ -429,7 +429,7 @@ let make = () => {
         <DesktopRow itemWrapperClass="mx-1">
           <FieldRenderer
             labelClass={`!${body.lg.semibold} !text-nd-gray-700`}
-            fieldWrapperClass="w-full flex justify-between sitems-center border-nd_gray-200 py-8"
+            fieldWrapperClass="w-full flex justify-between items-center border-nd_gray-200 py-8"
             field={makeFieldInfo(
               ~name="is_manual_retry_enabled",
               ~label="Manual Retries",
@@ -523,7 +523,7 @@ let make = () => {
             ~label="Connector Agnostic",
             ~customInput=InputFields.boolInput(
               ~isDisabled=false,
-              ~boolCustomClass="rounded-lg ",
+              ~boolCustomClass="rounded-lg",
               ~toggleEnableColor="bg-nd_primary_blue-450",
             ),
           )}

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevamped.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevamped.res
@@ -11,7 +11,7 @@ module InfoViewForWebhooks = {
     <div className={`flex flex-col gap-2 mx-1 my-4 w-1/3`}>
       <p className="font-medium text-fs-14 text-nd_gray-400"> {heading->React.string} </p>
       <div className="flex gap-2 break-all w-full items-start">
-        <p className="font-medium text-fs-16 text-nd_gray-600 "> {subHeading->React.string} </p>
+        <p className="font-medium text-fs-16 text-nd_gray-600"> {subHeading->React.string} </p>
         <RenderIf condition={isCopy}>
           <Icon
             name="nd-copy"
@@ -110,7 +110,7 @@ let make = () => {
         />
         <InfoViewForWebhooks heading="Profile ID" subHeading=profileId isCopy=true />
       </div>
-      <div className="flex ">
+      <div className="flex">
         <InfoViewForWebhooks heading="Merchant ID" subHeading=merchantId />
         <InfoViewForWebhooks
           heading="Payment Response Hash Key"

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsThreeDs.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsThreeDs.res
@@ -116,7 +116,7 @@ let make = () => {
               ~label="Force 3DS Challenge",
               ~customInput=InputFields.boolInput(
                 ~isDisabled=false,
-                ~boolCustomClass="rounded-lg ",
+                ~boolCustomClass="rounded-lg",
                 ~toggleEnableColor="bg-nd_primary_blue-450",
               ),
             )}
@@ -131,7 +131,7 @@ let make = () => {
             ->authenticationConnectors}
             errorClass
             labelClass={`!${body.lg.semibold} !text-nd_gray-700`}
-            fieldWrapperClass="max-w-sm  "
+            fieldWrapperClass="max-w-sm"
           />
           <ThreeDsRequestorUrl />
           <ThreeDsAppUrl />


### PR DESCRIPTION
## Summary

Fix spacing inconsistencies in Developer Settings PaymentSettingsRevamped components.

## Changes Made

Fixed various spacing issues across 6 files:

### Trailing Spaces Removed
- `PaymentSettingsRevamped.res`: Removed trailing spaces in `className` attributes
- `PaymentSettingsThreeDs.res`: Removed trailing spaces from CSS classes
- `PaymentSettingsCustomMetadataHeaders.res`: Cleaned up className formatting
- `PaymentSettingsCustomWebhookHeaders.res`: Fixed spacing in multiple className strings

### Double Spaces Fixed
- `PaymentSettingsDomainName.res`: Fixed double space in className concatenation
- `PaymentSettingsPaymentBehaviour.res`: Fixed multiple double-space issues

### Other Fixes
- `PaymentSettingsPaymentBehaviour.res`: 
  - Fixed typo `sitems-center` → `items-center`
  - Added missing space in template string interpolation `${body.md.medium} text-nd_gray-700`

## Testing

- ✅ Build passes (`npm ci`, `npm run re:build`, `npm run build`)
- ✅ ReScript compilation: 3841 files compiled successfully
- ✅ No runtime behavior changes - purely cosmetic fixes

## Related Issue

Closes #4853