### PR TITLE
fix(sidebar): hide Configure PMTs from platform merchant accounts

### DIFF
--- a/src/entryPoints/SidebarHooks.res
+++ b/src/entryPoints/SidebarHooks.res
@@ -102,6 +102,7 @@ let useGetHsSidebarValues = () => {
       ~devModularityV2Enabled=devModularityV2,
       ~devThemeEnabled=devTheme,
       ~devUsers,
+      ~isCurrentMerchantPlatform,
     ),
   ]
 }

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -532,10 +532,11 @@ let settings = (
   ~devModularityV2Enabled,
   ~devThemeEnabled,
   ~devUsers,
+  ~isCurrentMerchantPlatform,
 ) => {
   let settingsLinkArray = []
 
-  if isConfigurePmtsEnabled {
+  if isConfigurePmtsEnabled && !isCurrentMerchantPlatform {
     settingsLinkArray->Array.push(configurePMTs(userHasResourceAccess))->ignore
   }
 


### PR DESCRIPTION
## Summary
Platform merchant accounts were seeing the "Configure PMTs" menu item in the Settings section but didn't have access to it. This PR hides the menu item for platform merchants.

## Changes
- `src/entryPoints/SidebarValues.res`: Add `~isCurrentMerchantPlatform` parameter to `settings()` function and hide Configure PMTs when merchant is a platform account
- `src/entryPoints/SidebarHooks.res`: Pass `~isCurrentMerchantPlatform` to the `settings()` call

## Test Evidence
```bash
npm run re:build  # ✅ 3836/3836 modules compiled
npm run build     # ✅ Build successful
```

## How to test
1. Log in as a platform merchant account
2. Navigate to Settings section in sidebar
3. Verify "Configure PMTs" is NOT visible
4. Log in as a non-platform merchant account
5. Verify "Configure PMTs" IS visible (if feature flag enabled)

## Checklist
- [x] I ran `npm run re:build`
- [x] I ran `npm run build`
- [x] I reviewed submitted code