### PR TITLE
feat: Add Nextiva Connector in Dashboard

### DIFF
--- a/public/hyperswitch/assets/Gateway/NEXTIVA.svg
+++ b/public/hyperswitch/assets/Gateway/NEXTIVA.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="39" height="39" rx="3.5" fill="#FAFAFA"/>
+<rect x="0.5" y="0.5" width="39" height="39" rx="3.5" stroke="#E6E6E6"/>
+<text x="20" y="26" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#1A1A1A" text-anchor="middle">N</text>
+</svg>

--- a/src/screens/Connectors/ConnectorTypes.res
+++ b/src/screens/Connectors/ConnectorTypes.res
@@ -117,6 +117,7 @@ type processorTypes =
   | TOKENIO
   | PAYLOAD
   | PAYTM
+  | NEXTIVA
   | PHONEPE
   | FLEXITI
   | BREADPAY

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -168,6 +168,7 @@ let connectorList: array<connectorTypes> = [
   Processors(TOKENIO),
   Processors(PAYLOAD),
   Processors(PAYTM),
+  Processors(NEXTIVA),
   Processors(PHONEPE),
   Processors(FLEXITI),
   Processors(BREADPAY),
@@ -800,6 +801,10 @@ let paytmInfo = {
   description: "Paytm is an Indian multinational fintech company specializing in digital payments and financial services. Initially known for its mobile wallet, it has expanded to include a payment bank, e-commerce, ticketing, and wealth management services.",
 }
 
+let nextivaInfo = {
+  description: "Nextiva (PayConex by Bluefin) is a US payment gateway that provides card processing and secure payment services for merchants.",
+}
+
 let phonepeInfo = {
   description: "PhonePe is a digital payments and financial services platform built on the UPI system. It allows users to make instant payments, recharge mobiles, pay bills, and access financial services like investments and insurance.",
 }
@@ -985,6 +990,7 @@ let getConnectorNameString = (connector: processorTypes) =>
   | TOKENIO => "tokenio"
   | PAYLOAD => "payload"
   | PAYTM => "paytm"
+  | NEXTIVA => "nextiva"
   | PHONEPE => "phonepe"
   | FLEXITI => "flexiti"
   | BREADPAY => "breadpay"
@@ -1193,6 +1199,7 @@ let getConnectorNameTypeFromString = (connector, ~connectorType=ConnectorTypes.P
     | "tokenio" => Processors(TOKENIO)
     | "payload" => Processors(PAYLOAD)
     | "paytm" => Processors(PAYTM)
+    | "nextiva" => Processors(NEXTIVA)
     | "phonepe" => Processors(PHONEPE)
     | "flexiti" => Processors(FLEXITI)
     | "breadpay" => Processors(BREADPAY)
@@ -1377,6 +1384,7 @@ let getProcessorInfo = (connector: ConnectorTypes.processorTypes) => {
   | PAYLOAD => payloadInfo
   | TOKENIO => tokenioInfo
   | PAYTM => paytmInfo
+  | NEXTIVA => nextivaInfo
   | PHONEPE => phonepeInfo
   | FLEXITI => flexitiInfo
   | BREADPAY => breadpayInfo
@@ -2367,6 +2375,7 @@ let getDisplayNameForProcessor = (connector: ConnectorTypes.processorTypes) =>
   | PAYLOAD => "Payload"
   | TOKENIO => "Token.io"
   | PAYTM => "Paytm"
+  | NEXTIVA => "Nextiva"
   | PHONEPE => "PhonePe"
   | FLEXITI => "Flexiti"
   | BREADPAY => "Breadpay"


### PR DESCRIPTION
## Summary

Registers the **Nextiva** connector (PayConex by Bluefin) in the Control Center dashboard so merchants can configure it. Backend support: hyperswitch [PR #12608](https://github.com/juspay/hyperswitch/pull/12608).

Nextiva is a **UCS-only** connector. Auth is `BodyKey`:
- `api_key` — PayConex API access key
- `key1` — PayConex Account ID

## Changes

- `src/screens/Connectors/ConnectorTypes.res` — add `NEXTIVA` to `processorTypes`
- `src/screens/Connectors/ConnectorUtils.res` — `connectorList` entry, `nextivaInfo`, `getConnectorNameString` (`"nextiva"`), reverse mapping, `getProcessorInfo`, `getDisplayNameForProcessor` (`"Nextiva"`)
- `public/hyperswitch/assets/Gateway/NEXTIVA.svg` — gateway icon (**placeholder** — replace with the official Nextiva/PayConex logo before merge)

The auth fields (API access key + Account ID) are rendered from the euclid wasm config, regenerated in the companion WASM PR.

> The config form fields depend on the regenerated euclid wasm bundle (separate WASM PR). Merge that alongside this so the BodyKey fields render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
