### PR TITLE
ci: Move visual tests into an separate job

### DIFF
--- a/.github/scripts/ctrf-merge-summary.mjs
+++ b/.github/scripts/ctrf-merge-summary.mjs
@@ -34,7 +34,7 @@ function walk(d) {
   for (const e of entries) {
     const p = join(d, e);
     if (statSync(p).isDirectory()) files = files.concat(walk(p));
-    else if (/^ctrf-shard-\d+\.json$/.test(e)) files.push(p);
+    else if (/^ctrf-shard-(\d+|visual)\.json$/.test(e)) files.push(p);
   }
   return files;
 }
@@ -72,7 +72,8 @@ const push = (map, shard, value) => {
 };
 
 for (const file of files) {
-  const shard = Number(basename(file).match(/ctrf-shard-(\d+)\.json/)[1]);
+  const shardRaw = basename(file).match(/ctrf-shard-(\d+|visual)\.json/)[1];
+  const shard = shardRaw === "visual" ? "visual" : Number(shardRaw);
   let report;
   try {
     report = JSON.parse(readFileSync(file, "utf8"));
@@ -129,9 +130,14 @@ const section = (map, title, count, open) => {
     `<details${open ? " open" : ""}><summary><b>${title} (${count})</b></summary>`,
     "",
   );
-  for (const shard of [...map.keys()].sort((a, b) => a - b)) {
+  for (const shard of [...map.keys()].sort((a, b) => {
+    if (typeof a === "number" && typeof b === "number") return a - b;
+    if (typeof a === "number") return -1;
+    if (typeof b === "number") return 1;
+    return String(a).localeCompare(String(b));
+  })) {
     const items = map.get(shard);
-    out.push(`**Shard ${shard}/4** (${items.length})`, "");
+    out.push(`**${typeof shard === "number" ? `Shard ${shard}/4` : "Visual Tests"}** (${items.length})`, "");
     for (const item of items) out.push(`- \`${item}\``);
     out.push("");
   }

--- a/.github/workflows/playwright-test.yml
+++ b/.github/workflows/playwright-test.yml
@@ -119,7 +119,7 @@ jobs:
           echo "$response"
 
       - name: Run Playwright tests (Shard ${{ matrix.shard }}/4)
-        run: npx playwright test --shard=${{ matrix.shard }}/4
+        run: npx playwright test e2e --shard=${{ matrix.shard }}/4
         env:
           PW_COVERAGE: "1"
           PLAYWRIGHT_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
@@ -185,8 +185,116 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
+  visual-tests:
+    needs: setup
+    runs-on: ubuntu-latest
+    # Skip the visual suite when a single shard is re-run via workflow_dispatch.
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.shard != 'all') }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Start backend services
+        env:
+          HYPERSWITCH_TAG: ${{ vars.HYPERSWITCH_TAG }}
+        run: |
+          chmod +x playwright-tests/start_hyperswitch.sh
+          ./playwright-tests/start_hyperswitch.sh
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-dist
+          path: dist/
+
+      - name: Restore Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright browsers (fallback on cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Health check for Backend
+        run: |
+          response=$(curl --location --request GET 'http://0.0.0.0:8080/health')
+          echo "Response:"
+          echo "$response"
+
+      - name: Run Playwright visual tests
+        run: npx playwright test visual-testing
+        env:
+          PW_COVERAGE: "1"
+          PLAYWRIGHT_USERNAME: ${{ secrets.CYPRESS_USERNAME }}
+          PLAYWRIGHT_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
+
+      - name: Stage visual CTRF report
+        if: always()
+        run: |
+          src=$(ls ctrf/*.json 2>/dev/null | head -1 || true)
+          if [ -z "$src" ]; then
+            echo "No CTRF report found for visual tests."
+            exit 0
+          fi
+          cp "$src" "ctrf-shard-visual.json"
+
+      - name: Artifact - Visual CTRF report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-ctrf-shard-visual
+          path: ctrf-shard-visual.json
+          if-no-files-found: warn
+          retention-days: 1
+
+      - name: Artifact - Failed Visual Test Artifacts
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-visual-artifacts
+          path: |
+            test-results/**/*-failed-*
+            test-results/**/*-retry*/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Merge visual Istanbul coverage
+        if: always()
+        run: |
+          if [ -z "$(ls -A .nyc_output 2>/dev/null)" ]; then
+            echo "No coverage data in .nyc_output for visual tests; skipping."
+            exit 0
+          fi
+          npx nyc merge .nyc_output "coverage-shard-visual.json"
+          echo "Merged $(ls .nyc_output | wc -l) per-test file(s) for visual tests."
+
+      - name: Artifact - Playwright Visual Coverage Report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-coverage-shard-visual
+          path: coverage-shard-visual.json
+          if-no-files-found: warn
+          retention-days: 1
+
   merge-reports:
-    needs: playwright-tests
+    needs: [playwright-tests, visual-tests]
     runs-on: ubuntu-latest
     if: always()
     permissions:


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Splits visual tests out of the sharded Playwright runs into a dedicated visual-tests job within the same workflow.
Changes to .github/workflows/playwright-test.yml:
- Restricted the 4 sharded playwright-tests jobs to E2E only: npx playwright test e2e --shard=... (previously ran the entire playwright-tests/ directory including visual tests)
- Added a new visual-tests job (needs: setup) that runs npx playwright test visual-testing as a single non-matrix job, in parallel with the 4 shards
- The job mirrors the shard setup: checkout → start backend services → download playwright-dist artifact → restore browsers → health check → run tests with PW_COVERAGE=1
- Visual test CTRF and coverage artifacts use playwright-ctrf-shard-visual / playwright-coverage-shard-visual naming so they are picked up by the existing * glob patterns in merge-reports
- Failed test artifacts uploaded separately as playwright-visual-artifacts
- merge-reports now needs: [playwright-tests, visual-tests] so both CTRF and coverage are merged together
- Visual job is skipped when a single shard is re-run via workflow_dispatch (inputs.shard != 'all')
Changes to .github/scripts/ctrf-merge-summary.mjs:
- Updated file regex to accept ctrf-shard-visual.json alongside ctrf-shard-<N>.json
- Shard identifier now parsed as either a number or the string "visual"
- Sort comparator handles mixed types (numbers first, strings after)
- Section header renders Visual Tests instead of Shard N/4 for the visual group


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

Visual tests were previously bundled into the 4 required sharded jobs (playwright-tests (1–4)). This meant:
- Visual test failures blocked PR merging even though they are inherently flaky (snapshot diffs from font rendering, timing, etc.)
- Re-running a single shard to fix a functional test failure would also re-run all visual tests in that shard
Moving visual tests to a separate parallel job allows them to run alongside the shards (same setup dependency, same build artifact) while keeping them off the required status checks list. Functional E2E tests and visual tests no longer interfere with each other's re-run cadence.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Verified path filters with --list:
- npx playwright test visual-testing --list → 84 tests in 8 files (only playwright-tests/visual-testing/**)
- npx playwright test e2e --list → 667 tests in 36 files, 0 from visual-testing/
- Confirmed no overlap between e2e and visual-testing path filters
2. Validated workflow YAML syntax with yaml.safe_load()
3. Validated JS syntax of ctrf-merge-summary.mjs with node -c
4. Verified artifact name compatibility — the existing merge-reports download patterns (playwright-ctrf-shard-*, playwright-coverage-shard-*) and the find ... -name 'coverage-shard-*.json' command already match the visual artifacts via glob, so no additional changes were needed in the merge job

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [ ] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [ ] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
