### PR TITLE
fix: payment link create new button

### DIFF
--- a/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingUtils.res
+++ b/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingUtils.res
@@ -1,4 +1,3 @@
-open VerticalStepIndicatorTypes
 open IntelligentRoutingTypes
 
 let dataSource = [Historical, Realtime]
@@ -12,7 +11,7 @@ let dataTypeVariantToString = dataType =>
   | Realtime => "Realtime Data"
   }
 
-let sections = [
+let sections: array<VerticalStepIndicatorTypes.section> = [
   {
     id: (#analyze: sections :> string),
     name: "Choose Your Data Source",

--- a/src/blend/adapters/ToastAdapter.res
+++ b/src/blend/adapters/ToastAdapter.res
@@ -40,8 +40,7 @@ let useShowToast = () => {
         let duration = toastDuration > 0 ? toastDuration : 3000
 
         let toastOptions: addToastOptions = {
-          header: "",
-          description: message,
+          header: message,
           variant,
           duration,
           position: TopCenter,

--- a/src/screens/PaymentLinkThemeConfigurator/PaymentLinkThemeConfiguratorTool.res
+++ b/src/screens/PaymentLinkThemeConfigurator/PaymentLinkThemeConfiguratorTool.res
@@ -525,7 +525,7 @@ module StyleIdSelection = {
       <div className={`text-nd_gray-700 py-2 ${body.md.medium}`}>
         {"Select Payment Link Config ID"->React.string}
       </div>
-      <SelectBoxAdapter.BaseDropdown
+      <SelectBox.BaseDropdown
         allowMultiSelect=false
         buttonText="Select Payment Link Config ID"
         input


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The "Create new" button on the Payment Link Config ID dropdown disappeared when Blend was enabled. Blend's `SingleSelect` has no slot for a custom footer inside the dropdown menu, so the `bottomComponent` was silently dropped. Since this dropdown is customised (same as the merchant/profile switches), it now uses the legacy `SelectBox.BaseDropdown` directly instead of the Blend adapter, so the footer button renders again.

Also included two small fixes found along the way:
- `ToastAdapter`: Blend toast message now goes in `header` instead of `description`, so single-line messages render inline with the icon instead of wrapping to the next line.
- `IntelligentRoutingUtils`: silenced a shadowed-label build warning (`icon`) by dropping the redundant `open` and qualifying the one `section` reference.

<img width="906" height="535" alt="Screenshot 2026-06-23 at 5 24 42 PM" src="https://github.com/user-attachments/assets/16a37463-be60-4510-9bd2-8646a9332db4" />


Every dropdown component with some base component like merchant,profile or other dropdown, can't be migrated to blend since it doesnt support such functionality now. I have raised issue to support this in their upcoming releases.
https://github.com/juspay/blend-design-system/issues/1535

## Motivation and Context

Create new payment link config was unreachable when Blend is on.

## How did you test it?

Manually with `dev_blend_enabled=true` — the "Create new" button shows in the dropdown and opens the modal; toast renders on a single line.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code

🤖 Generated with [Claude Code](https://claude.com/claude-code)