### PR TITLE
chore: show connector_name instead of MCA ID in webhook URLs

### DIFF
--- a/src/OrchestrationV2/OrchestrationV2Screens/Connectors/PaymentConnectorOnboarding.res
+++ b/src/OrchestrationV2/OrchestrationV2Screens/Connectors/PaymentConnectorOnboarding.res
@@ -244,7 +244,7 @@ let make = () => {
           />
           <ConnectorWebhookPreview
             merchantId
-            connectorName=connectorInfoDict.id
+            connectorName=connectorInfoDict.connector_name
             textCss="border border-nd_gray-300 font-[700] rounded-xl px-4 py-2 mb-6 mt-6 text-nd_gray-400 font-jetbrains-mono text-sm min-w-0 truncate"
             containerClass="flex flex-col lg:flex-row items-center"
             hideLabel=true

--- a/src/OrchestrationV2/OrchestrationV2Screens/Connectors/PaymentConnectorReview.res
+++ b/src/OrchestrationV2/OrchestrationV2Screens/Connectors/PaymentConnectorReview.res
@@ -69,7 +69,7 @@ let make = (~connectorInfo) => {
         <div className="flex flex-col">
           <ConnectorHelperV2.PreviewCreds connectorInfo=connectorInfodict connectorAccountFields />
         </div>
-        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.id />
+        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
       </div>
     </div>
     <ACLButton

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorHome.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorHome.res
@@ -207,7 +207,7 @@ let make = () => {
         />
         <ConnectorWebhookPreview
           merchantId
-          connectorName=connectorInfoDict.id
+          connectorName=connectorInfoDict.connector_name
           textCss="border border-nd_gray-300 font-[700] rounded-xl px-4 py-2 mb-6 mt-6  text-nd_gray-400"
           containerClass="flex flex-row items-center justify-between"
           hideLabel=true

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
@@ -238,7 +238,7 @@ let make = (
         <div className="px-3 pb-5">
           <ConnectorWebhookPreview
             merchantId
-            connectorName=connectorInfoDict.id
+            connectorName=connectorInfoDict.connector_name
             textCss={`border border-nd_gray-400 ${body.md.medium} rounded-xl px-4 py-2 text-nd_gray-400 w-full !font-jetbrains-mono`}
             containerClass="flex flex-row items-center justify-between"
             displayTextLength=38

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryProcessorReview.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryProcessorReview.res
@@ -61,7 +61,7 @@ let make = (~connectorInfo) => {
         <div className="flex flex-col ">
           <ConnectorHelperV2.PreviewCreds connectorInfo=connectorInfodict connectorAccountFields />
         </div>
-        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.id />
+        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
       </div>
     </div>
     <ACLButton

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
@@ -247,7 +247,7 @@ module BillingConnectorDetails = {
             condition={connectorName->getConnectorNameTypeFromString(
               ~connectorType=BillingProcessor,
             ) != BillingProcessor(CUSTOMBILLING)}>
-            <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.id />
+            <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
           </RenderIf>
         </div>
         {switch connectorName->getConnectorNameTypeFromString(~connectorType=BillingProcessor) {
@@ -447,7 +447,7 @@ module PaymentConnectorDetails = {
                   <h4 className="text-nd_gray-400 "> {"Profile"->React.string} </h4>
                   {connectorInfodict.profile_id->React.string}
                 </div>
-                <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.id />
+                <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
               </div>
               <div className="flex flex-col gap-4">
                 <div className="flex justify-between border-b pb-4 px-2 items-end">

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
@@ -447,7 +447,9 @@ module PaymentConnectorDetails = {
                   <h4 className="text-nd_gray-400 "> {"Profile"->React.string} </h4>
                   {connectorInfodict.profile_id->React.string}
                 </div>
-                <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
+                <ConnectorWebhookPreview
+                  merchantId connectorName=connectorInfodict.connector_name
+                />
               </div>
               <div className="flex flex-col gap-4">
                 <div className="flex justify-between border-b pb-4 px-2 items-end">

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
@@ -12,7 +12,7 @@ let make = (~initialValues, ~merchantId, ~onNextClick) => {
       <div className="mb-10 flex flex-col gap-7 w-540-px">
         <ConnectorWebhookPreview
           merchantId
-          connectorName=connectorInfoDict.id
+          connectorName=connectorInfoDict.connector_name
           textCss="border border-nd_gray-400 font-medium rounded-xl px-4 py-2 mb-6 mt-6  text-nd_gray-400 w-full !font-jetbrains-mono"
           containerClass="flex flex-row items-center justify-between"
           displayTextLength=38

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -236,7 +236,7 @@ let make = (
         <div className="px-3 pb-5">
           <ConnectorWebhookPreview
             merchantId
-            connectorName=connectorInfoDict.id
+            connectorName=connectorInfoDict.connector_name
             textCss="border border-nd_gray-400 font-medium rounded-xl px-4 py-2 text-nd_gray-400 w-full !font-jetbrains-mono"
             containerClass="flex flex-row items-center justify-between"
             displayTextLength=38

--- a/src/Vault/VaultScreens/VaultConnectors/VaultProcessorReview.res
+++ b/src/Vault/VaultScreens/VaultConnectors/VaultProcessorReview.res
@@ -69,7 +69,7 @@ let make = (~connectorInfo) => {
         <div className="flex flex-col ">
           <ConnectorHelperV2.PreviewCreds connectorInfo=connectorInfodict connectorAccountFields />
         </div>
-        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.id />
+        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
       </div>
     </div>
     <ACLButton

--- a/src/Vault/VaultScreens/VaultOnboarding.res
+++ b/src/Vault/VaultScreens/VaultOnboarding.res
@@ -248,7 +248,7 @@ let make = () => {
           />
           <ConnectorWebhookPreview
             merchantId
-            connectorName=connectorInfoDict.id
+            connectorName=connectorInfoDict.connector_name
             textCss="border border-nd_gray-300 font-[700] rounded-xl px-4 py-2 mb-6 mt-6 text-nd_gray-400 font-jetbrains-mono text-sm min-w-0 truncate"
             containerClass="flex flex-col lg:flex-row items-center"
             hideLabel=true

--- a/src/screens/ConnectorV2/PaymentProcessorSummary.res
+++ b/src/screens/ConnectorV2/PaymentProcessorSummary.res
@@ -236,7 +236,7 @@ let make = (
         <div className="flex flex-col gap-12">
           <div className="flex gap-10 max-w-3xl flex-wrap px-2">
             <ConnectorWebhookPreview
-              merchantId connectorName=connectorInfodict.id truncateDisplayValue=true
+              merchantId connectorName=connectorInfodict.connector_name truncateDisplayValue=true
             />
             <div className="flex flex-col gap-2 ">
               <h4 className="text-nd_gray-400 "> {"Profile"->React.string} </h4>

--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/ConnectorPreview.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/ConnectorPreview.res
@@ -145,7 +145,7 @@ module ConnectorSummaryGrid = {
 
     let {merchantId} = useCommonAuthInfo()->Option.getOr(defaultAuthInfo)
     let copyValueOfWebhookEndpoint = getWebhooksUrl(
-      ~connectorName={connectorInfo.merchant_connector_id},
+      ~connectorName={connectorInfo.connector_name},
       ~merchantId,
     )
     let (processorType, _) =


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The webhook URL builders (`ConnectorWebhookPreview` and `getWebhooksUrl`) already accept a `connectorName`, but every call site was passing the merchant connector account (MCA) ID into it. As a result the Dashboard was rendering and copying webhook endpoints as `/webhooks/{merchant_id}/{merchant_connector_id}` instead of the intended `/webhooks/{merchant_id}/{connector_name}`.

This PR fixes the call sites to pass `connector_name`:

- All `ConnectorWebhookPreview` usages (Connector V2 summary, Orchestration V2 onboarding/review, Vault onboarding/review, and Revenue Recovery payment & billing screens) now pass `connectorInfo(d/D)ict.connector_name` instead of `.id`.
- The V1 `ConnectorPreview` now passes `connectorInfo.connector_name` to `getWebhooksUrl` instead of `connectorInfo.merchant_connector_id`.

No behavioural change beyond what's displayed/copied — these builders are pure string constructors, so the fix is purely at the call sites.

## Motivation and Context

Aligns the Dashboard webhook URLs with the connector-level webhook shape from the Prism/UCS refactor, where the incoming event reference is parsed from the payload and the account is resolved internally, so the MCA ID is no longer needed in the URL.

Closes https://github.com/juspay/hyperswitch-control-center/issues/5042

> Note: existing merchants configured with the old `/{merchant_connector_id}` URLs rely on the backend webhook route continuing to accept that path form. That routing lives in the backend and is out of scope for this Dashboard-only change — worth confirming both forms resolve before rollout.

## How did you test it?

- Ran `npm run re:build` — compiles clean; `connector_name` exists on the connector payload types used at every call site.
- Manually verified no webhook builder still receives an MCA ID (grepped for `getWebhooksUrl` / `ConnectorWebhookPreview` and the `webhooks/` string).

## Where to test it?

- [x] SANDBOX
- [ ] INTEG
- [ ] PROD

## Backend Dependency

- [x] Yes

Backend PR URL: https://github.com/juspay/hyperswitch-prism/pull/1025

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
