### PR TITLE
fix: Set content type when uploading dispute evidence

### DIFF
--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -66,6 +66,27 @@ let getFileTypeFromFileName = fileName => {
   afterDotFileType
 }
 
+@get external getFileMimeType: 'a => string = "type"
+
+let getMimeTypeFromFileName = fileName => {
+  switch fileName->getFileTypeFromFileName->String.toLowerCase {
+  | "pdf" => "application/pdf"
+  | "csv" => "text/csv"
+  | "jpeg" | "jpg" => "image/jpeg"
+  | "png" => "image/png"
+  | _ => "application/octet-stream"
+  }
+}
+
+// Some browsers report an empty `File.type` (e.g. for csv or unrecognised files).
+// Uploading such a file leaves the multipart part without a Content-Type, which the
+// backend rejects with IR_36 ("File content type not found"). Fall back to a MIME
+// type derived from the file extension so a Content-Type is always present.
+let getEvidenceFileContentType = (fileValue, fileName) => {
+  let fileMimeType = fileValue->getFileMimeType
+  fileMimeType->isNonEmptyString ? fileMimeType : fileName->getMimeTypeFromFileName
+}
+
 let (startTimeFilterKey, endTimeFilterKey) = ("start_time", "end_time")
 
 let getFilterTypeFromString = filterType => {

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -66,8 +66,6 @@ let getFileTypeFromFileName = fileName => {
   afterDotFileType
 }
 
-@get external getFileMimeType: 'a => string = "type"
-
 let getMimeTypeFromFileName = fileName => {
   switch fileName->getFileTypeFromFileName->String.toLowerCase {
   | "pdf" => "application/pdf"
@@ -76,15 +74,6 @@ let getMimeTypeFromFileName = fileName => {
   | "png" => "image/png"
   | _ => "application/octet-stream"
   }
-}
-
-// Some browsers report an empty `File.type` (e.g. for csv or unrecognised files).
-// Uploading such a file leaves the multipart part without a Content-Type, which the
-// backend rejects with IR_36 ("File content type not found"). Fall back to a MIME
-// type derived from the file extension so a Content-Type is always present.
-let getEvidenceFileContentType = (fileValue, fileName) => {
-  let fileMimeType = fileValue->getFileMimeType
-  fileMimeType->isNonEmptyString ? fileMimeType : fileName->getMimeTypeFromFileName
 }
 
 let (startTimeFilterKey, endTimeFilterKey) = ("start_time", "end_time")

--- a/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
+++ b/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
@@ -88,7 +88,7 @@ module UploadDisputeEvidenceModal = {
       let formData = formData()
       append(formData, "dispute_id", disputeId)
       append(formData, "evidence_type", keyValue)
-      let contentType = DisputesUtils.getEvidenceFileContentType(fileValue, fileName)
+      let contentType = DisputesUtils.getMimeTypeFromFileName(fileName)
       let fileBlob = blob([fileValue], {"type": contentType})
       appendBlob(formData, "file", fileBlob, fileName)
 
@@ -304,9 +304,10 @@ module DisputesInfoBarComponent = {
                     ->Array.map(value => {
                       let fileName =
                         fileUploadedDict->getDictfromDict(value)->getString("fileName", "")
-                      let iconName = switch fileName->getFileTypeFromFileName {
+                      let fileType = fileName->getFileTypeFromFileName
+                      let iconName = switch fileType {
                       | "jpeg" | "jpg" | "png" => "image-icon"
-                      | _ => `${fileName->getFileTypeFromFileName}-icon`
+                      | _ => `${fileType}-icon`
                       }
                       <div
                         className={`p-2 border rounded-md bg-white w-fit flex gap-2 items-center border-grey-200`}>

--- a/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
+++ b/src/screens/Transaction/Disputes/UploadEvidenceForDisputes.res
@@ -39,7 +39,7 @@ module EvidenceUploadForm = {
             <input
               key={Int.toString(index)}
               type_="file"
-              accept=".pdf,.csv,.img,.jpeg"
+              accept=".pdf,.csv,.jpeg,.jpg,.png"
               onChange={ev => ev->handleBrowseChange(uploadEvidenceType)}
               hidden=true
             />
@@ -83,12 +83,14 @@ module UploadDisputeEvidenceModal = {
     open LogicUtils
     let getURL = useGetURL()
     let updateDetails = useUpdateMethod()
-    let acceptFile = (keyValue, fileValue) => {
+    let acceptFile = (keyValue, fileValue, fileName) => {
       let url = getURL(~entityName=V1(DISPUTES_ATTACH_EVIDENCE), ~methodType=Put)
       let formData = formData()
       append(formData, "dispute_id", disputeId)
       append(formData, "evidence_type", keyValue)
-      append(formData, "file", fileValue)
+      let contentType = DisputesUtils.getEvidenceFileContentType(fileValue, fileName)
+      let fileBlob = blob([fileValue], {"type": contentType})
+      appendBlob(formData, "file", fileBlob, fileName)
 
       updateDetails(
         ~bodyFormData=formData,
@@ -111,7 +113,8 @@ module UploadDisputeEvidenceModal = {
       let promisesOfAttachEvidence = dictToIterate->Array.map(ele => {
         let jsonObject = fileUploadedDict->Dict.get(ele)->Option.getOr(JSON.Encode.null)
         let fileValue = jsonObject->getDictFromJsonObject->getJsonObjectFromDict("uploadedFile")
-        let res = acceptFile(ele, fileValue)
+        let fileName = jsonObject->getDictFromJsonObject->getString("fileName", "")
+        let res = acceptFile(ele, fileValue, fileName)
         res
       })
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Description
Uploading dispute evidence failed with:

```json
{ "error": { "type": "invalid_request", "message": "File content type not found", "code": "IR_36" } }
```

### Root cause
The evidence file was appended directly to `FormData` via `append(formData, "file", file)`. When the browser reports an **empty `File.type`** (which commonly happens for `.csv` files and files whose type the OS/browser can't infer), the resulting multipart part is sent **without a `Content-Type`**. The backend then can't determine the file's content type and rejects the request with `IR_36`.

### Fix
Re-wrap the file in a `Blob` with an explicit content type before appending, and append it with its filename via `appendBlob` (the same pattern already used for CSV uploads in `ReviewDataSummary`):

- Content type is taken from the file's own `File.type`.
- When that is empty, it falls back to a MIME type inferred from the file extension (`pdf`, `csv`, `jpeg/jpg`, `png`, else `application/octet-stream`).

This guarantees the multipart `file` part always carries a `Content-Type`, resolving `IR_36`.

Also fixed the invalid `accept=".pdf,.csv,.img,.jpeg"` filter — `.img` is not a real extension and `.png`/`.jpg` (which the UI already renders icons for) were missing. Now `accept=".pdf,.csv,.jpeg,.jpg,.png"`.

### Changes
- `DisputesUtils.res` — add `getEvidenceFileContentType` (with `getMimeTypeFromFileName` fallback) helper.
- `UploadEvidenceForDisputes.res` — build a typed `Blob` and use `appendBlob` with the filename; pass `fileName` through to `acceptFile`; fix the `accept` filter.

## Motivation and Context
Closes #4833

## How did you test it?
- `npm run re:build` compiles cleanly with no type errors.
- Verified generated output appends the file as `new Blob([fileValue], { type: contentType })` followed by `formData.append("file", fileBlob, fileName)`, so the multipart part always has a Content-Type.
- Manual: upload `.csv`/`.pdf`/image evidence on a dispute → attach succeeds instead of failing with IR_36.

## Checklist
- [x] I formatted the code `npm run re:format`
- [x] My changes generate no new warnings