### PR TITLE
fix: chevron direction on OMP view data chip

### DIFF
--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -265,9 +265,14 @@ module OMPViewsComp = {
     ~customLabel="View data for:",
   ) => {
     let (arrow, setArrow) = React.useState(_ => false)
+    let isInitialMount = React.useRef(true)
 
     let toggleChevronState = () => {
-      setArrow(prev => !prev)
+      if isInitialMount.current {
+        isInitialMount.current = false
+      } else {
+        setArrow(prev => !prev)
+      }
     }
 
     let customScrollStyle = "md:max-h-72 md:overflow-scroll md:px-1 md:pt-1"


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<img width="1466" height="813" alt="Screenshot 2026-05-27 at 12 04 27 PM" src="https://github.com/user-attachments/assets/41dc9805-69bf-4979-8557-806bbe739131" />

The "View data for: <merchant>" chip was rendering an up-arrow when the dropdown was closed. Fixed by skipping the spurious first `toggleChevronState` call in `OMPViewsComp`.

## Motivation and Context

`SelectBox.BaseDropdown` has a `useEffect([showDropDown])` that calls `toggleChevronState` — but `useEffect` always runs once on mount too, so the local `arrow` state was flipped before the user clicked anything. Other `ListBaseComp` consumers compensate via reversed rotation classes; `OMPViewBaseComp` doesn't, so the bug was visible only here.

Fix is local (one ref) so it doesn't disturb the blend path or any other consumer.

## How did you test it?

Manually opened/closed the chip and confirmed: closed → ▼, open → ▲. Verified in both blend and non-blend paths.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran \`npm run re:build\`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible