### PR TITLE
chore: pin react-qr-code to 2.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react-dom": "18.3.1",
     "react-final-form": "^6.5.9",
     "react-ga4": "^2.0.0",
-    "react-qr-code": "^2.0.12",
+    "react-qr-code": "2.0.21",
     "react-syntax-highlighter": "^15.5.0",
     "react-window": "^1.8.8",
     "recoil": "^0.1.2",


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

One-line pin: `"react-qr-code": "^2.0.12"` → `"react-qr-code": "2.0.21"`.

## Motivation and Context

`react-qr-code@2.1.0` (published 2026-06-08) ships a strict-ESM `.mjs` entry whose imports of `qr.js/lib/ErrorCorrectLevel` and `qr.js/lib/QRCode` lack the required `.js` extension. Webpack 5's strict-ESM resolver fails to find them and the production build dies with:

```
Module not found: Error: Can't resolve 'qr.js/lib/ErrorCorrectLevel'
  in '/usr/src/app/node_modules/react-qr-code/lib'
Did you mean 'ErrorCorrectLevel.js'?
```

**Why main builds fine today:** the committed `package-lock.json` pins `2.0.21` regardless of the `^` range.

**Why hotfixes break:** tags cut without `package-lock.json` (e.g. `2026.05.20.0`) hit the failure on every rebuild since 2026-06-08, because `Dockerfile` uses `npm i` (not `npm ci`) and the free `^2.0.12` range now resolves to `2.1.1`.

Pinning the dependency exactly in `package.json` makes the build reproducible even when a lockfile isn't present in the source tree — restores hotfix builds and protects future tags if a lockfile is ever dropped.

`npm view react-qr-code time` confirmation:
| Version | Published | Ships |
|---|---|---|
| `2.0.21` | 2026-04-29 | CJS only — works |
| `2.1.0` | 2026-06-08 14:10 UTC | adds `.mjs` — breaks |
| `2.1.1` | 2026-06-08 14:34 UTC | adds `.mjs` — breaks |

## How did you test it?

- `npm run re:build` — clean compile
- `npm run build:prod` — webpack production build succeeds (40s, 0 errors, 2 pre-existing size warnings)
- Verified `npm i` with the new pin installs `react-qr-code@2.0.21` and the resulting `lib/` contains no `.mjs` file

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

Closes #4942