### PR TITLE
fix: payout-routing - remove center alignment causing layout issues on large screens

### DIFF
--- a/src/screens/PayoutRouting/PayoutRoutingStack.res
+++ b/src/screens/PayoutRouting/PayoutRoutingStack.res
@@ -125,7 +125,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   <PageLoaderWrapper screenState>
     <div className={`${widthClass} ${marginClass} gap-2.5`}>
-      <div className="flex flex-col gap-6 items-center justify-center">
+      <div className="flex flex-col gap-6">
         <PageUtils.PageHeading
           title="Payout routing configuration"
           subTitle="Smart routing stack helps you to increase success rates and reduce costs by optimising your payment traffic across the various processors in the most customised yet reliable way. Set it up based on the preferred level of control"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixed the layout alignment issue on the Payout Routing Configuration page for larger screens by removing `items-center justify-center` CSS classes from the main content container.

**Change:**
```diff
- <div className="flex flex-col gap-6 items-center justify-center">
+ <div className="flex flex-col gap-6">
```

## Motivation and Context

The `items-center justify-center` CSS classes on the PayoutRoutingStack container caused content to collapse toward the center on large screens instead of utilizing the full available width. This made the heading and card layout appear misaligned compared to the regular Smart Routing page.

The layout pattern in `RoutingStack.res` (the working payment routing page) does not use these centering classes.

## How did you test it?

- Ran `npm run re:build` — all 3,841 ReScript modules compiled successfully
- Ran `npm run build` — production bundle created successfully
- Verified the fix aligns the layout with the regular Routing page

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

Closes #4859