### PR TITLE
feat: show connector label and ID in configure PMTs table

### DIFF
--- a/src/screens/ConfigurePMTs/PaymentMethodConfigTypes.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodConfigTypes.res
@@ -3,6 +3,7 @@ type paymentMethodConfiguration = {
   payment_method_types_index: int,
   merchant_connector_id: string,
   connector_name: string,
+  connector_label: string,
   profile_id: string,
   payment_method: string,
   payment_method_type: string,

--- a/src/screens/ConfigurePMTs/PaymentMethodConfigUtils.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodConfigUtils.res
@@ -126,6 +126,7 @@ let mapPaymentMethodTypeValues = (
   payment_method_types_index: pmtIndex,
   merchant_connector_id: connectorPayload.id,
   connector_name: connectorPayload.connector_name,
+  connector_label: connectorPayload.connector_label,
   profile_id: connectorPayload.profile_id,
   payment_method: paymentMethod,
   payment_method_type: paymentMethodType.payment_method_subtype,

--- a/src/screens/ConfigurePMTs/PaymentMethodEntity.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodEntity.res
@@ -1,6 +1,8 @@
 open PaymentMethodConfigTypes
 type colType =
   | Processor
+  | ConnectorLabel
+  | ConnectorId
   | PaymentMethodType
   | PaymentMethod
   | CardNetwork
@@ -9,6 +11,8 @@ type colType =
 
 let defaultColumns = [
   Processor,
+  ConnectorLabel,
+  ConnectorId,
   PaymentMethodType,
   PaymentMethod,
   CountriesAllowed,
@@ -19,6 +23,8 @@ let defaultColumns = [
 let getHeading = colType => {
   switch colType {
   | Processor => Table.makeHeaderInfo(~key="connector_name", ~title="Processor")
+  | ConnectorLabel => Table.makeHeaderInfo(~key="connector_label", ~title="Connector Label")
+  | ConnectorId => Table.makeHeaderInfo(~key="merchant_connector_id", ~title="Connector ID")
   | PaymentMethod => Table.makeHeaderInfo(~key="payment_method", ~title="Payment Method")
   | PaymentMethodType =>
     Table.makeHeaderInfo(~key="payment_method_type", ~title="Payment Method Type")
@@ -40,6 +46,20 @@ let getCell = (~setRefresh) => {
       Table.CustomCell(
         <PaymentMethodConfig
           paymentMethodConfig config={paymentMethodConfig.connector_name} setRefresh
+        />,
+        "",
+      )
+    | ConnectorLabel =>
+      Table.CustomCell(
+        <PaymentMethodConfig
+          paymentMethodConfig config={paymentMethodConfig.connector_label} setRefresh
+        />,
+        "",
+      )
+    | ConnectorId =>
+      Table.CustomCell(
+        <PaymentMethodConfig
+          paymentMethodConfig config={paymentMethodConfig.merchant_connector_id} setRefresh
         />,
         "",
       )

--- a/src/screens/ConfigurePMTs/PaymentMethodEntity.res
+++ b/src/screens/ConfigurePMTs/PaymentMethodEntity.res
@@ -2,7 +2,7 @@ open PaymentMethodConfigTypes
 type colType =
   | Processor
   | ConnectorLabel
-  | ConnectorId
+  | MerchantConnectorId
   | PaymentMethodType
   | PaymentMethod
   | CardNetwork
@@ -12,7 +12,7 @@ type colType =
 let defaultColumns = [
   Processor,
   ConnectorLabel,
-  ConnectorId,
+  MerchantConnectorId,
   PaymentMethodType,
   PaymentMethod,
   CountriesAllowed,
@@ -24,7 +24,8 @@ let getHeading = colType => {
   switch colType {
   | Processor => Table.makeHeaderInfo(~key="connector_name", ~title="Processor")
   | ConnectorLabel => Table.makeHeaderInfo(~key="connector_label", ~title="Connector Label")
-  | ConnectorId => Table.makeHeaderInfo(~key="merchant_connector_id", ~title="Connector ID")
+  | MerchantConnectorId =>
+    Table.makeHeaderInfo(~key="merchant_connector_id", ~title="Merchant Connector ID")
   | PaymentMethod => Table.makeHeaderInfo(~key="payment_method", ~title="Payment Method")
   | PaymentMethodType =>
     Table.makeHeaderInfo(~key="payment_method_type", ~title="Payment Method Type")
@@ -56,10 +57,15 @@ let getCell = (~setRefresh) => {
         />,
         "",
       )
-    | ConnectorId =>
+    | MerchantConnectorId =>
       Table.CustomCell(
         <PaymentMethodConfig
-          paymentMethodConfig config={paymentMethodConfig.merchant_connector_id} setRefresh
+          paymentMethodConfig
+          element={<HelperComponents.CopyTextCustomComp
+            customTextCss="w-36 truncate whitespace-nowrap"
+            displayValue=Some(paymentMethodConfig.merchant_connector_id)
+          />}
+          setRefresh
         />,
         "",
       )


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Adds two columns — Connector Label and Connector ID — to the Configure PMTs table.
<img width="1961" height="1306" alt="Screenshot 2026-06-04 at 4 48 41 PM" src="https://github.com/user-attachments/assets/4ffabb87-5035-48e4-ab29-c896d6f8fe9a" />


## Motivation and Context
You can have multiple instances of the same connector with different IDs and labels. The table only showed the connector name, so there was no way to tell which PMT row belonged to which connector instance. Now the label and ID are visible right in the table.

## How did you test it?
Tested manually on the Configure PMTs page; `rescript build` passes.

## Where to test it?
- [x] INTEG

🤖 Generated with [Claude Code](https://claude.com/claude-code)