### PR TITLE
fix: prevent duplicate events/profile/list API call on Webhooks page load

### DIFF
--- a/src/screens/Developer/Webhooks/Webhooks.res
+++ b/src/screens/Developer/Webhooks/Webhooks.res
@@ -17,7 +17,7 @@ let make = () => {
   let businessProfileRecoilVal =
     HyperswitchAtom.businessProfileFromIdAtom->Recoil.useRecoilValueFromAtom
   let (searchText, setSearchText) = React.useState(_ => "")
-  let (lastFilterState, setLastFilterState) = React.useState(_ => "")
+  let lastFiltersSignature = React.useRef("")
 
   let webhookURL = businessProfileRecoilVal.webhook_details.webhook_url->Option.getOr("")
 
@@ -103,31 +103,20 @@ let make = () => {
   }
 
   React.useEffect(() => {
-    let currentFilterState = {
-      let filterDict = Dict.make()
-      filterValueJson
-      ->Dict.toArray
-      ->Array.forEach(((key, value)) => {
-        if key !== "offset" && key !== "limit" {
-          filterDict->Dict.set(key, value)
-        }
-      })
-      filterDict->JSON.Encode.object->JSON.stringify
-    }
-
-    if currentFilterState !== lastFilterState && searchText->isEmptyString {
-      setLastFilterState(_ => currentFilterState)
-      if offset !== 0 {
-        setOffset(_ => 0)
-      } else {
-        fetchWebhooks()->ignore
-      }
-    } else {
-      fetchWebhooks()->ignore
-    }
-
     if filterValueJson->isEmptyDict {
       setInitialFilters()
+    } else {
+      let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
+      let start_time = filterValueJson->getString(startTimeFilterKey, defaultDate.start_time)
+      let end_time = filterValueJson->getString(endTimeFilterKey, defaultDate.end_time)
+      let currentFilterState = `${start_time}|${end_time}|${offset->Int.toString}`
+
+      if currentFilterState !== lastFiltersSignature.current && searchText->isEmptyString {
+        lastFiltersSignature.current = currentFilterState
+        fetchWebhooks()->ignore
+      } else if searchText->isNonEmptyString {
+        fetchWebhooks()->ignore
+      }
     }
     None
   }, (filterValueJson, offset))

--- a/src/screens/Developer/Webhooks/Webhooks.res
+++ b/src/screens/Developer/Webhooks/Webhooks.res
@@ -102,8 +102,6 @@ let make = () => {
     }
   }
 
-  Js.log2("offset", offset)
-
   React.useEffect(() => {
     if filterValueJson->isEmptyDict {
       setInitialFilters()

--- a/src/screens/Developer/Webhooks/Webhooks.res
+++ b/src/screens/Developer/Webhooks/Webhooks.res
@@ -102,14 +102,20 @@ let make = () => {
     }
   }
 
+  Js.log2("offset", offset)
+
   React.useEffect(() => {
     if filterValueJson->isEmptyDict {
       setInitialFilters()
     } else {
-      let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
-      let start_time = filterValueJson->getString(startTimeFilterKey, defaultDate.start_time)
-      let end_time = filterValueJson->getString(endTimeFilterKey, defaultDate.end_time)
-      let currentFilterState = `${start_time}|${end_time}|${offset->Int.toString}`
+      let currentFilterState = {
+        let filterDict = Dict.make()
+        filterValueJson
+        ->Dict.toArray
+        ->Array.forEach(((key, value)) => filterDict->Dict.set(key, value))
+        filterDict->Dict.set("offset", offset->Int.toFloat->JSON.Encode.float)
+        filterDict->JSON.Encode.object->JSON.stringify
+      }
 
       if currentFilterState !== lastFiltersSignature.current && searchText->isEmptyString {
         lastFiltersSignature.current = currentFilterState


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The Webhooks page (`/dashboard/webhooks`) was firing `events/profile/list` **twice** on initial page load. This PR reduces it to exactly one call by adopting the dedup pattern already used by `RemoteTableFilters` in [`HSwitchRemoteFilter.res:310-337`](src/screens/HSwitchRemoteFilter.res#L310-L337). All other behavior in `Webhooks.res` is unchanged — same `<Filter>` UI, same `setInitialFilters` seed, same `fetchWebhooks`, same JSX.

**Two changes inside the existing `useEffect`:**

1. **Skip the fetch on the empty-`filterValueJson` first run.** Previously the effect fired `fetchWebhooks` with fully-defaulted values on mount and then fired it again after `setInitialFilters` populated `filterValueJson`. Now the empty case only calls `setInitialFilters` — the follow-up run (with populated `filterValueJson`) does the single fetch. This matches the early-return that `RemoteTableFilters` does at line 310-315.

2. **Move the dedup tracker from `React.useState` → `React.useRef`, and key it on the effective payload.** The previous guard tracked a stringified raw `filterValueJson`, but two mount-time updates produce different raw shapes (`{start_time}` vs `{start_time, end_time, …}`) even though the resolved backend payload is identical (`end_time` falls back to the same default). A `useRef` updates synchronously, and the signature `"${start_time}|${end_time}|${offset}"` after defaults are resolved makes same-effective-payload updates collapse to one fetch.

## Motivation and Context

This was surfacing on prod as **two 504s** for the same merchant — the page was doubling traffic on an already-slow endpoint. Both network entries had identical payloads (`{"limit":50,"offset":0,"created_after":"...","created_before":"..."}`), confirming the duplicate originated client-side.

Closes [#4936](https://github.com/juspay/hyperswitch-control-center/issues/4936)

## How did you test it?



- **Before:** Network tab on `/dashboard/webhooks` shows two `events/profile/list` POSTs with identical payloads on a fresh
<img width="2558" height="1347" alt="Screenshot 2026-06-08 at 3 13 39 PM" src="https://github.com/user-attachments/assets/b7c5bd7e-9bee-4668-b65c-d2904e61137c" />
 page load.

- **After:** Exactly one `events/profile/list` POST on page load.
<img width="2559" height="1345" alt="Screenshot 2026-06-08 at 3 03 52 PM" src="https://github.com/user-attachments/assets/f59d86c2-52d1-48b5-9581-e4532dadfaa0" />


Also verified:
- Pagination (next/prev page) still triggers a fetch on offset change.
- Filter changes (date range picker) still trigger a fetch.
- Search by Object ID / Event ID still fires through the imperative `handleSearchSubmit` path.
- Refresh button still works.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: _N/A_

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): _N/A_

## Checklist

- [x] I ran \`npm run re:build\`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible