### PR TITLE
feat: recon engine enable `.txt` file input in sources

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
@@ -31,7 +31,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
     let fileSize = file["size"]
     let hasSupportedExtension = isSupportedFileType(fileName)
     if !hasSupportedExtension {
-      showToast(~message="Please select a .csv, .ext, or .xlsx file.", ~toastType=ToastError)
+      showToast(~message="Please select a .csv, .ext, .xlsx, or .txt file.", ~toastType=ToastError)
       setSelectedFile(_ => None)
       clearFileInput()
     } else if fileSize > maxFileSizeBytes {
@@ -144,7 +144,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
         <input
           ref={fileInputRef->ReactDOM.Ref.domRef}
           type_="file"
-          accept=".csv,.ext,.xlsx"
+          accept=".csv,.ext,.xlsx,.txt"
           disabled={!hasManageAccess}
           onChange=handleFileUpload
           hidden=true
@@ -177,7 +177,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
                 {"Choose a file or drag & drop it here"->React.string}
               </div>
               <div className={`${body.md.medium} text-nd_gray-500`}>
-                {".csv,.ext,.xlsx only | Max size 8 MB"->React.string}
+                {".csv,.ext,.xlsx,.txt only | Max size 8 MB"->React.string}
               </div>
             </div>
             <div

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesTypes.res
@@ -14,6 +14,7 @@ type supportedFileExtensions =
   | Csv
   | Ext
   | Xlsx
+  | Txt
 
 @unboxed
 type buttonActionType =

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesUtils.res
@@ -225,6 +225,7 @@ let supportedFileTypes: array<ReconEngineDataSourcesTypes.supportedFileExtension
   Csv,
   Ext,
   Xlsx,
+  Txt,
 ]
 
 let isSupportedFileType = (fileName: string): bool => {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Add ability to upload `.txt` files in recon engine sources, alongside the existing `.csv`, `.ext`, and `.xlsx` support.

- Add `Txt` to the `supportedFileExtensions` variant and `supportedFileTypes` list that drive upload validation.
- Update the file input's `accept` attribute, the unsupported-file-type toast, and the dropzone helper text to include `.txt`.

## Motivation and Context

The manual ingestion upload on the Data Sources page rejected `.txt` files with a "please select a .csv, .ext, or .xlsx file" error, even though `.txt` is a common export format for reconciliation files.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

- [ ] Yes
- [x] No

<img width="2560" height="1352" alt="Screenshot 2026-07-02 at 3 52 55 PM" src="https://github.com/user-attachments/assets/d361e2ba-1a97-47e9-9dcc-56bfecca0928" />


## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible