### PR TITLE
fix: recon engine change download to octet stream

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewIngestion.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewIngestion.res
@@ -52,11 +52,11 @@ let make = (~ingestionHistoryData: ingestionHistoryType) => {
         ~id=Some(ingestionHistoryData.id),
       )
       let res = await fetchApi(url, ~method_=Get, ~xFeatureRoute, ~forceCookies)
-      let csvContent = await res->Fetch.Response.text
+      let csvContent = await res->Fetch.Response.blob
       DownloadUtils.download(
         ~fileName=ingestionHistoryData.file_name,
         ~content=csvContent,
-        ~fileType="text/csv",
+        ~fileType="application/octet-stream",
       )
       showToast(~message="File downloaded successfully", ~toastType=ToastSuccess)
     } catch {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesHelper.res
@@ -221,11 +221,11 @@ module IngestionHistoryActionsComponent = {
           ~id=Some(ingestionHistory.id),
         )
         let res = await fetchApi(url, ~method_=Get, ~xFeatureRoute, ~forceCookies)
-        let csvContent = await res->Fetch.Response.text
+        let csvContent = await res->Fetch.Response.blob
         DownloadUtils.download(
           ~fileName=ingestionHistory.file_name,
           ~content=csvContent,
-          ~fileType="text/csv",
+          ~fileType="application/octet-stream",
         )
         showToast(~message="File downloaded successfully", ~toastType=ToastSuccess)
       } catch {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionComponents/ReconEngineExceptionTransactionResolution.res
@@ -742,7 +742,7 @@ let make = (
     } catch {
     | _ =>
       showToast(
-        ~message="Failed to ignore the transaction. Please try again.",
+        ~message="Failed to force reconcile the transaction. Please try again.",
         ~toastType=ToastError,
       )
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

When downloading non csv files the content will be corrupted. Use octet stream and blob to download files for all the file types.

<!-- Describe your changes in detail -->

## Motivation and Context

Fixes: #5007 

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
