### PR TITLE
fix(filters): only include amount_filter when values are non-null

### DIFF
--- a/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
+++ b/src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res
@@ -79,14 +79,22 @@ let validateAmount = dict => {
 let createAmountQuery = (~dict) => {
   let hasAmountError = validateAmount(dict)
   if !hasAmountError {
-    let encodeAmount = value => value->mapOptionOrDefault(JSON.Encode.null, encodeFloatOrDefault)
-    dict->Dict.set(
-      "amount_filter",
-      [
-        ("start_amount", dict->getOptionValFromDict("start_amount")->encodeAmount),
-        ("end_amount", dict->getOptionValFromDict("end_amount")->encodeAmount),
-      ]->getJsonFromArrayOfJson,
-    )
+    let startAmount = dict->getOptionValFromDict("start_amount")
+    let endAmount = dict->getOptionValFromDict("end_amount")
+    
+    // Only create amount_filter if at least one value is non-null
+    let hasAmountValue = startAmount->Option.isSome || endAmount->Option.isSome
+    
+    if hasAmountValue {
+      let encodeAmount = value => value->mapOptionOrDefault(JSON.Encode.null, encodeFloatOrDefault)
+      dict->Dict.set(
+        "amount_filter",
+        [
+          ("start_amount", startAmount->encodeAmount),
+          ("end_amount", endAmount->encodeAmount),
+        ]->getJsonFromArrayOfJson,
+      )
+    }
   }
   dict
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The `amount_filter` object with `start_amount` and `end_amount` set to null was always being included in the filter JSON, even when the amount filter wasn't being used. This is inconsistent with other filters (like status, currency, connector) which only appear in the filter JSON when they have actual values.

### Root Cause

`AmountFilterUtils.createAmountQuery` was creating the `amount_filter` object whenever validation passed, regardless of whether the amount values were null or not. This meant that queries without any amount filter still contained:

```json
{
  "amount_filter": {
    "start_amount": null,
    "end_amount": null
  }
}
```

### Changes

Modified `src/screens/Transaction/CommonFilters/AmountFilter/AmountFilterUtils.res`:
- Added check to verify if at least one of `start_amount` or `end_amount` has a non-null value
- Only creates the `amount_filter` object when `hasAmountValue` is true
- Maintains all existing validation and encoding logic

### After Fix

Queries without amount filter now exclude the `amount_filter` key entirely, matching the behavior of other filters.

Closes #4190

## Motivation and Context

Other filters (status, currency, connector) only appear in the filter JSON when they have actual values. The amount filter should follow the same pattern for consistency and to avoid sending unnecessary null objects in API requests.

## How did you test it?

- [x] Created queries with no amount filter - verified `amount_filter` key is not present
- [x] Created queries with `start_amount` only - verified `amount_filter` contains correct value
- [x] Created queries with `end_amount` only - verified `amount_filter` contains correct value  
- [x] Created queries with both values - verified `amount_filter` contains both correct values
- [x] Verified existing amount filter validation continues to work correctly
- [x] Build passed: `npm run re:build && npm run build:prod`

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible