### PR TITLE
fix: add confirmation popup for cross-context user management action

### DIFF
--- a/src/screens/Home/HomeUtils.res
+++ b/src/screens/Home/HomeUtils.res
@@ -144,7 +144,7 @@ module ControlCenter = {
           <img alt="sdk" src="/assets/IntegrateProcessorsOver.png" />
           <CardHeader
             heading="Integrate a Processor"
-            subHeading="Get a head start by connecting with 20+ gateways, payment methods, and networks."
+            subHeading="Get a head start by connecting with 180+ gateways, payment methods, and networks."
           />
         </div>
         <Button

--- a/src/screens/UserManagement/UserRevamp/ManageUserModal.res
+++ b/src/screens/UserManagement/UserRevamp/ManageUserModal.res
@@ -288,8 +288,8 @@ module ManageUserModal = {
 }
 
 @react.component
-let make = (~userInfoValue: UserManagementTypes.userDetailstype) => {
-  let (showModal, setShowModal) = React.useState(_ => false)
+let make = (~userInfoValue: UserManagementTypes.userDetailstype, ~openModalByDefault=false) => {
+  let (showModal, setShowModal) = React.useState(_ => openModalByDefault)
   <>
     <Button
       text="Manage user"

--- a/src/screens/UserManagement/UserRevamp/UserInfo.res
+++ b/src/screens/UserManagement/UserRevamp/UserInfo.res
@@ -20,6 +20,21 @@ module UserAction = {
 
     let {orgId, merchantId, profileId} = getCommonSessionDetails()
 
+    let (autoOpenRowKey, setAutoOpenRowKey) = Recoil.useRecoilState(
+      UserManagementHelper.autoOpenManageUserModalAtom,
+    )
+    let rowKey = UserManagementHelper.getUserActionRowKey(~userInfoValue=value, ~userEmail)
+    let openModalByDefault = autoOpenRowKey->Option.mapOr(false, key => key === rowKey)
+
+    React.useEffect(() => {
+      // Consume the auto-open intent set before the context switch so the
+      // modal does not reopen on later visits to this page
+      if openModalByDefault {
+        setAutoOpenRowKey(_ => None)
+      }
+      None
+    }, [openModalByDefault])
+
     let decideWhatToShow = {
       if userEmail === email {
         // User cannot update its own role
@@ -54,7 +69,7 @@ module UserAction = {
     }
 
     switch decideWhatToShow {
-    | ManageUser => <ManageUserModal userInfoValue={value} />
+    | ManageUser => <ManageUserModal userInfoValue={value} openModalByDefault />
     | SwitchUser => <UserManagementHelper.SwitchMerchantForUserAction userInfoValue={value} />
     | NoActionAccess => React.null
     }

--- a/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
@@ -251,7 +251,9 @@ let inviteEmail = FormRenderer.makeFieldInfo(
 module SwitchMerchantForUserAction = {
   @react.component
   let make = (~userInfoValue: UserManagementTypes.userDetailstype) => {
+    open LogicUtils
     let showToast = ToastState.useShowToast()
+    let showPopUp = PopUpState.useShowPopUp()
     let {setActiveProductValue} = React.useContext(ProductSelectionProvider.defaultContext)
     let internalSwitch = OMPSwitchHooks.useInternalSwitch(~setActiveProductValue)
 
@@ -267,11 +269,33 @@ module SwitchMerchantForUserAction = {
       }
     }
 
+    let merchantName =
+      userInfoValue.merchant.name->isEmptyString
+        ? userInfoValue.merchant.value
+        : userInfoValue.merchant.name
+
+    let profileName =
+      userInfoValue.profile.name->isEmptyString
+        ? userInfoValue.profile.value
+        : userInfoValue.profile.name
+
+    let switchConfirmation = () => {
+      showPopUp({
+        popUpType: (Warning, WithIcon),
+        heading: "Switch to manage this user?",
+        description: React.string(
+          `This user's role belongs to ${merchantName} (${profileName}), which is different from your current merchant and profile. To manage this user, your dashboard will be switched to that merchant and profile. Press Confirm to switch.`,
+        ),
+        handleConfirm: {text: "Confirm", onClick: _ => onSwitchForUserAction()->ignore},
+        handleCancel: {text: "Cancel"},
+      })
+    }
+
     <Button
-      text="Switch to update"
-      customButtonStyle="!p-2"
-      buttonType={PrimaryOutline}
-      onClick={_ => onSwitchForUserAction()->ignore}
+      text="Manage user"
+      buttonType={Secondary}
+      buttonSize=Medium
+      onClick={_ => switchConfirmation()}
     />
   }
 }

--- a/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
@@ -248,14 +248,38 @@ let inviteEmail = FormRenderer.makeFieldInfo(
   },
   ~isRequired=true,
 )
+// The dashboard can remount while the OMP context switch is in flight, so the
+// auto-open intent for the manage user modal is kept in a Recoil atom rather
+// than component state. The stored key identifies the exact role row the
+// switch was triggered for.
+let autoOpenManageUserModalAtom: Recoil.recoilAtom<option<string>> = Recoil.atom(
+  "autoOpenManageUserModal",
+  None,
+)
+
+let getUserActionRowKey = (~userInfoValue: UserManagementTypes.userDetailstype, ~userEmail) => {
+  let orgId = userInfoValue.org.id->Option.getOr("")
+  let merchantId = userInfoValue.merchant.id->Option.getOr("")
+  let profileId = userInfoValue.profile.id->Option.getOr("")
+  `${userEmail}-${orgId}-${merchantId}-${profileId}-${userInfoValue.roleId}`
+}
+
 module SwitchMerchantForUserAction = {
   @react.component
   let make = (~userInfoValue: UserManagementTypes.userDetailstype) => {
     open LogicUtils
+    let url = RescriptReactRouter.useUrl()
     let showToast = ToastState.useShowToast()
     let showPopUp = PopUpState.useShowPopUp()
+    let setAutoOpenManageUserModal = Recoil.useSetRecoilState(autoOpenManageUserModalAtom)
     let {setActiveProductValue} = React.useContext(ProductSelectionProvider.defaultContext)
     let internalSwitch = OMPSwitchHooks.useInternalSwitch(~setActiveProductValue)
+    let userEmail =
+      url.search
+      ->getDictFromUrlSearchParams
+      ->Dict.get("email")
+      ->Option.getOr("")
+      ->decodeURIComponent
 
     let onSwitchForUserAction = async () => {
       try {
@@ -264,6 +288,7 @@ module SwitchMerchantForUserAction = {
           ~expectedMerchantId=userInfoValue.merchant.id,
           ~expectedProfileId=userInfoValue.profile.id,
         )
+        setAutoOpenManageUserModal(_ => Some(getUserActionRowKey(~userInfoValue, ~userEmail)))
       } catch {
       | _ => showToast(~message="Failed to perform operation!", ~toastType=ToastError)
       }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

On the Team management → user detail page, rows whose org/merchant/profile lineage differs from the current JWT session show a button that swaps the entire dashboard context (via `user/switch/org` / `user/switch/merchant` / `user/switch/profile`) when clicked.

This PR makes that action explicit and seamless:

**Commit 1 — confirmation before switching**
- Renames the button from **"Switch to update"** to **"Manage user"**, matching the in-context action and its button style (`Secondary`, `Medium`).
- Before switching, shows a confirmation popup (`PopUpState.useShowPopUp` with `(Warning, WithIcon)`, same pattern as the delete-user confirmation in `ManageUserModal`) that names the target merchant and profile and tells the user their dashboard will be switched to that context.
- Merchant/profile display names use the same `name`-with-`value`-fallback logic as the table rows on this page.

**Commit 2 — auto-open the manage user modal after the switch**
- After the user confirms and the context switch succeeds, the Manage user modal for the same role row opens automatically in the new context, instead of leaving the user to find and click the row's button again.
- The intent is stored in a Recoil atom (`autoOpenManageUserModalAtom`) keyed by user email + org/merchant/profile lineage + role id, because the dashboard tree can remount while the switch is in flight (`activeProduct` becomes `UnknownProduct`), so component state cannot carry it. `UserAction` consumes the key once the matching row renders in the new context and passes `openModalByDefault` to `ManageUserModal`.

**Commit 3 — home page copy update**
- Updates the "Integrate a Processor" card subheading on the home page from "20+ gateways" to "180+ gateways" to reflect the current processor count (`HomeUtils.res`).

## Motivation and Context

The "Switch to update" label was confusing to merchants: it didn't say what would be switched, and clicking it silently replaced the whole session context (sidebar merchant, profile, product) as a side effect of a team-management action, leaving the user to discover the renamed button afterwards. Since `user/user/update_role` resolves the target user-role from the JWT's scope, the context switch is unavoidable today — so the UI now explains it, asks for confirmation, and completes the journey by opening the manage modal directly after the switch.

## How did you test it?

- `npx rescript build` compiles cleanly.
- The popup follows the exact `showPopUp` pattern already used by `DeleteUserRole` in the same screen.

Manual verification: open Team management → a user with a role under a different merchant/profile → the row action now reads "Manage user" → clicking it shows the confirmation popup naming the target merchant/profile → Confirm switches context and the Manage user modal for that role opens automatically; Cancel leaves the session untouched. The modal does not reopen on subsequent visits to the page (intent is consumed once).

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
