### PR TITLE
chore: enrich mixpanel payload with browser and session context

### DIFF
--- a/src/hooks/MixpanelHook.res
+++ b/src/hooks/MixpanelHook.res
@@ -4,8 +4,10 @@ let useSendEvent = () => {
   open GlobalVars
   open Window
   let fetchApi = AuthHooks.useApiFetcher()
-  let {merchantId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
-  let {name, email: authInfoEmail} = React.useContext(
+  let {orgId, profileId, merchantId} = React.useContext(
+    UserInfoProvider.defaultContext,
+  ).getCommonSessionDetails()
+  let {name, email: authInfoEmail, roleId, version} = React.useContext(
     UserInfoProvider.defaultContext,
   ).getResolvedUserInfo()
 
@@ -21,6 +23,11 @@ let useSendEvent = () => {
   let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {clientCountry} = HSwitchUtils.getBrowserDetails()
   let country = clientCountry.isoAlpha2->CountryUtils.getCountryCodeStringFromVariant
+  let (browserName, browserVersion) = HSwitchUtils.getBrowserNameAndVersion()
+  let dashboardVersion = switch version {
+  | UserInfoTypes.V1 => "v1"
+  | V2 => "v2"
+  }
 
   let environment = GlobalVars.hostType->getEnvironment
 
@@ -58,11 +65,18 @@ let useSendEvent = () => {
         "email": email,
         "mp_lib": "restapi",
         "merchantId": merchantId,
+        "orgId": orgId,
+        "profileId": profileId,
+        "roleId": roleId,
+        "dashboardVersion": dashboardVersion,
+        "appVersion": GlobalVars.appVersion,
         "environment": environment,
         "description": description,
         "lang": Navigator.browserLanguage,
         "$os": Navigator.platform,
-        "$browser": Navigator.browserName,
+        "$browser": browserName,
+        "$browser_version": browserVersion,
+        "$current_url": Window.Location.href,
         "mp_country_code": country,
       },
     }
@@ -101,12 +115,21 @@ let usePageView = () => {
   open GlobalVars
   open Window
   let fetchApi = AuthHooks.useApiFetcher()
-  let {merchantId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
-  let {name, email} = React.useContext(UserInfoProvider.defaultContext).getResolvedUserInfo()
+  let {orgId, profileId, merchantId} = React.useContext(
+    UserInfoProvider.defaultContext,
+  ).getCommonSessionDetails()
+  let {name, email, roleId, version} = React.useContext(
+    UserInfoProvider.defaultContext,
+  ).getResolvedUserInfo()
 
   let environment = GlobalVars.hostType->getEnvironment
   let {clientCountry} = HSwitchUtils.getBrowserDetails()
   let country = clientCountry.isoAlpha2->CountryUtils.getCountryCodeStringFromVariant
+  let (browserName, browserVersion) = HSwitchUtils.getBrowserNameAndVersion()
+  let dashboardVersion = switch version {
+  | UserInfoTypes.V1 => "v1"
+  | V2 => "v2"
+  }
   let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   async (~path) => {
     let mixpanel_token = Window.env.mixpanelToken
@@ -123,10 +146,17 @@ let usePageView = () => {
         "email": email,
         "mp_lib": "restapi",
         "merchantId": merchantId,
+        "orgId": orgId,
+        "profileId": profileId,
+        "roleId": roleId,
+        "dashboardVersion": dashboardVersion,
+        "appVersion": GlobalVars.appVersion,
         "environment": environment,
         "lang": Navigator.browserLanguage,
         "$os": Navigator.platform,
-        "$browser": Navigator.browserName,
+        "$browser": browserName,
+        "$browser_version": browserVersion,
+        "$current_url": Window.Location.href,
         "mp_country_code": country,
         "page": path,
       },

--- a/src/hooks/MixpanelHook.res
+++ b/src/hooks/MixpanelHook.res
@@ -21,9 +21,8 @@ let useSendEvent = () => {
   }
 
   let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
-  let {clientCountry} = HSwitchUtils.getBrowserDetails()
+  let {clientCountry, browserName, browserVersion} = HSwitchUtils.getBrowserDetails()
   let country = clientCountry.isoAlpha2->CountryUtils.getCountryCodeStringFromVariant
-  let (browserName, browserVersion) = HSwitchUtils.getBrowserNameAndVersion()
   let dashboardVersion = switch version {
   | UserInfoTypes.V1 => "v1"
   | V2 => "v2"
@@ -123,9 +122,8 @@ let usePageView = () => {
   ).getResolvedUserInfo()
 
   let environment = GlobalVars.hostType->getEnvironment
-  let {clientCountry} = HSwitchUtils.getBrowserDetails()
+  let {clientCountry, browserName, browserVersion} = HSwitchUtils.getBrowserDetails()
   let country = clientCountry.isoAlpha2->CountryUtils.getCountryCodeStringFromVariant
-  let (browserName, browserVersion) = HSwitchUtils.getBrowserNameAndVersion()
   let dashboardVersion = switch version {
   | UserInfoTypes.V1 => "v1"
   | V2 => "v2"

--- a/src/libraries/Window.res
+++ b/src/libraries/Window.res
@@ -188,12 +188,6 @@ module Navigator = {
   external userAgent: string = "userAgent"
 
   @val @scope(("window", "navigator"))
-  external browserName: string = "appName"
-
-  @val @scope(("window", "navigator"))
-  external browserVersion: string = "appVersion"
-
-  @val @scope(("window", "navigator"))
   external platform: string = "platform"
 
   @val @scope(("window", "navigator"))

--- a/src/screens/HSwitchUtils.res
+++ b/src/screens/HSwitchUtils.res
@@ -91,6 +91,28 @@ let getBrowserDetails = () => {
   }
 }
 
+// navigator.appName/appVersion are legacy and return constants (e.g. "Netscape") across modern browsers, so parse the userAgent for real name/version
+let getBrowserNameAndVersion = () => {
+  let userAgent = Window.Navigator.userAgent
+
+  let getVersion = regex =>
+    userAgent->String.match(regex)->Option.mapOr("", matches => matches->getValueFromArray(1, ""))
+
+  if userAgent->String.includes("Edg/") {
+    ("Edge", getVersion(%re("/Edg\/([\d.]+)/")))
+  } else if userAgent->String.includes("OPR/") || userAgent->String.includes("Opera") {
+    ("Opera", getVersion(%re("/(?:OPR|Opera)\/([\d.]+)/")))
+  } else if userAgent->String.includes("Chrome") {
+    ("Chrome", getVersion(%re("/Chrome\/([\d.]+)/")))
+  } else if userAgent->String.includes("Firefox") {
+    ("Firefox", getVersion(%re("/Firefox\/([\d.]+)/")))
+  } else if userAgent->String.includes("Safari") {
+    ("Safari", getVersion(%re("/Version\/([\d.]+)/")))
+  } else {
+    ("Unknown", "")
+  }
+}
+
 let getBodyForFeedBack = (~email, ~values, ~modalType=HSwitchFeedBackModalUtils.FeedBackModal) => {
   open HSwitchFeedBackModalUtils
   let valueDict = values->getDictFromJsonObject

--- a/src/screens/HSwitchUtils.res
+++ b/src/screens/HSwitchUtils.res
@@ -78,27 +78,11 @@ let getBrowserDetails = () => {
   open HSwitchUtilsTypes
   let clientTimeZone = dateTimeFormat().resolvedOptions().timeZone
   let clientCountry = clientTimeZone->getClientCountry
-  {
-    userAgent,
-    browserVersion,
-    platform,
-    browserName,
-    browserLanguage,
-    screenHeight,
-    screenWidth,
-    timeZoneOffset,
-    clientCountry,
-  }
-}
-
-// navigator.appName/appVersion are legacy and return constants (e.g. "Netscape") across modern browsers, so parse the userAgent for real name/version
-let getBrowserNameAndVersion = () => {
-  let userAgent = Window.Navigator.userAgent
 
   let getVersion = regex =>
     userAgent->String.match(regex)->Option.mapOr("", matches => matches->getValueFromArray(1, ""))
 
-  if userAgent->String.includes("Edg/") {
+  let (browserName, browserVersion) = if userAgent->String.includes("Edg/") {
     ("Edge", getVersion(%re("/Edg\/([\d.]+)/")))
   } else if userAgent->String.includes("OPR/") || userAgent->String.includes("Opera") {
     ("Opera", getVersion(%re("/(?:OPR|Opera)\/([\d.]+)/")))
@@ -110,6 +94,18 @@ let getBrowserNameAndVersion = () => {
     ("Safari", getVersion(%re("/Version\/([\d.]+)/")))
   } else {
     ("Unknown", "")
+  }
+
+  {
+    userAgent,
+    browserVersion,
+    platform,
+    browserName,
+    browserLanguage,
+    screenHeight,
+    screenWidth,
+    timeZoneOffset,
+    clientCountry,
   }
 }
 

--- a/src/screens/HSwitchUtils.res
+++ b/src/screens/HSwitchUtils.res
@@ -80,7 +80,9 @@ let getBrowserDetails = () => {
   let clientCountry = clientTimeZone->getClientCountry
 
   let getVersion = regex =>
-    userAgent->String.match(regex)->Option.mapOr("", matches => matches->getValueFromArray(1, ""))
+    userAgent
+    ->String.match(regex)
+    ->mapOptionOrDefault("", matches => matches->getValueFromArray(1, ""))
 
   let (browserName, browserVersion) = if userAgent->String.includes("Edg/") {
     ("Edge", getVersion(%re("/Edg\/([\d.]+)/")))


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Enriches the Mixpanel `track` and `page_view` payloads (`src/hooks/MixpanelHook.res`) with the actual browser name/version and additional session context. All new fields come from data already available in the hook — no extra API calls or dependencies.

**Browser**
- `getBrowserDetails` (`src/screens/HSwitchUtils.res`) now parses `navigator.userAgent` to detect Edge, Opera, Chrome, Firefox and Safari with their versions, populating its existing `browserName`/`browserVersion` fields with real values instead of the legacy `navigator.appName`/`appVersion` bindings (removed from `Window.res`).
- Feeds the `$browser` and new `$browser_version` properties.

**Session context**
- Adds `orgId`, `profileId`, `roleId` and `dashboardVersion` (v1/v2).

**Build / URL**
- Adds `appVersion` (release, from `APP_VERSION`) and `$current_url`.

All fields are added to both `useSendEvent` and `usePageView` for consistency.

## Motivation and Context

`$browser` was previously wired to `navigator.appName` / `appVersion`, which are legacy fields that return constants (e.g. `"Netscape"`) across all modern browsers — so the browser data in Mixpanel was effectively useless. This parses the real values from the user agent instead.

The added session context (`orgId`, `profileId`, `roleId`, `dashboardVersion`) lets events be segmented across the org → merchant → profile hierarchy and by role and dashboard version, and `appVersion` lets us correlate events/regressions to a specific deploy.

## How did you test it?

Verified `npm run re:build` compiles cleanly and inspected the resulting payloads locally.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

