### PR TITLE
fix: reset status filter form value when filter chip is removed

### DIFF
--- a/src/components/FilterSelectBox.res
+++ b/src/components/FilterSelectBox.res
@@ -1593,11 +1593,12 @@ module BaseDropdown = {
         ->Dict.keysToArray
         ->Array.filter(item => item != "start_time" && item != "end_time" && item != "status")
       if nonStatusFilters->Array.length == 0 {
-        setPreservedAppliedOptions(_ =>
+        let statusValues =
           filterValueJson
           ->getArrayFromDict("status", [])
           ->getStrArrayFromJsonArray
-        )
+        setPreservedAppliedOptions(_ => statusValues)
+        newInputSelect.onChange(statusValues)
       }
       None
     }, [filterValueJson])


### PR DESCRIPTION
https://github.com/user-attachments/assets/e9074d0c-d832-4e36-92aa-dfa293a4f716

## Type of Change

- [x] Bugfix

## Description

Added `newInputSelect.onChange(statusValues)` in `FilterSelectBox.BaseDropdown` to reset the form field value when the status filter chip is removed.

## Motivation and Context

Fixes #4332.

When a user applied a status filter, removed the filter chip via `X`, and then re-added the status filter, the previously deleted filter criteria were automatically re-applied without user interaction.

The `useEffect` watching `filterValueJson` was only updating `preservedAppliedOptions`, but not the actual React Final Form field value. This caused stale selections to persist and trigger the `AutoSubmitter` on re-mount.

## How did you test it?

Tested locally against `app.hyperswitch.io` with payment data.

Video attached showing the bug before and after the fix.

## Where to test it?

- [x] INTEG

1. Go to Payment Operations: `/payments`
2. Click `+ Add Filters` → select `Status` → select options → click `Apply`
3. Click `X` on the filter chip to remove it
4. Click `+ Add Filters` → select `Status` again
5. Before fix: old filter re-applies automatically
6. After fix: fresh empty status dropdown appears

## Backend Dependency

- [ ] Yes
- [x] No

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible