### PR TITLE
feat: add opensearch payments foundation

### DIFF
--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -55,6 +55,7 @@ type analytics_row = {
   merchant_order_reference_id: string,
   attempt_count: int,
   connector_label: string,
+  // These names intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id: string,
   card_last_4: string,
   card_network: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -55,7 +55,6 @@ type analytics_row = {
   merchant_order_reference_id: string,
   attempt_count: int,
   connector_label: string,
-  // These names intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id: string,
   card_last_4: string,
   card_network: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -56,5 +56,13 @@ type analytics_row = {
   attempt_count: int,
   connector_label: string,
   active_attempt_id: string,
+  card_last_4: string,
+  card_network: string,
+  card_issuer: string,
+  refunds_status: string,
+  refunds_count: int,
+  dispute_status: string,
+  dispute_count: int,
+  routing_approach: string,
   attempts_list: array<analytics_attempt>,
 }

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -134,7 +134,6 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
-  // These optional fields intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id?: string,
   card_last_4?: string,
   card_issuer?: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -134,6 +134,7 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
+  // These optional fields intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id?: string,
   card_last_4?: string,
   card_issuer?: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -113,6 +113,7 @@ type order = {
   order_quantity?: string,
   product_name?: string,
   card_brand?: string,
+  card_network?: string,
   payment_experience: string,
   frm_message: frmMessage,
   connector_payment_id: string,
@@ -133,6 +134,16 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
+  active_attempt_id?: string,
+  card_last_4?: string,
+  card_issuer?: string,
+  refunds_status?: string,
+  refunds_count?: int,
+  dispute_status?: string,
+  dispute_count?: int,
+  routing_approach?: string,
+  unified_code?: string,
+  unified_message?: string,
 }
 
 type ordersObject = {

--- a/src/Interface/PaymentInterface/PaymentInterfaceUtils/PaymentInterfaceUtilsAnalytics.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceUtils/PaymentInterfaceUtilsAnalytics.res
@@ -52,7 +52,7 @@ let getAnalyticsRow = (json: JSON.t): analytics_row => {
     next_action: dict->getString("next_action", ""),
     cancellation_reason: dict->getString("cancellation_reason", ""),
     error_code: dict->getString("error_code", ""),
-    error_message: dict->getString("error_message", ""),
+    error_message: dict->getString("error_message", dict->getString("error_reason", "")),
     unified_code: dict->getString("unified_code", ""),
     unified_message: dict->getString("unified_message", ""),
     connector: dict->getString("connector", ""),
@@ -65,6 +65,14 @@ let getAnalyticsRow = (json: JSON.t): analytics_row => {
     attempt_count: dict->getInt("attempt_count", 0),
     connector_label: dict->getString("connector_label", ""),
     active_attempt_id: dict->getString("active_attempt_id", ""),
+    card_last_4: dict->getString("card_last_4", ""),
+    card_network: dict->getString("card_network", ""),
+    card_issuer: dict->getString("card_issuer", ""),
+    refunds_status: dict->getString("refunds_status", ""),
+    refunds_count: dict->getInt("refunds_count", 0),
+    dispute_status: dict->getString("dispute_status", ""),
+    dispute_count: dict->getInt("dispute_count", 0),
+    routing_approach: dict->getString("routing_approach", ""),
     attempts_list: dict
     ->getArrayFromDict("attempts_list", [])
     ->JSON.Encode.array
@@ -191,6 +199,7 @@ let mapAnalyticsRowToCommonType = (row: analytics_row): PaymentInterfaceTypes.or
     order_quantity: "",
     product_name: "",
     card_brand: "",
+    card_network: row.card_network,
     payment_experience: row.payment_experience,
     frm_message: {
       frm_name: row.frm_message,
@@ -215,6 +224,16 @@ let mapAnalyticsRowToCommonType = (row: analytics_row): PaymentInterfaceTypes.or
     extended_auth_applied: false,
     request_extended_auth: false,
     hyperswitch_error_description: "",
+    active_attempt_id: row.active_attempt_id,
+    card_last_4: row.card_last_4,
+    card_issuer: row.card_issuer,
+    refunds_status: row.refunds_status,
+    refunds_count: row.refunds_count,
+    dispute_status: row.dispute_status,
+    dispute_count: row.dispute_count,
+    routing_approach: row.routing_approach,
+    unified_code: row.unified_code,
+    unified_message: row.unified_message,
   }
 }
 

--- a/src/components/NewFeatureTag.res
+++ b/src/components/NewFeatureTag.res
@@ -1,0 +1,10 @@
+@react.component
+let make = (~className="", ~description="") => {
+  let tag =
+    <span className={`inline-flex shrink-0 items-center align-middle ${className}`}>
+      <TagBinding text="NEW" color=Primary variant=Subtle shape=Squarical size=Xs />
+    </span>
+  description->LogicUtils.isNonEmptyString
+    ? <ToolTip description toolTipFor=tag toolTipPosition=ToolTip.Top />
+    : tag
+}

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -441,65 +441,138 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-let csvHeaders = [
-  ("payment_id", "Payment ID"),
-  ("status", "Payment Status"),
-  ("amount", "Amount"),
-  ("currency", "Currency"),
-  ("connector", "Connector"),
-  ("payment_method", "Payment Method"),
-  ("payment_method_type", "Payment Method Type"),
-  ("profile_id", "Profile ID"),
-  ("merchant_id", "Merchant ID"),
-  ("customer_id", "Customer ID"),
-  ("active_attempt_id", "Active Attempt ID"),
-  ("merchant_connector_id", "Merchant Connector ID"),
-  ("card_last_4", "Card Last 4"),
-  ("card_network", "Card Network"),
-  ("card_issuer", "Card Issuer"),
-  ("refunds_status", "Refund Status"),
-  ("refunds_count", "Refund Count"),
-  ("dispute_status", "Dispute Status"),
-  ("dispute_count", "Dispute Count"),
-  ("routing_approach", "Routing Approach"),
-  ("unified_code", "Unified Code"),
-  ("unified_message", "Unified Message"),
-  ("created", "Created"),
-  ("modified", "Modified"),
+type openSearchCsvColumn =
+  | CsvPaymentId
+  | CsvStatus
+  | CsvAmount
+  | CsvCurrency
+  | CsvConnector
+  | CsvPaymentMethod
+  | CsvPaymentMethodType
+  | CsvProfileId
+  | CsvMerchantId
+  | CsvCustomerId
+  | CsvActiveAttemptId
+  | CsvMerchantConnectorId
+  | CsvCardLast4
+  | CsvCardNetwork
+  | CsvCardIssuer
+  | CsvRefundsStatus
+  | CsvRefundsCount
+  | CsvDisputeStatus
+  | CsvDisputeCount
+  | CsvRoutingApproach
+  | CsvUnifiedCode
+  | CsvUnifiedMessage
+  | CsvCreated
+  | CsvModified
+
+let openSearchCsvColumns = [
+  CsvPaymentId,
+  CsvStatus,
+  CsvAmount,
+  CsvCurrency,
+  CsvConnector,
+  CsvPaymentMethod,
+  CsvPaymentMethodType,
+  CsvProfileId,
+  CsvMerchantId,
+  CsvCustomerId,
+  CsvActiveAttemptId,
+  CsvMerchantConnectorId,
+  CsvCardLast4,
+  CsvCardNetwork,
+  CsvCardIssuer,
+  CsvRefundsStatus,
+  CsvRefundsCount,
+  CsvDisputeStatus,
+  CsvDisputeCount,
+  CsvRoutingApproach,
+  CsvUnifiedCode,
+  CsvUnifiedMessage,
+  CsvCreated,
+  CsvModified,
 ]
 
+let getOpenSearchCsvKey = column =>
+  switch column {
+  | CsvPaymentId => "payment_id"
+  | CsvStatus => "status"
+  | CsvAmount => "amount"
+  | CsvCurrency => "currency"
+  | CsvConnector => "connector"
+  | CsvPaymentMethod => "payment_method"
+  | CsvPaymentMethodType => "payment_method_type"
+  | CsvProfileId => "profile_id"
+  | CsvMerchantId => "merchant_id"
+  | CsvCustomerId => "customer_id"
+  | CsvActiveAttemptId => "active_attempt_id"
+  | CsvMerchantConnectorId => "merchant_connector_id"
+  | CsvCardLast4 => "card_last_4"
+  | CsvCardNetwork => "card_network"
+  | CsvCardIssuer => "card_issuer"
+  | CsvRefundsStatus => "refunds_status"
+  | CsvRefundsCount => "refunds_count"
+  | CsvDisputeStatus => "dispute_status"
+  | CsvDisputeCount => "dispute_count"
+  | CsvRoutingApproach => "routing_approach"
+  | CsvUnifiedCode => "unified_code"
+  | CsvUnifiedMessage => "unified_message"
+  | CsvCreated => "created"
+  | CsvModified => "modified"
+  }
+
+let getOpenSearchCsvHeader = column =>
+  switch column {
+  | CsvPaymentId => "Payment ID"
+  | CsvStatus => "Payment Status"
+  | CsvAmount => "Amount"
+  | CsvCurrency => "Currency"
+  | CsvConnector => "Connector"
+  | CsvPaymentMethod => "Payment Method"
+  | CsvPaymentMethodType => "Payment Method Type"
+  | CsvProfileId => "Profile ID"
+  | CsvMerchantId => "Merchant ID"
+  | CsvCustomerId => "Customer ID"
+  | CsvActiveAttemptId => "Active Attempt ID"
+  | CsvMerchantConnectorId => "Merchant Connector ID"
+  | CsvCardLast4 => "Card Last 4"
+  | CsvCardNetwork => "Card Network"
+  | CsvCardIssuer => "Card Issuer"
+  | CsvRefundsStatus => "Refund Status"
+  | CsvRefundsCount => "Refund Count"
+  | CsvDisputeStatus => "Dispute Status"
+  | CsvDisputeCount => "Dispute Count"
+  | CsvRoutingApproach => "Routing Approach"
+  | CsvUnifiedCode => "Unified Code"
+  | CsvUnifiedMessage => "Unified Message"
+  | CsvCreated => "Created"
+  | CsvModified => "Modified"
+  }
+
+let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, column) =>
+  switch column {
+  | CsvAmount => dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string
+  | CsvRefundsCount => dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string
+  | CsvDisputeCount => dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string
+  | CsvMerchantConnectorId =>
+    dict
+    ->getString("merchant_connector_id", dict->getString("connector_id", ""))
+    ->JSON.Encode.string
+  | CsvCreated => dict->getString("created_at", "")->JSON.Encode.string
+  | CsvModified => dict->getString("modified_at", "")->JSON.Encode.string
+  | column => dict->getString(column->getOpenSearchCsvKey, "")->JSON.Encode.string
+  }
+
+let csvHeaders =
+  openSearchCsvColumns->Array.map(column => (
+    column->getOpenSearchCsvKey,
+    column->getOpenSearchCsvHeader,
+  ))
+
 let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
-  [
-    ("payment_id", dict->getString("payment_id", "")->JSON.Encode.string),
-    ("status", dict->getString("status", "")->JSON.Encode.string),
-    ("amount", dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string),
-    ("currency", dict->getString("currency", "")->JSON.Encode.string),
-    ("connector", dict->getString("connector", "")->JSON.Encode.string),
-    ("payment_method", dict->getString("payment_method", "")->JSON.Encode.string),
-    ("payment_method_type", dict->getString("payment_method_type", "")->JSON.Encode.string),
-    ("profile_id", dict->getString("profile_id", "")->JSON.Encode.string),
-    ("merchant_id", dict->getString("merchant_id", "")->JSON.Encode.string),
-    ("customer_id", dict->getString("customer_id", "")->JSON.Encode.string),
-    ("active_attempt_id", dict->getString("active_attempt_id", "")->JSON.Encode.string),
-    (
-      "merchant_connector_id",
-      dict
-      ->getString("merchant_connector_id", dict->getString("connector_id", ""))
-      ->JSON.Encode.string,
-    ),
-    ("card_last_4", dict->getString("card_last_4", "")->JSON.Encode.string),
-    ("card_network", dict->getString("card_network", "")->JSON.Encode.string),
-    ("card_issuer", dict->getString("card_issuer", "")->JSON.Encode.string),
-    ("refunds_status", dict->getString("refunds_status", "")->JSON.Encode.string),
-    ("refunds_count", dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string),
-    ("dispute_status", dict->getString("dispute_status", "")->JSON.Encode.string),
-    ("dispute_count", dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string),
-    ("routing_approach", dict->getString("routing_approach", "")->JSON.Encode.string),
-    ("unified_code", dict->getString("unified_code", "")->JSON.Encode.string),
-    ("unified_message", dict->getString("unified_message", "")->JSON.Encode.string),
-    ("created", dict->getString("created_at", "")->JSON.Encode.string),
-    ("modified", dict->getString("modified_at", "")->JSON.Encode.string),
-  ]
+  openSearchCsvColumns
+  ->Array.map(column => (column->getOpenSearchCsvKey, getOpenSearchCsvValue(dict, column)))
   ->Dict.fromArray
   ->JSON.Encode.object
 
@@ -614,20 +687,17 @@ let formatActivityCount = (count, label) => {
 type activityTag = {label: string}
 
 let getActivityTags = order => {
-  let refundsCount = switch order.refunds_count {
-  | Some(count) => count
-  | None => order.refunds->Array.length
-  }
+  let refundsCount = order.refunds_count->Option.mapOr(order.refunds->Array.length, count => count)
   let disputeStatus = order.dispute_status->Option.getOr("")
-  let disputesCount = switch order.dispute_count {
-  | Some(count) => count
-  | None =>
-    order.disputes->Array.length > 0
-      ? order.disputes->Array.length
-      : disputeStatus->isNonEmptyString
-      ? 1
-      : 0
-  }
+  let disputesCount =
+    order.dispute_count->Option.mapOr(
+      order.disputes->isNonEmptyArray
+        ? order.disputes->Array.length
+        : disputeStatus->isNonEmptyString
+        ? 1
+        : 0,
+      count => count,
+    )
 
   let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
   let disputeTags =
@@ -638,30 +708,31 @@ let getActivityTags = order => {
 
 let getActivitiesCell = (order): Table.cell => {
   let activityTags = order->getActivityTags
-  if activityTags->Array.length == 0 {
-    CustomCell(
-      <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>,
-      "-",
-    )
-  } else {
-    let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
-    CustomCell(
-      <ToolTip
-        description=activityText
-        toolTipFor={<div className="w-40 overflow-hidden">
-          <div className="flex items-center gap-1 whitespace-nowrap">
-            {activityTags
-            ->Array.map(tag =>
-              <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
-            )
-            ->React.array}
-          </div>
-        </div>}
-        toolTipPosition=ToolTip.Top
-      />,
-      activityText,
-    )
-  }
+  let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
+
+  CustomCell(
+    <>
+      <RenderIf condition={activityTags->isEmptyArray}>
+        <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>
+      </RenderIf>
+      <RenderIf condition={activityTags->isNonEmptyArray}>
+        <ToolTip
+          description=activityText
+          toolTipFor={<div className="w-40 overflow-hidden">
+            <div className="flex items-center gap-1 whitespace-nowrap">
+              {activityTags
+              ->Array.map(tag =>
+                <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
+              )
+              ->React.array}
+            </div>
+          </div>}
+          toolTipPosition=ToolTip.Top
+        />
+      </RenderIf>
+    </>,
+    activityTags->isEmptyArray ? "-" : activityText,
+  )
 }
 
 let formatAdvancedDisplayValue = value => value->isNonEmptyString ? value->snakeToTitle : ""

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -314,6 +314,51 @@ let defaultColumns: array<colType> = [
   Created,
   Modified,
 ]
+
+let openSearchDefaultColumns: array<colType> = [
+  PaymentId,
+  Connector,
+  ProfileId,
+  Amount,
+  Status,
+  Activities,
+  PaymentMethod,
+  PaymentMethodType,
+  CardNetwork,
+  Created,
+  Modified,
+]
+
+let openSearchNewColumns = [
+  MerchantConnectorId,
+  ActiveAttemptId,
+  CardLast4,
+  CardIssuer,
+  RefundsStatus,
+  RefundsCount,
+  Activities,
+  RoutingApproach,
+  UnifiedCode,
+  UnifiedMessage,
+]
+
+let isOpenSearchNewColumn = colType => openSearchNewColumns->Array.includes(colType)
+
+let getOpenSearchNewColumnDescription = colType =>
+  switch colType {
+  | MerchantConnectorId => "Connector account used for this payment attempt."
+  | ActiveAttemptId => "Current active payment attempt linked to the payment."
+  | CardLast4 => "Last 4 digits of the card used for the payment."
+  | CardIssuer => "Bank or institution that issued the card."
+  | RefundsStatus => "Refund state derived from the payment refund lifecycle."
+  | RefundsCount => "Number of refunds linked to this payment."
+  | Activities => "Related refund and dispute activity for this payment."
+  | RoutingApproach => "Routing strategy used to select the connector."
+  | UnifiedCode => "Normalized error or status code from Hyperswitch."
+  | UnifiedMessage => "Normalized message explaining the payment outcome."
+  | _ => ""
+  }
+
 //Columns array for V1 Orders page
 let allColumnsV1 = [
   Amount,
@@ -369,6 +414,94 @@ let allColumnsV2 = [
   PaymentType,
   ErrorMessage,
 ]
+
+let openSearchBaseColumns: array<colType> = [
+  Amount,
+  AmountCapturable,
+  AmountReceived,
+  AuthenticationType,
+  ProfileId,
+  CaptureMethod,
+  Connector,
+  ConnectorTransactionID,
+  Created,
+  Modified,
+  Currency,
+  CustomerId,
+  MerchantOrderReferenceId,
+  PaymentId,
+  PaymentMethod,
+  PaymentMethodType,
+  SetupFutureUsage,
+  Status,
+  AttemptCount,
+  CardNetwork,
+  ErrorMessage,
+]
+
+let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
+
+let csvHeaders = [
+  ("payment_id", "Payment ID"),
+  ("status", "Payment Status"),
+  ("amount", "Amount"),
+  ("currency", "Currency"),
+  ("connector", "Connector"),
+  ("payment_method", "Payment Method"),
+  ("payment_method_type", "Payment Method Type"),
+  ("profile_id", "Profile ID"),
+  ("merchant_id", "Merchant ID"),
+  ("customer_id", "Customer ID"),
+  ("active_attempt_id", "Active Attempt ID"),
+  ("merchant_connector_id", "Merchant Connector ID"),
+  ("card_last_4", "Card Last 4"),
+  ("card_network", "Card Network"),
+  ("card_issuer", "Card Issuer"),
+  ("refunds_status", "Refund Status"),
+  ("refunds_count", "Refund Count"),
+  ("dispute_status", "Dispute Status"),
+  ("dispute_count", "Dispute Count"),
+  ("routing_approach", "Routing Approach"),
+  ("unified_code", "Unified Code"),
+  ("unified_message", "Unified Message"),
+  ("created", "Created"),
+  ("modified", "Modified"),
+]
+
+let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
+  [
+    ("payment_id", dict->getString("payment_id", "")->JSON.Encode.string),
+    ("status", dict->getString("status", "")->JSON.Encode.string),
+    ("amount", dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string),
+    ("currency", dict->getString("currency", "")->JSON.Encode.string),
+    ("connector", dict->getString("connector", "")->JSON.Encode.string),
+    ("payment_method", dict->getString("payment_method", "")->JSON.Encode.string),
+    ("payment_method_type", dict->getString("payment_method_type", "")->JSON.Encode.string),
+    ("profile_id", dict->getString("profile_id", "")->JSON.Encode.string),
+    ("merchant_id", dict->getString("merchant_id", "")->JSON.Encode.string),
+    ("customer_id", dict->getString("customer_id", "")->JSON.Encode.string),
+    ("active_attempt_id", dict->getString("active_attempt_id", "")->JSON.Encode.string),
+    (
+      "merchant_connector_id",
+      dict
+      ->getString("merchant_connector_id", dict->getString("connector_id", ""))
+      ->JSON.Encode.string,
+    ),
+    ("card_last_4", dict->getString("card_last_4", "")->JSON.Encode.string),
+    ("card_network", dict->getString("card_network", "")->JSON.Encode.string),
+    ("card_issuer", dict->getString("card_issuer", "")->JSON.Encode.string),
+    ("refunds_status", dict->getString("refunds_status", "")->JSON.Encode.string),
+    ("refunds_count", dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string),
+    ("dispute_status", dict->getString("dispute_status", "")->JSON.Encode.string),
+    ("dispute_count", dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string),
+    ("routing_approach", dict->getString("routing_approach", "")->JSON.Encode.string),
+    ("unified_code", dict->getString("unified_code", "")->JSON.Encode.string),
+    ("unified_message", dict->getString("unified_message", "")->JSON.Encode.string),
+    ("created", dict->getString("created_at", "")->JSON.Encode.string),
+    ("modified", dict->getString("modified_at", "")->JSON.Encode.string),
+  ]
+  ->Dict.fromArray
+  ->JSON.Encode.object
 
 let getHeading = (~devSortEnabled, colType: colType) => {
   switch colType {
@@ -426,6 +559,17 @@ let getHeading = (~devSortEnabled, colType: colType) => {
   | AttemptCount =>
     Table.makeHeaderInfo(~key="attempt_count", ~title="Attempt Count", ~showSort=true)
   | PaymentType => Table.makeHeaderInfo(~key="payment_type", ~title="Payment Type")
+  | MerchantConnectorId =>
+    Table.makeHeaderInfo(~key="merchant_connector_id", ~title="Merchant Connector ID")
+  | ActiveAttemptId => Table.makeHeaderInfo(~key="active_attempt_id", ~title="Active Attempt ID")
+  | CardLast4 => Table.makeHeaderInfo(~key="card_last_4", ~title="Card Last 4")
+  | CardIssuer => Table.makeHeaderInfo(~key="card_issuer", ~title="Card Issuer")
+  | RefundsStatus => Table.makeHeaderInfo(~key="refunds_status", ~title="Refund Status")
+  | RefundsCount => Table.makeHeaderInfo(~key="refunds_count", ~title="Refund Count")
+  | Activities => Table.makeHeaderInfo(~key="activities", ~title="Related Activity")
+  | RoutingApproach => Table.makeHeaderInfo(~key="routing_approach", ~title="Routing Approach")
+  | UnifiedCode => Table.makeHeaderInfo(~key="unified_code", ~title="Unified Code")
+  | UnifiedMessage => Table.makeHeaderInfo(~key="unified_message", ~title="Unified Message")
   }
 }
 
@@ -461,6 +605,66 @@ let useGetStatus = order => {
     </div>
   }
 }
+
+let formatActivityCount = (count, label) => {
+  let suffix = count == 1 ? "" : "S"
+  `${count->Int.toString} ${label}${suffix}`
+}
+
+type activityTag = {label: string}
+
+let getActivityTags = order => {
+  let refundsCount = switch order.refunds_count {
+  | Some(count) => count
+  | None => order.refunds->Array.length
+  }
+  let disputeStatus = order.dispute_status->Option.getOr("")
+  let disputesCount = switch order.dispute_count {
+  | Some(count) => count
+  | None =>
+    order.disputes->Array.length > 0
+      ? order.disputes->Array.length
+      : disputeStatus->isNonEmptyString
+      ? 1
+      : 0
+  }
+
+  let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
+  let disputeTags =
+    disputesCount > 0 ? [{label: formatActivityCount(disputesCount, "DISPUTE")}] : []
+
+  refundTags->Array.concat(disputeTags)
+}
+
+let getActivitiesCell = (order): Table.cell => {
+  let activityTags = order->getActivityTags
+  if activityTags->Array.length == 0 {
+    CustomCell(
+      <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>,
+      "-",
+    )
+  } else {
+    let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
+    CustomCell(
+      <ToolTip
+        description=activityText
+        toolTipFor={<div className="w-40 overflow-hidden">
+          <div className="flex items-center gap-1 whitespace-nowrap">
+            {activityTags
+            ->Array.map(tag =>
+              <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
+            )
+            ->React.array}
+          </div>
+        </div>}
+        toolTipPosition=ToolTip.Top
+      />,
+      activityText,
+    )
+  }
+}
+
+let formatAdvancedDisplayValue = value => value->isNonEmptyString ? value->snakeToTitle : ""
 
 let getHeadingForSummary = summaryColType => {
   switch summaryColType {
@@ -833,20 +1037,24 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
       },
     )
   | CardNetwork => {
-      let cardNetwork = switch order.payment_method_data {
-      | Some(val) =>
-        switch val->JSON.Classify.classify {
-        | Object(value) => Some(value->getString("card_network", ""))
-        | String(value) =>
-          Some(
-            value
-            ->safeParse
-            ->getDictFromJsonObject
-            ->getStringFromNestedDict("card", "card_network", ""),
-          )
+      let cardNetwork = switch order.card_network {
+      | Some(value) if value->LogicUtils.isNonEmptyString => Some(value)
+      | _ =>
+        switch order.payment_method_data {
+        | Some(val) =>
+          switch val->JSON.Classify.classify {
+          | Object(value) => Some(value->getString("card_network", ""))
+          | String(value) =>
+            Some(
+              value
+              ->safeParse
+              ->getDictFromJsonObject
+              ->getStringFromNestedDict("card", "card_network", ""),
+            )
+          | _ => None
+          }
         | _ => None
         }
-      | _ => None
       }->Option.mapOr("", val => val)
 
       Text(cardNetwork)
@@ -859,6 +1067,43 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
     | Some(false) => Text("Standard")
     | None => Text("N/A")
     }
+  | MerchantConnectorId =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-44 truncate whitespace-nowrap"
+        displayValue=Some(order.connector_id)
+        showTooltip=true
+      />,
+      "",
+    )
+  | ActiveAttemptId =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-40 truncate whitespace-nowrap"
+        displayValue=Some(order.active_attempt_id->Option.getOr(""))
+        showTooltip=true
+      />,
+      order.active_attempt_id->Option.getOr(""),
+    )
+  | CardLast4 => EllipsisText(order.card_last_4->Option.getOr(""), "w-20")
+  | CardIssuer =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-36 truncate whitespace-nowrap"
+        displayValue=Some(order.card_issuer->Option.getOr(""))
+        showTooltip=true
+      />,
+      "",
+    )
+  | RefundsStatus =>
+    EllipsisText(order.refunds_status->Option.getOr("")->formatAdvancedDisplayValue, "w-28")
+  | RefundsCount => EllipsisText(order.refunds_count->Option.getOr(0)->Int.toString, "w-20")
+  | Activities => order->getActivitiesCell
+  | RoutingApproach =>
+    EllipsisText(order.routing_approach->Option.getOr("")->formatAdvancedDisplayValue, "w-36")
+  | UnifiedCode =>
+    EllipsisText(order.unified_code->Option.getOr("")->formatAdvancedDisplayValue, "w-32")
+  | UnifiedMessage => EllipsisText(order.unified_message->Option.getOr(""), "w-40")
   }
 }
 
@@ -888,5 +1133,22 @@ let orderEntity = (merchantId, orgId, ~version: UserInfoTypes.version=V1, ~devSo
           )
         }
       }
+    },
+  )
+
+let openSearchOrderEntity = (merchantId, orgId, ~devSortEnabled) =>
+  EntityType.makeEntity(
+    ~uri=``,
+    ~getObjects=getOrders,
+    ~defaultColumns=openSearchDefaultColumns,
+    ~allColumns=openSearchAllColumns,
+    ~getHeading=colType => getHeading(~devSortEnabled, colType),
+    ~getCell=(order, colType) => getCell(order, colType, merchantId, orgId),
+    ~dataKey="",
+    ~getShowLink={
+      order =>
+        GlobalVars.appendDashboardPath(
+          ~url=`/payments/${order.payment_id}/${order.profile_id}/${merchantId}/${orgId}`,
+        )
     },
   )

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -441,33 +441,7 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-type openSearchCsvColumn =
-  | CsvPaymentId
-  | CsvStatus
-  | CsvAmount
-  | CsvCurrency
-  | CsvConnector
-  | CsvPaymentMethod
-  | CsvPaymentMethodType
-  | CsvProfileId
-  | CsvMerchantId
-  | CsvCustomerId
-  | CsvActiveAttemptId
-  | CsvMerchantConnectorId
-  | CsvCardLast4
-  | CsvCardNetwork
-  | CsvCardIssuer
-  | CsvRefundsStatus
-  | CsvRefundsCount
-  | CsvDisputeStatus
-  | CsvDisputeCount
-  | CsvRoutingApproach
-  | CsvUnifiedCode
-  | CsvUnifiedMessage
-  | CsvCreated
-  | CsvModified
-
-let openSearchCsvColumns = [
+let openSearchCsvColumns: array<openSearchCsvColumn> = [
   CsvPaymentId,
   CsvStatus,
   CsvAmount,

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -187,6 +187,11 @@ type paymentListSource =
 
 let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
+let paymentListSources = [Normal, Advanced]
+
+let getPaymentListSourceFromLabel = value =>
+  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
+
 let getPaymentListTableTitle = source =>
   switch source {
   | Normal => "Orders"

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -96,6 +96,16 @@ type colType =
   | MerchantOrderReferenceId
   | AttemptCount
   | PaymentType
+  | MerchantConnectorId
+  | ActiveAttemptId
+  | CardLast4
+  | CardIssuer
+  | RefundsStatus
+  | RefundsCount
+  | Activities
+  | RoutingApproach
+  | UnifiedCode
+  | UnifiedMessage
 
 type summaryColType =
   | Created
@@ -169,6 +179,47 @@ type optionObj = {
   urlKey: string,
   label: string,
 }
+
+type paymentListSource =
+  | Postgres
+  | OpenSearch
+
+let getPaymentListSourceLabel = source =>
+  switch source {
+  | Postgres => "Postgres"
+  | OpenSearch => "OpenSearch"
+  }
+
+let getPaymentListTableTitle = source =>
+  switch source {
+  | Postgres => "Orders"
+  | OpenSearch => "OrdersOpenSearch"
+  }
+
+let getPaymentListSourceDisplayName = source =>
+  switch source {
+  | Postgres => "Normal"
+  | OpenSearch => "Advanced"
+  }
+
+let getPaymentListSourceDescription = source =>
+  switch source {
+  | Postgres => "Standard payments list."
+  | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  }
+
+let openSearchRefundStatusValues = ["partial_refunded", "full_refunded"]
+
+let openSearchDisputeStatusValues = [
+  "dispute_present",
+  "dispute_opened",
+  "dispute_challenged",
+  "dispute_lost",
+  "dispute_won",
+  "dispute_accepted",
+  "dispute_cancelled",
+  "dispute_expired",
+]
 
 type frmStatus = [#APPROVE | #REJECT]
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -182,28 +182,54 @@ type optionObj = {
 
 @unboxed
 type paymentListSource =
-  | @as("Postgres") Postgres
-  | @as("OpenSearch") OpenSearch
+  | @as("Normal") Normal
+  | @as("Advanced") Advanced
 
 let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
 let getPaymentListTableTitle = source =>
   switch source {
-  | Postgres => "Orders"
-  | OpenSearch => "OrdersOpenSearch"
+  | Normal => "Orders"
+  | Advanced => "OrdersAdvanced"
   }
 
 let getPaymentListSourceDisplayName = source =>
   switch source {
-  | Postgres => "Normal"
-  | OpenSearch => "Advanced"
+  | Normal => "Normal"
+  | Advanced => "Advanced"
   }
 
 let getPaymentListSourceDescription = source =>
   switch source {
-  | Postgres => "Standard payments list."
-  | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  | Normal => "Standard payments list."
+  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
   }
+
+type openSearchCsvColumn =
+  | CsvPaymentId
+  | CsvStatus
+  | CsvAmount
+  | CsvCurrency
+  | CsvConnector
+  | CsvPaymentMethod
+  | CsvPaymentMethodType
+  | CsvProfileId
+  | CsvMerchantId
+  | CsvCustomerId
+  | CsvActiveAttemptId
+  | CsvMerchantConnectorId
+  | CsvCardLast4
+  | CsvCardNetwork
+  | CsvCardIssuer
+  | CsvRefundsStatus
+  | CsvRefundsCount
+  | CsvDisputeStatus
+  | CsvDisputeCount
+  | CsvRoutingApproach
+  | CsvUnifiedCode
+  | CsvUnifiedMessage
+  | CsvCreated
+  | CsvModified
 
 type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -180,15 +180,12 @@ type optionObj = {
   label: string,
 }
 
+@unboxed
 type paymentListSource =
-  | Postgres
-  | OpenSearch
+  | @as("Postgres") Postgres
+  | @as("OpenSearch") OpenSearch
 
-let getPaymentListSourceLabel = source =>
-  switch source {
-  | Postgres => "Postgres"
-  | OpenSearch => "OpenSearch"
-  }
+let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
 let getPaymentListTableTitle = source =>
   switch source {
@@ -208,18 +205,36 @@ let getPaymentListSourceDescription = source =>
   | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
   }
 
-let openSearchRefundStatusValues = ["partial_refunded", "full_refunded"]
+type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 
-let openSearchDisputeStatusValues = [
-  "dispute_present",
-  "dispute_opened",
-  "dispute_challenged",
-  "dispute_lost",
-  "dispute_won",
-  "dispute_accepted",
-  "dispute_cancelled",
-  "dispute_expired",
+let openSearchRefundStatuses: array<openSearchRefundStatus> = [#partial_refunded, #full_refunded]
+
+let openSearchRefundStatusValues = openSearchRefundStatuses->Array.map(status => (status :> string))
+
+type openSearchDisputeStatus = [
+  | #dispute_present
+  | #dispute_opened
+  | #dispute_challenged
+  | #dispute_lost
+  | #dispute_won
+  | #dispute_accepted
+  | #dispute_cancelled
+  | #dispute_expired
 ]
+
+let openSearchDisputeStatuses: array<openSearchDisputeStatus> = [
+  #dispute_present,
+  #dispute_opened,
+  #dispute_challenged,
+  #dispute_lost,
+  #dispute_won,
+  #dispute_accepted,
+  #dispute_cancelled,
+  #dispute_expired,
+]
+
+let openSearchDisputeStatusValues =
+  openSearchDisputeStatuses->Array.map(status => (status :> string))
 
 type frmStatus = [#APPROVE | #REJECT]
 

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -373,7 +373,9 @@ let unsupportedAdvancedPaymentFilterKeys = [
 
 type hiddenAdvancedPaymentFilter = [#first_attempt]
 
-let hiddenAdvancedPaymentFilterKeys = [(#first_attempt: hiddenAdvancedPaymentFilter :> string)]
+let firstAttemptFilterKey = (#first_attempt: hiddenAdvancedPaymentFilter :> string)
+
+let hiddenAdvancedPaymentFilterKeys = [firstAttemptFilterKey]
 
 let advancedPaymentFilterCleanupKeys =
   advancedPaymentOnlyFilterKeys
@@ -489,12 +491,8 @@ let isTextFilter = filter =>
   | _ => false
   }
 
-let copyFilterIfPresent = (~fromDict, ~toDict, key) => {
-  switch fromDict->Dict.get(key) {
-  | Some(value) => toDict->Dict.set(key, value)
-  | None => ()
-  }
-}
+let copyFilterIfPresent = (~fromDict, ~toDict, key) =>
+  fromDict->Dict.get(key)->Option.mapOr((), value => toDict->Dict.set(key, value))
 
 let normalizeStringListFilterValue = value => {
   switch value->JSON.Decode.array {
@@ -571,9 +569,10 @@ let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>
 
 let isAdvancedPaymentSearchTextEmail = value => RegExp.test(advancedPaymentSearchEmailRegex, value)
 
-let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
-  switch fromDict->Dict.get(key) {
-  | Some(value) =>
+let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
+  fromDict
+  ->Dict.get(key)
+  ->Option.mapOr((), value => {
     if key === "customer_email" {
       switch value->normalizeSingleStringFilterValue {
       | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
@@ -585,7 +584,7 @@ let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
       | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
       | None => ()
       }
-    } else if key === "first_attempt" {
+    } else if key === firstAttemptFilterKey {
       switch value->normalizeBoolListFilterValue {
       | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
       | None => ()
@@ -593,9 +592,7 @@ let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
     } else {
       toDict->Dict.set(key, value)
     }
-  | None => ()
-  }
-}
+  })
 
 let buildAdvancedPaymentListPayload = (
   ~filterParams: Dict.t<JSON.t>,

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -348,7 +348,7 @@ let itemToObjMapper = dict => {
   }
 }
 
-let advancedPaymentFilterTypes = [
+let advancedPaymentFilterTypes: array<filter> = [
   #customer_email,
   #card_last_4,
   #active_attempt_id,
@@ -364,9 +364,16 @@ let advancedPaymentOnlyFilterKeys =
 
 let isAdvancedPaymentOnlyFilter = key => advancedPaymentOnlyFilterKeys->Array.includes(key)
 
-let unsupportedAdvancedPaymentFilterKeys = ["unified_code", "unified_message"]
+type unsupportedAdvancedPaymentFilter = [#unified_code | #unified_message]
 
-let hiddenAdvancedPaymentFilterKeys = ["first_attempt"]
+let unsupportedAdvancedPaymentFilterKeys = [
+  (#unified_code: unsupportedAdvancedPaymentFilter :> string),
+  (#unified_message: unsupportedAdvancedPaymentFilter :> string),
+]
+
+type hiddenAdvancedPaymentFilter = [#first_attempt]
+
+let hiddenAdvancedPaymentFilterKeys = [(#first_attempt: hiddenAdvancedPaymentFilter :> string)]
 
 let advancedPaymentFilterCleanupKeys =
   advancedPaymentOnlyFilterKeys
@@ -376,59 +383,96 @@ let advancedPaymentFilterCleanupKeys =
 let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
 
 let getAdvancedPaymentFilterDescription = key =>
-  switch key {
-  | "customer_email" => "Filter payments by customer email."
-  | "card_last_4" => "Find payments by the last 4 digits of the card."
-  | "active_attempt_id" => "Filter payments by the active payment attempt ID."
-  | "merchant_connector_id" => "Filter payments by the connector account used for processing."
-  | "refunds_status" => "Filter payments by refund state, such as partial or full refund."
-  | "dispute_status" => "Filter payments by dispute state."
-  | "routing_approach" => "Filter payments by the routing strategy used for connector selection."
-  | "card_issuer" => "Filter payments by the issuing bank or card institution."
+  switch key->getFilterTypeFromString {
+  | #customer_email => "Filter payments by customer email."
+  | #card_last_4 => "Find payments by the last 4 digits of the card."
+  | #active_attempt_id => "Filter payments by the active payment attempt ID."
+  | #merchant_connector_id => "Filter payments by the connector account used for processing."
+  | #refunds_status => "Filter payments by refund state, such as partial or full refund."
+  | #dispute_status => "Filter payments by dispute state."
+  | #routing_approach => "Filter payments by the routing strategy used for connector selection."
+  | #card_issuer => "Filter payments by the issuing bank or card institution."
   | _ => "Advanced OpenSearch-only payment filter."
   }
 
-let advancedPaymentTextListFilterKeys = [
-  "card_last_4",
-  "active_attempt_id",
-  "merchant_connector_id",
-  "card_issuer",
+type advancedPaymentTextListFilter = [
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #card_issuer
 ]
 
-let advancedRoutingApproachValues = [
-  "default_fallback",
-  "straight_through_routing",
-  "rule_based_routing",
-  "volume_based_routing",
+let advancedPaymentTextListFilterTypes: array<advancedPaymentTextListFilter> = [
+  #card_last_4,
+  #active_attempt_id,
+  #merchant_connector_id,
+  #card_issuer,
 ]
+
+let advancedPaymentTextListFilterKeys =
+  advancedPaymentTextListFilterTypes->Array.map(filter => (filter :> string))
+
+type advancedRoutingApproach = [
+  | #default_fallback
+  | #straight_through_routing
+  | #rule_based_routing
+  | #volume_based_routing
+]
+
+let advancedRoutingApproaches: array<advancedRoutingApproach> = [
+  #default_fallback,
+  #straight_through_routing,
+  #rule_based_routing,
+  #volume_based_routing,
+]
+
+let advancedRoutingApproachValues =
+  advancedRoutingApproaches->Array.map(routingApproach => (routingApproach :> string))
 
 let getAdvancedPaymentStaticFilterValues = key =>
-  switch key {
-  | "refunds_status" => OrderTypes.openSearchRefundStatusValues
-  | "dispute_status" => OrderTypes.openSearchDisputeStatusValues
-  | "routing_approach" => advancedRoutingApproachValues
+  switch key->getFilterTypeFromString {
+  | #refunds_status => OrderTypes.openSearchRefundStatusValues
+  | #dispute_status => OrderTypes.openSearchDisputeStatusValues
+  | #routing_approach => advancedRoutingApproachValues
   | _ => []
   }
 
-let basePaymentListFilterKeys = [
-  "payment_id",
-  "payment_method",
-  "currency",
-  "status",
-  "connector",
-  "connector_label",
-  "payment_method_type",
-  "card_network",
-  "customer_id",
-  "authentication_type",
-  "card_discovery",
-  "merchant_order_reference_id",
+type basePaymentListFilter = [
+  | #payment_id
+  | #payment_method
+  | #currency
+  | #status
+  | #connector
+  | #connector_label
+  | #payment_method_type
+  | #card_network
+  | #customer_id
+  | #authentication_type
+  | #card_discovery
+  | #merchant_order_reference_id
 ]
+
+let basePaymentListFilters: array<basePaymentListFilter> = [
+  #payment_id,
+  #payment_method,
+  #currency,
+  #status,
+  #connector,
+  #connector_label,
+  #payment_method_type,
+  #card_network,
+  #customer_id,
+  #authentication_type,
+  #card_discovery,
+  #merchant_order_reference_id,
+]
+
+let basePaymentListFilterKeys = basePaymentListFilters->Array.map(filter => (filter :> string))
 
 let advancedPaymentListFilterKeys =
   basePaymentListFilterKeys
   ->Array.concat(advancedPaymentOnlyFilterKeys)
-  ->Array.concat(["first_attempt"])
+  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
 
 let mergeUniqueFilterValues = (values, staticValues) =>
   Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
@@ -460,7 +504,7 @@ let normalizeStringListFilterValue = value => {
       ->getStrArrayFromJsonArray
       ->Array.map(value => value->String.trim)
       ->Array.filter(isNonEmptyString)
-    normalizedValues->Array.length > 0
+    normalizedValues->isNonEmptyArray
       ? Some(normalizedValues->Array.map(JSON.Encode.string)->JSON.Encode.array)
       : None
   | None =>
@@ -498,9 +542,11 @@ let getBoolFromJsonFilterValue = value =>
   | None =>
     switch value->JSON.Decode.string {
     | Some(value) =>
-      switch value->String.toLowerCase {
-      | "true" => Some(true)
-      | "false" => Some(false)
+      let normalizedValue = value->String.trim->String.toLowerCase
+      switch normalizedValue {
+      | "true"
+      | "false" =>
+        Some(normalizedValue->getBoolFromString(false))
       | _ => None
       }
     | None => None
@@ -511,7 +557,7 @@ let normalizeBoolListFilterValue = value =>
   switch value->JSON.Decode.array {
   | Some(values) =>
     let normalizedValues = values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
-    normalizedValues->Array.length > 0
+    normalizedValues->isNonEmptyArray
       ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
       : None
   | None =>
@@ -609,7 +655,7 @@ let initialFiltersWithSource = (
   }
 
   let connectorFilter = filterValues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
-  if connectorFilter->Array.length !== 0 {
+  if connectorFilter->isNonEmptyArray {
     filtersArray->Array.push(#connector_label->getLabelFromFilterType)
   }
 
@@ -629,9 +675,8 @@ let initialFiltersWithSource = (
     | #authentication_type => filterData.authentication_type
     | #status => filterData.status
     | #payment_method_type =>
-      getConditionalFilter(key, filterDict, filterValues)->Array.length > 0
-        ? getConditionalFilter(key, filterDict, filterValues)
-        : filterData.payment_method_type
+      let conditionalFilter = getConditionalFilter(key, filterDict, filterValues)
+      conditionalFilter->isNonEmptyArray ? conditionalFilter : filterData.payment_method_type
     | #connector_label => getConditionalFilter(key, filterDict, filterValues)
     | #card_network => filterData.card_network
     | #card_discovery => filterData.card_discovery

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,3 +1,5 @@
+open LogicUtils
+
 type filterTypes = {
   connector: array<string>,
   currency: array<string>,
@@ -11,6 +13,14 @@ type filterTypes = {
   customer_id: array<string>,
   amount: array<string>,
   merchant_order_reference_id: array<string>,
+  customer_email: array<string>,
+  card_last_4: array<string>,
+  active_attempt_id: array<string>,
+  merchant_connector_id: array<string>,
+  refunds_status: array<string>,
+  dispute_status: array<string>,
+  routing_approach: array<string>,
+  card_issuer: array<string>,
 }
 
 type filter = [
@@ -26,6 +36,14 @@ type filter = [
   | #customer_id
   | #amount
   | #merchant_order_reference_id
+  | #customer_email
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #refunds_status
+  | #dispute_status
+  | #routing_approach
+  | #card_issuer
   | #unknown
 ]
 
@@ -43,6 +61,14 @@ let getFilterTypeFromString = filterType => {
   | "customer_id" => #customer_id
   | "amount" => #amount
   | "merchant_order_reference_id" => #merchant_order_reference_id
+  | "customer_email" => #customer_email
+  | "card_last_4" => #card_last_4
+  | "active_attempt_id" => #active_attempt_id
+  | "merchant_connector_id" => #merchant_connector_id
+  | "refunds_status" => #refunds_status
+  | "dispute_status" => #dispute_status
+  | "routing_approach" => #routing_approach
+  | "card_issuer" => #card_issuer
   | _ => #unknown
   }
 }
@@ -194,7 +220,6 @@ let endTimeFilterKey = (version: UserInfoTypes.version) =>
   }
 
 let filterByData = (txnArr, value) => {
-  open LogicUtils
   let searchText = value->getStringFromJson("")
 
   txnArr
@@ -233,8 +258,6 @@ let getValueFromFilterTypeV2 = (filter: filter) => {
 }
 
 let getConditionalFilter = (key, dict, filterValues) => {
-  open LogicUtils
-
   let filtersArr = switch key->getFilterTypeFromString {
   | #connector_label =>
     filterValues
@@ -266,7 +289,6 @@ let getConditionalFilter = (key, dict, filterValues) => {
 }
 
 let getOptionsForOrderFilters = (dict, filterValues) => {
-  open LogicUtils
   filterValues
   ->getArrayFromDict("connector", [])
   ->getStrArrayFromJsonArray
@@ -276,7 +298,7 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
       let label = item->getDictFromJsonObject->getString("connector_label", "")
       let value = item->getDictFromJsonObject->getString("merchant_connector_id", "")
       let option: FilterSelectBox.dropdownOption = {
-        label: label->LogicUtils.snakeToTitle,
+        label: label->snakeToTitle,
         value,
       }
       option
@@ -285,7 +307,6 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
 }
 
 let getAllPaymentMethodType = dict => {
-  open LogicUtils
   let paymentMethods = dict->getDictfromDict("payment_method")->Dict.keysToArray
   paymentMethods->Array.reduce([], (acc, item) => {
     Array.concat(
@@ -301,7 +322,6 @@ let getAllPaymentMethodType = dict => {
 }
 
 let itemToObjMapper = dict => {
-  open LogicUtils
   {
     connector: dict->getDictfromDict("connector")->Dict.keysToArray,
     currency: dict->getArrayFromDict("currency", [])->getStrArrayFromJsonArray,
@@ -317,12 +337,268 @@ let itemToObjMapper = dict => {
     customer_id: [],
     amount: [],
     merchant_order_reference_id: [],
+    customer_email: [],
+    card_last_4: [],
+    active_attempt_id: [],
+    merchant_connector_id: [],
+    refunds_status: dict->getArrayFromDict("refunds_status", [])->getStrArrayFromJsonArray,
+    dispute_status: dict->getArrayFromDict("dispute_status", [])->getStrArrayFromJsonArray,
+    routing_approach: dict->getArrayFromDict("routing_approach", [])->getStrArrayFromJsonArray,
+    card_issuer: dict->getArrayFromDict("card_issuer", [])->getStrArrayFromJsonArray,
   }
 }
 
-let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) => {
-  open LogicUtils
+let advancedPaymentFilterTypes = [
+  #customer_email,
+  #card_last_4,
+  #active_attempt_id,
+  #merchant_connector_id,
+  #refunds_status,
+  #dispute_status,
+  #routing_approach,
+  #card_issuer,
+]
 
+let advancedPaymentOnlyFilterKeys =
+  advancedPaymentFilterTypes->Array.map(filterType => filterType->getValueFromFilterType)
+
+let isAdvancedPaymentOnlyFilter = key => advancedPaymentOnlyFilterKeys->Array.includes(key)
+
+let unsupportedAdvancedPaymentFilterKeys = ["unified_code", "unified_message"]
+
+let hiddenAdvancedPaymentFilterKeys = ["first_attempt"]
+
+let advancedPaymentFilterCleanupKeys =
+  advancedPaymentOnlyFilterKeys
+  ->Array.concat(unsupportedAdvancedPaymentFilterKeys)
+  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
+
+let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
+
+let getAdvancedPaymentFilterDescription = key =>
+  switch key {
+  | "customer_email" => "Filter payments by customer email."
+  | "card_last_4" => "Find payments by the last 4 digits of the card."
+  | "active_attempt_id" => "Filter payments by the active payment attempt ID."
+  | "merchant_connector_id" => "Filter payments by the connector account used for processing."
+  | "refunds_status" => "Filter payments by refund state, such as partial or full refund."
+  | "dispute_status" => "Filter payments by dispute state."
+  | "routing_approach" => "Filter payments by the routing strategy used for connector selection."
+  | "card_issuer" => "Filter payments by the issuing bank or card institution."
+  | _ => "Advanced OpenSearch-only payment filter."
+  }
+
+let advancedPaymentTextListFilterKeys = [
+  "card_last_4",
+  "active_attempt_id",
+  "merchant_connector_id",
+  "card_issuer",
+]
+
+let advancedRoutingApproachValues = [
+  "default_fallback",
+  "straight_through_routing",
+  "rule_based_routing",
+  "volume_based_routing",
+]
+
+let getAdvancedPaymentStaticFilterValues = key =>
+  switch key {
+  | "refunds_status" => OrderTypes.openSearchRefundStatusValues
+  | "dispute_status" => OrderTypes.openSearchDisputeStatusValues
+  | "routing_approach" => advancedRoutingApproachValues
+  | _ => []
+  }
+
+let basePaymentListFilterKeys = [
+  "payment_id",
+  "payment_method",
+  "currency",
+  "status",
+  "connector",
+  "connector_label",
+  "payment_method_type",
+  "card_network",
+  "customer_id",
+  "authentication_type",
+  "card_discovery",
+  "merchant_order_reference_id",
+]
+
+let advancedPaymentListFilterKeys =
+  basePaymentListFilterKeys
+  ->Array.concat(advancedPaymentOnlyFilterKeys)
+  ->Array.concat(["first_attempt"])
+
+let mergeUniqueFilterValues = (values, staticValues) =>
+  Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
+
+let isTextFilter = filter =>
+  switch filter {
+  | #customer_id
+  | #merchant_order_reference_id
+  | #customer_email
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #card_issuer => true
+  | _ => false
+  }
+
+let copyFilterIfPresent = (~fromDict, ~toDict, key) => {
+  switch fromDict->Dict.get(key) {
+  | Some(value) => toDict->Dict.set(key, value)
+  | None => ()
+  }
+}
+
+let normalizeStringListFilterValue = value => {
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    let normalizedValues =
+      values
+      ->getStrArrayFromJsonArray
+      ->Array.map(value => value->String.trim)
+      ->Array.filter(isNonEmptyString)
+    normalizedValues->Array.length > 0
+      ? Some(normalizedValues->Array.map(JSON.Encode.string)->JSON.Encode.array)
+      : None
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      let trimmedValue = value->String.trim
+      trimmedValue->isNonEmptyString
+        ? Some([trimmedValue->JSON.Encode.string]->JSON.Encode.array)
+        : None
+    | None => None
+    }
+  }
+}
+
+let normalizeSingleStringFilterValue = value => {
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    values
+    ->getStrArrayFromJsonArray
+    ->Array.map(value => value->String.trim)
+    ->Array.find(isNonEmptyString)
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      let trimmedValue = value->String.trim
+      trimmedValue->isNonEmptyString ? Some(trimmedValue) : None
+    | None => None
+    }
+  }
+}
+
+let getBoolFromJsonFilterValue = value =>
+  switch value->JSON.Decode.bool {
+  | Some(value) => Some(value)
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      switch value->String.toLowerCase {
+      | "true" => Some(true)
+      | "false" => Some(false)
+      | _ => None
+      }
+    | None => None
+    }
+  }
+
+let normalizeBoolListFilterValue = value =>
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    let normalizedValues = values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
+    normalizedValues->Array.length > 0
+      ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
+      : None
+  | None =>
+    switch value->getBoolFromJsonFilterValue {
+    | Some(value) => Some([value->JSON.Encode.bool]->JSON.Encode.array)
+    | None => None
+    }
+  }
+
+let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>()[\]\.,;:\s@"{}\/\\]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/`)
+
+let isAdvancedPaymentSearchTextEmail = value => RegExp.test(advancedPaymentSearchEmailRegex, value)
+
+let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
+  switch fromDict->Dict.get(key) {
+  | Some(value) =>
+    if key === "customer_email" {
+      switch value->normalizeSingleStringFilterValue {
+      | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
+        toDict->Dict.set(key, email->JSON.Encode.string)
+      | _ => ()
+      }
+    } else if advancedPaymentTextListFilterKeys->Array.includes(key) {
+      switch value->normalizeStringListFilterValue {
+      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
+      | None => ()
+      }
+    } else if key === "first_attempt" {
+      switch value->normalizeBoolListFilterValue {
+      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
+      | None => ()
+      }
+    } else {
+      toDict->Dict.set(key, value)
+    }
+  | None => ()
+  }
+}
+
+let buildAdvancedPaymentListPayload = (
+  ~filterParams: Dict.t<JSON.t>,
+  ~searchText,
+  ~startTimeKey,
+  ~endTimeKey,
+) => {
+  let body = Dict.make()
+  let trimmedSearchText = searchText->String.trim
+
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "offset")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "limit")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "order")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "amount_filter")
+
+  if trimmedSearchText->isEmptyString {
+    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, startTimeKey)
+    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, endTimeKey)
+  }
+
+  advancedPaymentListFilterKeys->Array.forEach(key => {
+    copyAdvancedPaymentFilterIfPresent(~fromDict=filterParams, ~toDict=body, key)
+  })
+
+  if trimmedSearchText->isNonEmptyString {
+    trimmedSearchText->isAdvancedPaymentSearchTextEmail
+      ? {
+          body->Dict.set("customer_email", trimmedSearchText->JSON.Encode.string)
+          body->Dict.delete("query")
+        }
+      : {
+          body->Dict.set("query", trimmedSearchText->JSON.Encode.string)
+        }
+  }
+
+  body
+}
+
+let filterNewTag = description => <NewFeatureTag className="ml-2" description />
+
+let initialFiltersWithSource = (
+  ~isOpenSearchSource=false,
+  json,
+  filterValues,
+  removeKeys,
+  filterKeys,
+  setfilterKeys,
+  version,
+) => {
   let filterDict = json->getDictFromJsonObject
 
   let filterData = filterDict->itemToObjMapper
@@ -338,14 +614,15 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
   }
 
   let additionalFilters =
-    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]->Array.map(
-      getLabelFromFilterType,
-    )
+    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]
+    ->Array.concat(isOpenSearchSource ? advancedPaymentFilterTypes : [])
+    ->Array.map(getLabelFromFilterType)
 
   let allFiltersArray = filtersArray->Array.concat(additionalFilters)
 
   allFiltersArray->Array.map((key): EntityType.initialFilters<'t> => {
-    let values = switch key->getFilterTypeFromString {
+    let filterType = key->getFilterTypeFromString
+    let values = switch filterType {
     | #connector => filterData.connector
     | #payment_method => filterData.payment_method
     | #currency => filterData.currency
@@ -358,20 +635,28 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
     | #connector_label => getConditionalFilter(key, filterDict, filterValues)
     | #card_network => filterData.card_network
     | #card_discovery => filterData.card_discovery
+    | #refunds_status => filterData.refunds_status
+    | #dispute_status => filterData.dispute_status
+    | #routing_approach => filterData.routing_approach
+    | #card_issuer => filterData.card_issuer
     | _ => []
     }
+    let values = isOpenSearchSource
+      ? values->mergeUniqueFilterValues(
+          getAdvancedPaymentStaticFilterValues(getValueFromFilterType(filterType)),
+        )
+      : values
 
     let title = `Select ${key->snakeToTitle}`
 
-    let options = switch key->getFilterTypeFromString {
+    let options = switch filterType {
     | #connector_label => getOptionsForOrderFilters(filterDict, filterValues)
     | #connector => values->ConnectorUtils.getConnectorFilterOptions
     | _ => values->FilterSelectBox.makeOptions(~isTitle=true)
     }
 
-    let customInput = switch key->getFilterTypeFromString {
-    | #customer_id
-    | #merchant_order_reference_id =>
+    let customInput = switch filterType {
+    | filterType if filterType->isTextFilter =>
       (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder as _) =>
         InputFields.textInput(
           ~rightIcon=<div
@@ -398,6 +683,12 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
         (),
       )
     }
+    let filterKey = getValueFromFilterType(key->getFilterTypeFromString)
+    let labelRightComponent =
+      isOpenSearchSource && filterKey->isAdvancedPaymentOnlyFilter
+        ? Some(filterNewTag(filterKey->getAdvancedPaymentFilterDescription))
+        : None
+
     {
       field: FormRenderer.makeFieldInfo(
         ~label=key,
@@ -408,11 +699,23 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
           }
         },
         ~customInput,
+        ~labelRightComponent?,
       ),
       localFilter: Some(filterByData),
     }
   })
 }
+
+let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) =>
+  initialFiltersWithSource(
+    ~isOpenSearchSource=false,
+    json,
+    filterValues,
+    removeKeys,
+    filterKeys,
+    setfilterKeys,
+    version,
+  )
 
 let initialFixedFilter = (version: UserInfoTypes.version, ~disable=false) => [
   (

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -541,12 +541,9 @@ let getBoolFromJsonFilterValue = value =>
     switch value->JSON.Decode.string {
     | Some(value) =>
       let normalizedValue = value->String.trim->String.toLowerCase
-      switch normalizedValue {
-      | "true"
-      | "false" =>
-        Some(normalizedValue->getBoolFromString(false))
-      | _ => None
-      }
+      normalizedValue === "true" || normalizedValue === "false"
+        ? Some(normalizedValue->getBoolFromString(false))
+        : None
     | None => None
     }
   }

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -3,26 +3,26 @@ module SourceTabs = {
   let make = (
     ~source: OrderTypes.paymentListSource,
     ~setSource: (OrderTypes.paymentListSource => OrderTypes.paymentListSource) => unit,
-    ~openSearchEnabled,
+    ~advancedEnabled,
   ) => {
     <TabsBinding
       value={source->OrderTypes.getPaymentListSourceLabel}
       onValueChange={value => {
         switch value {
-        | "OpenSearch" =>
-          if openSearchEnabled {
-            setSource(_ => OrderTypes.OpenSearch)
+        | "Advanced" =>
+          if advancedEnabled {
+            setSource(_ => OrderTypes.Advanced)
           }
-        | _ => setSource(_ => OrderTypes.Postgres)
+        | _ => setSource(_ => OrderTypes.Normal)
         }
       }}
       variant=Boxed
       size=Md>
       <TabsBinding.List variant=Boxed size=Md fitContent=true>
-        {[OrderTypes.Postgres, OrderTypes.OpenSearch]
+        {[OrderTypes.Normal, OrderTypes.Advanced]
         ->Array.map(item => {
           let value = item->OrderTypes.getPaymentListSourceLabel
-          let isDisabled = item === OrderTypes.OpenSearch && !openSearchEnabled
+          let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
           <TabsBinding.Trigger
             key=value
             value

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -1,0 +1,79 @@
+module SourceTabs = {
+  @react.component
+  let make = (
+    ~source: OrderTypes.paymentListSource,
+    ~setSource: (OrderTypes.paymentListSource => OrderTypes.paymentListSource) => unit,
+    ~openSearchEnabled,
+  ) => {
+    <TabsBinding
+      value={source->OrderTypes.getPaymentListSourceLabel}
+      onValueChange={value => {
+        switch value {
+        | "OpenSearch" =>
+          if openSearchEnabled {
+            setSource(_ => OrderTypes.OpenSearch)
+          }
+        | _ => setSource(_ => OrderTypes.Postgres)
+        }
+      }}
+      variant=Boxed
+      size=Md>
+      <TabsBinding.List variant=Boxed size=Md fitContent=true>
+        {[OrderTypes.Postgres, OrderTypes.OpenSearch]
+        ->Array.map(item => {
+          let value = item->OrderTypes.getPaymentListSourceLabel
+          let isDisabled = item === OrderTypes.OpenSearch && !openSearchEnabled
+          <TabsBinding.Trigger
+            key=value
+            value
+            variant=Boxed
+            size=Md
+            disabled=isDisabled
+            className="min-w-[75px] justify-center">
+            <ToolTip
+              description={item->OrderTypes.getPaymentListSourceDescription}
+              toolTipFor={<span>
+                {item->OrderTypes.getPaymentListSourceDisplayName->React.string}
+              </span>}
+              toolTipPosition=ToolTip.Top
+            />
+          </TabsBinding.Trigger>
+        })
+        ->React.array}
+      </TabsBinding.List>
+    </TabsBinding>
+  }
+}
+
+module ExportButton = {
+  @react.component
+  let make = (
+    ~selectedRowsCount,
+    ~canExportSelectedRows,
+    ~buttonState: Button.buttonState,
+    ~disabledCountClass,
+    ~onExport,
+  ) => {
+    let countClass = canExportSelectedRows
+      ? "border-white bg-white text-primary"
+      : `border-transparent bg-transparent ${disabledCountClass}`
+
+    <div className="relative shrink-0">
+      <Button
+        text="Export"
+        buttonType=Primary
+        buttonState
+        buttonSize=Small
+        customButtonStyle="!w-[128px] justify-start"
+        customIconMargin="ml-2"
+        customTextPaddingClass="!pl-2 !pr-8"
+        leftIcon={Button.CustomIcon(<Icon name="nd-download-bar-down" size=16 />)}
+        onClick={_ => canExportSelectedRows ? onExport() : ()}
+      />
+      <span
+        className={`pointer-events-none absolute right-2 top-1/2 flex h-5 min-w-5 -translate-y-1/2 items-center justify-center rounded-full border px-1 text-xs font-semibold leading-none ${countClass}`}>
+        {selectedRowsCount->Int.toString->React.string}
+      </span>
+    </div>
+  }
+}

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -8,18 +8,19 @@ module SourceTabs = {
     <TabsBinding
       value={source->OrderTypes.getPaymentListSourceLabel}
       onValueChange={value => {
-        switch value {
-        | "Advanced" =>
+        switch value->OrderTypes.getPaymentListSourceFromLabel {
+        | Some(OrderTypes.Advanced) =>
           if advancedEnabled {
             setSource(_ => OrderTypes.Advanced)
           }
-        | _ => setSource(_ => OrderTypes.Normal)
+        | Some(OrderTypes.Normal) => setSource(_ => OrderTypes.Normal)
+        | None => ()
         }
       }}
       variant=Boxed
       size=Md>
       <TabsBinding.List variant=Boxed size=Md fitContent=true>
-        {[OrderTypes.Normal, OrderTypes.Advanced]
+        {OrderTypes.paymentListSources
         ->Array.map(item => {
           let value = item->OrderTypes.getPaymentListSourceLabel
           let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
@@ -29,7 +30,7 @@ module SourceTabs = {
             variant=Boxed
             size=Md
             disabled=isDisabled
-            className="min-w-[75px] justify-center">
+            className="min-w-20 justify-center">
             <ToolTip
               description={item->OrderTypes.getPaymentListSourceDescription}
               toolTipFor={<span>
@@ -51,29 +52,27 @@ module ExportButton = {
     ~selectedRowsCount,
     ~canExportSelectedRows,
     ~buttonState: Button.buttonState,
-    ~disabledCountClass,
     ~onExport,
   ) => {
-    let countClass = canExportSelectedRows
-      ? "border-white bg-white text-primary"
-      : `border-transparent bg-transparent ${disabledCountClass}`
+    let selectedRowsCountClass = canExportSelectedRows ? "text-white" : "text-nd_gray-500"
 
-    <div className="relative shrink-0">
+    <div className="shrink-0">
       <Button
         text="Export"
         buttonType=Primary
         buttonState
         buttonSize=Small
-        customButtonStyle="!w-[128px] justify-start"
+        customButtonStyle="justify-start"
         customIconMargin="ml-2"
-        customTextPaddingClass="!pl-2 !pr-8"
+        customTextPaddingClass="!pl-2 !pr-1"
         leftIcon={Button.CustomIcon(<Icon name="nd-download-bar-down" size=16 />)}
+        rightIcon={Button.CustomIcon(
+          <span className={`${Typography.body.sm.semibold} ${selectedRowsCountClass}`}>
+            {selectedRowsCount->Int.toString->React.string}
+          </span>,
+        )}
         onClick={_ => canExportSelectedRows ? onExport() : ()}
       />
-      <span
-        className={`pointer-events-none absolute right-2 top-1/2 flex h-5 min-w-5 -translate-y-1/2 items-center justify-center rounded-full border px-1 text-xs font-semibold leading-none ${countClass}`}>
-        {selectedRowsCount->Int.toString->React.string}
-      </span>
     </div>
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR adds the hidden foundation required for the upcoming Advanced/OpenSearch payments list.

Changes included:

- Extends analytics payment row and common payment types with OpenSearch payment fields.
- Maps the new analytics fields into the existing common payment payload model.
- Adds OpenSearch payment column definitions, cell helpers, related activity helpers, and CSV row mapping.
- Adds local Advanced payment filter/search payload helpers, including email detection for Advanced search.
- Keeps the existing `initialFilters` API backward compatible for the current Payments page.
- Adds reusable `NewFeatureTag` for the follow-up UI PR.

This PR intentionally does not wire these helpers into the Payments page UI.

## Motivation and Context

The Advanced/OpenSearch payments list changes are being split into two PRs to keep review and rollout safe.

This first PR adds only the non-rendering foundation. After this PR is merged, users should not see any new Payments page UI, even when the existing `devOpensearch` flag is enabled. The follow-up PR will wire the source switch, Advanced table, export button, filters, search, and transaction cards.

## How did you test it?

- Ran `npm run re:build`
- Ran `git diff --check`
- Verified the PR diff does not include `Orders.res`, `config/config.toml`, webpack dev config, source-toggle UI, export button wiring, or table-selection wiring.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

N/A for this hidden foundation PR. The follow-up UI PR will depend on the OpenSearch analytics list response fields being available in the target environment.

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

No new config variable or feature flag is added in this PR. Existing `devOpensearch` remains unchanged and this PR does not add new UI rendering behind it.

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
