### PR TITLE
fix: close confirmation popup on browser back navigation

### DIFF
--- a/src/components/PopUpContainer.res
+++ b/src/components/PopUpContainer.res
@@ -4,11 +4,12 @@ open PopUpState
 let make = (~children) => {
   let (openPopUps, setOpenPopUp) = Recoil.useRecoilState(PopUpState.openPopUp)
   let url = RescriptReactRouter.useUrl()
+  let pathString = url.path->List.toArray->Array.joinWith("/")
 
   React.useEffect(() => {
     setOpenPopUp(_ => [])
     None
-  }, [url.path->List.toArray->Array.joinWith("/")])
+  }, [pathString])
 
   let activePopUp = openPopUps->Array.get(0)
   let popUp = switch activePopUp {

--- a/src/components/PopUpContainer.res
+++ b/src/components/PopUpContainer.res
@@ -3,6 +3,13 @@ open PopUpState
 @react.component
 let make = (~children) => {
   let (openPopUps, setOpenPopUp) = Recoil.useRecoilState(PopUpState.openPopUp)
+  let url = RescriptReactRouter.useUrl()
+
+  React.useEffect(() => {
+    setOpenPopUp(_ => [])
+    None
+  }, [url.path->List.toArray->Array.joinWith("/")])
+
   let activePopUp = openPopUps->Array.get(0)
   let popUp = switch activePopUp {
   | Some(popUp) => {


### PR DESCRIPTION

## Type of Change

- [x] Bugfix

## Description

Fixes #4057.

Added a `useEffect` in `PopUpContainer.res` that clears the `openPopUp` Recoil atom whenever the URL path changes. This ensures any open confirmation or warning popup is dismissed on browser back/forward navigation.

## Motivation and Context

The popup state was only cleared on explicit user actions such as Confirm, Cancel, or Close. Browser back navigation changes the URL without triggering those handlers, leaving the modal as a persistent overlay on unrelated pages.

This builds on the approach from #4276 with two fixes:

- Removed `url.hash` from the dependency array because it is not needed.
- Converted `url.path`, which is a `list<string>`, to a string using `List.toArray->Array.joinWith("/")` before using it as a React dependency. This avoids false triggers from reference inequality on every render and matches the existing pattern in `LoadedTable.res`.

## How did you test it?

Verified that the fix compiles cleanly using:

```bash
npm run re:build
````

The logic also matches the established pattern already used in the codebase.

## Where to test it?

* [x] INTEG

Steps:

1. Go to `integ.hyperswitch.io/dashboard/3ds-exemption` or `/dashboard/3ds`.
2. Click the delete/trash icon on any rule. The confirmation modal appears.
3. Hit the browser back button.
4. Expected: the modal closes.
5. Before fix: the modal persisted as an overlay.

## Checklist

* [x] I ran `npm run re:build`
* [x] I reviewed submitted code
