### PR TITLE
style(transaction): fix trailing spaces in className attributes

### DIFF
--- a/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
+++ b/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
@@ -50,7 +50,7 @@ module EvidenceUploadForm = {
           fileUploadedDict->getDictfromDict(uploadEvidenceType)->getString("fileName", "")
         let truncatedFileName = truncateFileNameWithEllipses(~fileName, ~maxTextLength=10)
 
-        <div className="flex gap-4 items-center ">
+        <div className="flex gap-4 items-center">
           <p className={`${p1RegularText} text-grey-700`}> {truncatedFileName->React.string} </p>
           <Icon
             name="cross-skeleton"

--- a/src/screens/Transaction/Order/HSwitchOrderUtils.res
+++ b/src/screens/Transaction/Order/HSwitchOrderUtils.res
@@ -296,7 +296,7 @@ module CopyLinkTableCell = {
             condition={!isTextVisible &&
             displayValue->isNonEmptyString &&
             displayValue->String.length > endValue}>
-            <div className="flex text-nowrap gap-1 ">
+            <div className="flex text-nowrap gap-1">
               <p className={`${customTextCss} overflow-hidden`}>
                 {`${displayValue->String.slice(~start=0, ~end=endValue)}`->React.string}
               </p>

--- a/src/screens/Transaction/Order/OrderRefundForm.res
+++ b/src/screens/Transaction/Order/OrderRefundForm.res
@@ -196,7 +196,7 @@ let make = (
       <div className="flex flex-col w-full max-w-4xl mx-auto p-6">
         <div
           className="border-b border-jp-gray-940 border-opacity-75 dark:border-jp-gray-960 dark:border-opacity-75 pb-4 mb-6">
-          <div className="flex flex-row justify-between items-center ">
+          <div className="flex flex-row justify-between items-center">
             <CardUtils.CardHeader
               heading="Initiate Refund" subHeading="" customSubHeadingStyle=""
             />
@@ -207,7 +207,7 @@ let make = (
               labelMargin="mt-0 py-0 "
             />
           </div>
-          <div className="flex text-fs-13 ">
+          <div className="flex text-fs-13">
             <Icon size={14} name="exclamation-circle" className="text-red-600 mr-2 mt-1" />
             <span className="font-medium text-jp-gray-700 mt-2">
               {React.string(

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -375,7 +375,7 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
       (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder as _) =>
         InputFields.textInput(
           ~rightIcon=<div
-            className="p-1 rounded-lg hover:bg-gray-200 cursor-pointer mr-6 "
+            className="p-1 rounded-lg hover:bg-gray-200 cursor-pointer mr-6"
             onClick={_ => input.name->onDeleteClick}>
             <Icon name="cross-outline" size=13 />
           </div>,

--- a/src/screens/Transaction/Order/ShowOrder.res
+++ b/src/screens/Transaction/Order/ShowOrder.res
@@ -589,7 +589,7 @@ module FraudRiskBanner = {
   let make = (~frmMessage: frmMessage, ~refElement: React.ref<Js.nullable<Dom.element>>) => {
     let {globalUIConfig: {font: {textColor}}} = React.useContext(ThemeProvider.themeContext)
     <div
-      className="flex justify-between items-center w-full  p-4 rounded-md bg-white border border-[#C04141]/50 ">
+      className="flex justify-between items-center w-full  p-4 rounded-md bg-white border border-[#C04141]/50">
       <div className="flex gap-2">
         <img alt="image" src={`/icons/redFlag.svg`} />
         <p className="text-lightgray_background font-medium text-fs-16">


### PR DESCRIPTION
## Description

This PR fixes trailing space inconsistencies in className attributes across Transaction screen files.

### Changes Made
- Fixed 6 trailing space issues in 5 files:
  - `src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res`
  - `src/screens/Transaction/Order/HSwitchOrderUtils.res`
  - `src/screens/Transaction/Order/OrderRefundForm.res` (2 fixes)
  - `src/screens/Transaction/Order/OrderUIUtils.res`
  - `src/screens/Transaction/Order/ShowOrder.res`

### Type of Change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (code quality/improvements)
- [ ] Documentation update

### How did you test it?
- Built the project: `npm run re:build` - All 3,839 ReScript files compiled successfully
- No functional changes, only whitespace cleanup

### Checklist
- [x] I reviewed my code before submitting
- [x] I followed the coding style guidelines
- [x] I added/updated no new dependencies