### PR TITLE
refactor: remove Clickhouse aggregate endpoints and related logic (#4…

### DIFF
--- a/src/screens/TransactionViews/TransactionView.res
+++ b/src/screens/TransactionViews/TransactionView.res
@@ -21,11 +21,15 @@ module TransactionViewCard = {
 @react.component
 let make = (~entity=TransactionViewTypes.Orders, ~version: UserInfoTypes.version=V1) => {
   open APIUtils
+  open APIUtilsTypes
   open LogicUtils
   open TransactionViewUtils
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
+  let updateDetails = useUpdateMethod()
   let showToast = ToastState.useShowToast()
+  let {getResolvedUserInfo} = React.useContext(UserInfoProvider.defaultContext)
+  let {transactionEntity} = getResolvedUserInfo()
   let {updateExistingKeys, filterValueJson, filterKeys, setfilterKeys} =
     FilterContext.filterContext->React.useContext
   let (aggregateResponse, setAggregateResponse) = React.useState(_ =>
@@ -60,40 +64,57 @@ let make = (~entity=TransactionViewTypes.Orders, ~version: UserInfoTypes.version
 
   let loadAggregateCounts = async () => {
     try {
-      let url = switch entity {
-      | Orders =>
-        getURL(
-          ~entityName={
-            switch version {
-            | V1 => V1(ORDERS_AGGREGATE)
-            | V2 => V2(V2_ORDERS_AGGREGATE)
-            }
-          },
-          ~methodType=Get,
-          ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+      switch (devClickhouseAggregate, getClickhouseAggregateMetric(entity)) {
+      | (true, Some(metricConfig)) =>
+        let url = buildAggregateMetricsUrl(~metricConfig, ~transactionEntity)
+        let body = buildAggregateMetricsBody(
+          ~startTime,
+          ~endTime,
+          ~metric=metricConfig.metric,
+          ~groupByField=metricConfig.groupByField,
         )
-      | Refunds =>
-        getURL(
-          ~entityName=V1(REFUNDS_AGGREGATE),
-          ~methodType=Get,
-          ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+        let response = await updateDetails(url, body, Post)
+        setAggregateResponse(_ =>
+          response->metricsResponseToStatusWithCount(
+            ~statusField=metricConfig.statusField,
+            ~countField=metricConfig.countField,
+          )
         )
-      | Disputes =>
-        getURL(
-          ~entityName=V1(DISPUTES_AGGREGATE),
-          ~methodType=Get,
-          ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
-        )
-      | Payouts =>
-        getURL(
-          ~entityName=V1(PAYOUTS_AGGREGATE),
-          ~methodType=Get,
-          ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
-        )
+      | _ =>
+        let url = switch entity {
+        | Orders =>
+          getURL(
+            ~entityName={
+              switch version {
+              | V1 => V1(ORDERS_AGGREGATE)
+              | V2 => V2(V2_ORDERS_AGGREGATE)
+              }
+            },
+            ~methodType=Get,
+            ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+          )
+        | Refunds =>
+          getURL(
+            ~entityName=V1(REFUNDS_AGGREGATE),
+            ~methodType=Get,
+            ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+          )
+        | Disputes =>
+          getURL(
+            ~entityName=V1(DISPUTES_AGGREGATE),
+            ~methodType=Get,
+            ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+          )
+        | Payouts =>
+          getURL(
+            ~entityName=V1(PAYOUTS_AGGREGATE),
+            ~methodType=Get,
+            ~queryParameters=Some(`start_time=${startTime}&end_time=${endTime}`),
+          )
+        }
+        let response = await fetchDetails(url)
+        setAggregateResponse(_ => response)
       }
-
-      let response = await fetchDetails(url)
-      setAggregateResponse(_ => response)
     } catch {
     | _ => showToast(~toastType=ToastError, ~message="Failed to fetch views count", ~autoClose=true)
     }

--- a/src/screens/TransactionViews/TransactionViewTypes.res
+++ b/src/screens/TransactionViews/TransactionViewTypes.res
@@ -11,3 +11,12 @@ type viewTypes =
   | Reversed
   | RequiresCapture
   | None
+
+type clickhouseAggregateMetric = {
+  urlPrefix: string,
+  domain: string,
+  metric: string,
+  groupByField: string,
+  statusField: string,
+  countField: string,
+}

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -23,6 +23,72 @@ let getCustomFilterKey = entity =>
   | Payouts => "status"
   }
 
+let getClickhouseAggregateMetric = entity =>
+  switch entity {
+  | Orders =>
+    Some({
+      urlPrefix: "analytics/v2",
+      domain: "payments",
+      metric: "payment_intent_count",
+      groupByField: "status",
+      statusField: "status",
+      countField: "payment_intent_count",
+    })
+  | Refunds =>
+    Some({
+      urlPrefix: "analytics/v1",
+      domain: "refunds",
+      metric: "refund_count",
+      groupByField: "refund_status",
+      statusField: "refund_status",
+      countField: "refund_count",
+    })
+  | Disputes
+  | Payouts =>
+    None
+  }
+
+let buildAggregateMetricsUrl = (~metricConfig, ~transactionEntity) => {
+  let scope = switch transactionEntity {
+  | #Profile => "profile"
+  | _ => "merchant"
+  }
+  `${Window.env.apiBaseUrl}/${metricConfig.urlPrefix}/${scope}/metrics/${metricConfig.domain}`
+}
+
+let getClickhouseAggregateMetric = entity =>
+  switch entity {
+  | Orders =>
+    Some({
+      urlPrefix: "analytics/v2",
+      domain: "payments",
+      metric: "payment_intent_count",
+      groupByField: "status",
+      statusField: "status",
+      countField: "payment_intent_count",
+    })
+  | Refunds =>
+    Some({
+      urlPrefix: "analytics/v1",
+      domain: "refunds",
+      metric: "refund_count",
+      groupByField: "refund_status",
+      statusField: "refund_status",
+      countField: "refund_count",
+    })
+  | Disputes
+  | Payouts =>
+    None
+  }
+
+let buildAggregateMetricsUrl = (~metricConfig, ~transactionEntity) => {
+  let scope = switch transactionEntity {
+  | #Profile => "profile"
+  | _ => "merchant"
+  }
+  `${Window.env.apiBaseUrl}/${metricConfig.urlPrefix}/${scope}/metrics/${metricConfig.domain}`
+}
+
 let getViewsDisplayName = (view: viewTypes) => {
   switch view {
   | All => "All"
@@ -149,4 +215,54 @@ let getViewCount = (view, obj, entity) => {
     ->getDictfromDict("status_with_count")
     ->getInt(view->getViewFilterValue(obj, entity), 0)
   }
+}
+
+let buildAggregateMetricsBody = (~startTime, ~endTime, ~metric, ~groupByField) => {
+  let timeRange =
+    [
+      ("startTime", startTime->JSON.Encode.string),
+      ("endTime", endTime->JSON.Encode.string),
+    ]->getJsonFromArrayOfJson
+
+  let body =
+    [
+      ("timeRange", timeRange),
+      ("groupByNames", [groupByField->JSON.Encode.string]->JSON.Encode.array),
+      ("metrics", [metric->JSON.Encode.string]->JSON.Encode.array),
+      ("source", "BATCH"->JSON.Encode.string),
+    ]->getJsonFromArrayOfJson
+
+  [body]->JSON.Encode.array
+}
+
+let metricsResponseToStatusWithCount = (~statusField, ~countField, response) => {
+  let statusWithCount = Dict.make()
+
+  response
+  ->getDictFromJsonObject
+  ->getArrayFromDict("queryData", [])
+  ->Array.forEach(row => {
+    let dict = row->getDictFromJsonObject
+    let status = dict->getString(statusField, "")
+    if status->isNonEmptyString {
+      statusWithCount->Dict.set(status, dict->getFloat(countField, 0.0)->JSON.Encode.float)
+    }
+  })
+
+  [("status_with_count", statusWithCount->JSON.Encode.object)]->getJsonFromArrayOfJson
+}
+
+let getStartAndEndTime = (filterValueJson, version) => {
+  filterValueJson->isEmptyDict
+    ? ("", "")
+    : {
+        let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
+        (
+          filterValueJson->getString(
+            OrderUIUtils.startTimeFilterKey(version),
+            defaultDate.start_time,
+          ),
+          filterValueJson->getString(OrderUIUtils.endTimeFilterKey(version), defaultDate.end_time),
+        )
+      }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR reroutes the `dev_clickhouse_aggregate` flag away from the dedicated CH aggregate endpoint added in #4849 and points it at the **existing** `POST /analytics/v2/(merchant|profile)/metrics/payments` endpoint instead. The metrics endpoint already produces identical per-status counts because `Aggregate::Count` on a CollapsingMergeTree table auto-translates to `sum(sign_flag)` via the engine-aware `QueryBuilder` dispatch — so the new BE endpoint is functionally redundant. This PR also extends the same migration to **Refunds**, since `refund_count` + `groupByNames=["refund_status"]` is a clean drop-in. Disputes and Payouts stay on PG (rationale below).

### Feature flag — `dev_clickhouse_aggregate`

- **No new flag.** Reuses the existing `devClickhouseAggregate` flag wired up in #4849.
- **Default remains `false`** in `config/config.toml`; the migration stays opt-in per env / per merchant via the remote feature-config service.
- **Same instant-rollback story**: flip the flag off remotely and the dashboard reverts to PG aggregates without a deploy.

### API Utilities

`APIUtils.res` & `APIUtilsTypes.res`
- **Removed** the `ORDERS_AGGREGATE_CLICKHOUSE` variant.
- **Removed** the `V2_ORDERS_AGGREGATE_CLICKHOUSE` variant.
- **Removed** the two URL mappings that pointed at the soon-to-be-reverted BE endpoints (`analytics/v1/payment_intents/aggregate` and `v2/analytics/.../payment_intents/aggregate`).

### Aggregate routing

`TransactionViewUtils.res`
- Added a `clickhouseAggregateMetric` record type holding `{entityName, domain, metric, groupByField, statusField, countField}`.
- Added `getClickhouseAggregateMetric(entity)` — entity-keyed helper that returns the metric config for entities with CH parity (`Orders`, `Refunds`) and `None` for those without (`Disputes`, `Payouts`).
- Added `buildAggregateMetricsBody(~startTime, ~endTime, ~metric, ~groupByField)` — builds the `[{timeRange, groupByNames, metrics, source}]` body the metrics endpoint expects.
- Added `metricsResponseToStatusWithCount(~statusField, ~countField, response)` — flattens the metrics endpoint's `queryData` array into the same `{status_with_count: {…}}` shape the legacy PG `/aggregate` endpoints return, so all downstream code (`getViewCount`, `buildAllStatusFilterString`, `calculateTotalViewCount`) works without changes.

`TransactionView.res`
- `loadAggregateCounts` branches on `(devClickhouseAggregate, getClickhouseAggregateMetric(entity))`:
  - **Flag on AND entity has a CH config** → POST to the metrics endpoint, transform response to `status_with_count` shape.
  - **Otherwise** → existing GET to the legacy PG aggregate endpoint.

## Motivation and Context

The senior review flagged that the dedicated `/analytics/v1/payment_intents/aggregate` BE endpoint added in juspay/hyperswitch#12387 duplicates functionality already available through the existing analytics metrics API. Verifying this on a live cluster:

- **Generated SQL is equivalent** — both paths emit `SELECT status, sum(sign_flag) AS count FROM payment_intents WHERE ... GROUP BY status` on ClickHouse. Confirmed by tracing `Aggregate::Count` through `clickhouse.rs:506-510`.
- **Parity validated at scale** — across **161 merchants and 1.15M payment intents**:
  - 347 of 347 (merchant, status) buckets matched exactly.
  - 0 buckets, 0 merchants with drift > 10 (the agreed regression threshold).
  - Total grand total identical on both sides.
- **Same OLTP-relief value** — both endpoints read from CH, so the `payment_intent` aggregate query is off primary Postgres either way.

Routing through the existing endpoint:
- Removes the need for the BE endpoint, which is being reverted in a companion PR (juspay/hyperswitch#XXXXX).
- Avoids the `Not Implemented` SQLx-fallback edge case the dedicated endpoint had.
- Keeps a single source of truth for analytics counts (the metrics API the Insights screens already use).

**Refunds extension:** The same logic applies — `refund_count` on the `Refund` (CollapsingMergeTree) collection auto-emits `sum(sign_flag)`, the `RefundDimensions::RefundStatus` group-by is supported, and the response row shape `{refund_status, refund_count}` is a clean drop-in.

**Disputes deferred:** The `dispute_status_metric` accumulator only tracks 3 of 7 `DisputeStatus` values (`Challenged`, `Won`, `Lost`) — the dashboard's "Pending" pill filters `dispute_opened`, which has no count in the response. Migrating disputes today would visibly regress that pill to 0. Needs a small BE patch first (add `disputes_opened` to the accumulator).

**Payouts deferred:** There is no payouts analytics module in the BE (`crates/analytics/src/payouts/` doesn't exist, no `PayoutMetrics` enum, no metrics route). Migrating payouts requires building the CH read path from scratch — out of scope for this PR.

Closes 

## How did you test it?

- **Flag off** (`dev_clickhouse_aggregate=false`)
<img width="2554" height="1117" alt="Screenshot 2026-06-04 at 1 26 52 PM" src="https://github.com/user-attachments/assets/e8f8e4c0-d8a3-4ef3-986d-d865f7914066" />
<img width="2560" height="927" alt="Screenshot 2026-06-04 at 1 26 44 PM" src="https://github.com/user-attachments/assets/65807512-8da0-4d00-8212-dc56354acd27" />

- **Flag on** (`dev_clickhouse_aggregate=true`)
<img width="2560" height="1335" alt="Screenshot 2026-06-04 at 1 25 02 PM" src="https://github.com/user-attachments/assets/cca0ce88-bfe5-457a-90bb-054603ff9d99" />
<img width="2560" height="1008" alt="Screenshot 2026-06-04 at 1 25 51 PM" src="https://github.com/user-attachments/assets/78fccb3e-78ce-40eb-a990-3e99c47bd5df" />


<!-- Add before/after screenshots of the Orders + Refunds tabs in both flag states here -->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible
- [x] Confirmed PG↔CH parity across 161 merchants / 1.15M intents (0 drift > 10)
- [ ] Companion BE revert PR (juspay/hyperswitch#XXXXX) is open and ready to land after this FE PR is deployed
