### PR TITLE
fix: show password mismatch error only on confirm field

### DIFF
--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -53,7 +53,7 @@ let confirmPasswordCheck = (value, key, passwordKey, confirmKey, valuesDict, err
     value->LogicUtils.isNonEmptyString &&
     !Option.equal(Dict.get(valuesDict, passwordKey), Dict.get(valuesDict, key), (a, b) => a == b)
   ) {
-    Dict.set(errors, key, "The New password does not match!"->JSON.Encode.string)
+    Dict.set(errors, key, "Passwords do not match. Please try again."->JSON.Encode.string)
   }
 }
 

--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -47,7 +47,7 @@ let passwordKeyValidation = (value, key, keyVal, errors) => {
   }
 }
 
-let confirmPasswordCheck = (value, key, confirmKey, passwordKey, valuesDict, errors) => {
+let confirmPasswordCheck = (value, key, passwordKey, confirmKey, valuesDict, errors) => {
   if (
     key === confirmKey &&
     value->LogicUtils.isNonEmptyString &&


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Earlier:
<img width="849" height="690" alt="Screenshot 2026-06-03 at 4 00 20 PM" src="https://github.com/user-attachments/assets/975c74bc-d65c-4ac9-b74f-5737d8e8a5f5" />

After Update:
<img width="738" height="703" alt="Screenshot 2026-06-03 at 4 10 42 PM" src="https://github.com/user-attachments/assets/edd3ca42-9e9c-4768-9b58-1450aaba2674" />
<img width="636" height="486" alt="Screenshot 2026-06-03 at 4 32 15 PM" src="https://github.com/user-attachments/assets/5f4f2d05-cbe9-4066-8c08-a72bc8955166" />


The "The New password does not match!" error was showing on the new-password field as soon as you started typing, before touching the confirm field. The validation was comparing the new-password value against the (still empty) confirm value and stamping the error on the wrong field. Fixed by correcting the password/confirm parameter order in `confirmPasswordCheck` so the check binds to the confirm field.

## Motivation and Context

In the reset/create-password and change-password flows, typing a new password immediately triggered a "does not match" error even though the confirm field hadn't been filled yet. The error now appears only once the confirm field is non-empty and actually differs from the new password.

## How did you test it?

Tested manually via Settings → Profile → Change Password: typing the new password no longer triggers the mismatch error; it only shows on the confirm field when the values differ. Same fix applies to the reset/create-password flow.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [x] No

Backend PR URL:

## Feature Flag

- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
