### PR TITLE
feat: add advanced payment list foundation

### DIFF
--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -55,6 +55,7 @@ type analytics_row = {
   merchant_order_reference_id: string,
   attempt_count: int,
   connector_label: string,
+  // These names intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id: string,
   card_last_4: string,
   card_network: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -55,7 +55,6 @@ type analytics_row = {
   merchant_order_reference_id: string,
   attempt_count: int,
   connector_label: string,
-  // These names intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id: string,
   card_last_4: string,
   card_network: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceAnalyticsTypes.res
@@ -56,5 +56,13 @@ type analytics_row = {
   attempt_count: int,
   connector_label: string,
   active_attempt_id: string,
+  card_last_4: string,
+  card_network: string,
+  card_issuer: string,
+  refunds_status: string,
+  refunds_count: int,
+  dispute_status: string,
+  dispute_count: int,
+  routing_approach: string,
   attempts_list: array<analytics_attempt>,
 }

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -134,7 +134,6 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
-  // These optional fields intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id?: string,
   card_last_4?: string,
   card_issuer?: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -134,6 +134,7 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
+  // These optional fields intentionally mirror the analytics/OpenSearch response contract.
   active_attempt_id?: string,
   card_last_4?: string,
   card_issuer?: string,

--- a/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceTypes/PaymentInterfaceTypes.res
@@ -113,6 +113,7 @@ type order = {
   order_quantity?: string,
   product_name?: string,
   card_brand?: string,
+  card_network?: string,
   payment_experience: string,
   frm_message: frmMessage,
   connector_payment_id: string,
@@ -133,6 +134,16 @@ type order = {
   extended_auth_applied?: bool,
   request_extended_auth?: bool,
   hyperswitch_error_description?: string,
+  active_attempt_id?: string,
+  card_last_4?: string,
+  card_issuer?: string,
+  refunds_status?: string,
+  refunds_count?: int,
+  dispute_status?: string,
+  dispute_count?: int,
+  routing_approach?: string,
+  unified_code?: string,
+  unified_message?: string,
 }
 
 type ordersObject = {

--- a/src/Interface/PaymentInterface/PaymentInterfaceUtils/PaymentInterfaceUtilsAnalytics.res
+++ b/src/Interface/PaymentInterface/PaymentInterfaceUtils/PaymentInterfaceUtilsAnalytics.res
@@ -52,7 +52,7 @@ let getAnalyticsRow = (json: JSON.t): analytics_row => {
     next_action: dict->getString("next_action", ""),
     cancellation_reason: dict->getString("cancellation_reason", ""),
     error_code: dict->getString("error_code", ""),
-    error_message: dict->getString("error_message", ""),
+    error_message: dict->getString("error_message", dict->getString("error_reason", "")),
     unified_code: dict->getString("unified_code", ""),
     unified_message: dict->getString("unified_message", ""),
     connector: dict->getString("connector", ""),
@@ -65,6 +65,14 @@ let getAnalyticsRow = (json: JSON.t): analytics_row => {
     attempt_count: dict->getInt("attempt_count", 0),
     connector_label: dict->getString("connector_label", ""),
     active_attempt_id: dict->getString("active_attempt_id", ""),
+    card_last_4: dict->getString("card_last_4", ""),
+    card_network: dict->getString("card_network", ""),
+    card_issuer: dict->getString("card_issuer", ""),
+    refunds_status: dict->getString("refunds_status", ""),
+    refunds_count: dict->getInt("refunds_count", 0),
+    dispute_status: dict->getString("dispute_status", ""),
+    dispute_count: dict->getInt("dispute_count", 0),
+    routing_approach: dict->getString("routing_approach", ""),
     attempts_list: dict
     ->getArrayFromDict("attempts_list", [])
     ->JSON.Encode.array
@@ -191,6 +199,7 @@ let mapAnalyticsRowToCommonType = (row: analytics_row): PaymentInterfaceTypes.or
     order_quantity: "",
     product_name: "",
     card_brand: "",
+    card_network: row.card_network,
     payment_experience: row.payment_experience,
     frm_message: {
       frm_name: row.frm_message,
@@ -215,6 +224,16 @@ let mapAnalyticsRowToCommonType = (row: analytics_row): PaymentInterfaceTypes.or
     extended_auth_applied: false,
     request_extended_auth: false,
     hyperswitch_error_description: "",
+    active_attempt_id: row.active_attempt_id,
+    card_last_4: row.card_last_4,
+    card_issuer: row.card_issuer,
+    refunds_status: row.refunds_status,
+    refunds_count: row.refunds_count,
+    dispute_status: row.dispute_status,
+    dispute_count: row.dispute_count,
+    routing_approach: row.routing_approach,
+    unified_code: row.unified_code,
+    unified_message: row.unified_message,
   }
 }
 

--- a/src/Recoils/TableAtoms.res
+++ b/src/Recoils/TableAtoms.res
@@ -6,6 +6,11 @@ let payoutsMapDefaultCols = Recoil.atom("payoutsMapDefaultCols", PayoutsEntity.d
 
 let ordersMapDefaultCols = Recoil.atom("ordersMapDefaultCols", OrderEntity.defaultColumns)
 
+let ordersAdvancedMapDefaultCols = Recoil.atom(
+  "ordersAdvancedMapDefaultCols",
+  OrderEntity.openSearchDefaultColumns,
+)
+
 let disputesMapDefaultCols = Recoil.atom("disputesMapDefaultCols", DisputesEntity.defaultColumns)
 
 let apiDefaultCols = Recoil.atom("hyperSwitchApiDefaultCols", DeveloperUtils.defaultColumns)

--- a/src/components/CustomizeTableColumns.res
+++ b/src/components/CustomizeTableColumns.res
@@ -13,6 +13,8 @@ let make = (
   ~showSerialNumber=true,
   ~isDraggable=false,
   ~title,
+  ~isNewColumn=_ => false,
+  ~getNewColumnDescription=_ => "",
 ) => {
   open LoadedTableWithCustomColumnsUtils
   let headingWhenDraggable = {
@@ -48,11 +50,20 @@ let make = (
   let initialHeadingData = heading->Array.map(head => {
     let columnName = getHeading(head).title
     let isDisabled = defaultColumnsString->Array.includes(columnName)
-    let options: SelectBox.dropdownOption = {
-      label: columnName,
-      value: columnName,
-      isDisabled,
-    }
+    let options: SelectBox.dropdownOption = isNewColumn(head)
+      ? {
+          label: columnName,
+          value: columnName,
+          isDisabled,
+          icon: Button.CustomRightIcon(
+            <NewFeatureTag description={getNewColumnDescription(head)} />,
+          ),
+        }
+      : {
+          label: columnName,
+          value: columnName,
+          isDisabled,
+        }
     options
   })
   let initialValues = visibleColumns->Array.map(head => getHeading(head).title)

--- a/src/components/DynamicTableUtils.res
+++ b/src/components/DynamicTableUtils.res
@@ -286,6 +286,8 @@ module ChooseColumns = {
     ~mandatoryOptions=[],
     ~isDraggable=false,
     ~title="",
+    ~isNewColumn=_ => false,
+    ~getNewColumnDescription=_ => "",
   ) => {
     open LoadedTableWithCustomColumnsUtils
     let (visibleColumns, setVisibleColumns) = Recoil.useRecoilState(activeColumnsAtom)
@@ -350,6 +352,8 @@ module ChooseColumns = {
         showSerialNumber
         isDraggable
         title
+        isNewColumn
+        getNewColumnDescription
       />
     } else {
       React.null
@@ -372,6 +376,8 @@ module ChooseColumnsWrapper = {
     ~setShowDropDown=_ => (),
     ~isDraggable=false,
     ~title="",
+    ~isNewColumn=_ => false,
+    ~getNewColumnDescription=_ => "",
   ) => {
     switch optionalActiveColumnsAtom {
     | Some(activeColumnsAtom) =>
@@ -388,6 +394,8 @@ module ChooseColumnsWrapper = {
           showSerialNumber
           isDraggable
           title
+          isNewColumn
+          getNewColumnDescription
         />
       </AddDataAttributes>
     | None => React.null

--- a/src/components/LoadedTableWithCustomColumns/LoadedTableWithCustomColumns.res
+++ b/src/components/LoadedTableWithCustomColumns/LoadedTableWithCustomColumns.res
@@ -70,6 +70,8 @@ let make = (
   ~isDraggable=false,
   ~customSeparation=?,
   ~checkBoxProps: option<LoadedTable.checkBoxProps>=?,
+  ~isNewColumn=_ => false,
+  ~getNewColumnDescription=_ => "",
 ) => {
   let (showColumnSelector, setShowColumnSelector) = React.useState(() => false)
   let activeColumnsAtom = customColumnMapper->Some
@@ -87,6 +89,8 @@ let make = (
       sortingBasedOnDisabled
       showSerialNumber={showSerialNumberInCustomizeColumns}
       isDraggable
+      isNewColumn
+      getNewColumnDescription
     />
 
   let filt =

--- a/src/components/NewFeatureTag.res
+++ b/src/components/NewFeatureTag.res
@@ -1,10 +1,14 @@
 @react.component
 let make = (~className="", ~description="") => {
+  let hasDescription = description->LogicUtils.isNonEmptyString
   let tag =
     <span className={`inline-flex shrink-0 items-center align-middle ${className}`}>
       <TagBinding text="NEW" color=Primary variant=Subtle shape=Squarical size=Xs />
     </span>
-  description->LogicUtils.isNonEmptyString
-    ? <ToolTip description toolTipFor=tag toolTipPosition=ToolTip.Top />
-    : tag
+  <>
+    <RenderIf condition=hasDescription>
+      <ToolTip description toolTipFor=tag toolTipPosition=ToolTip.Top />
+    </RenderIf>
+    <RenderIf condition={!hasDescription}> tag </RenderIf>
+  </>
 }

--- a/src/components/NewFeatureTag.res
+++ b/src/components/NewFeatureTag.res
@@ -1,0 +1,10 @@
+@react.component
+let make = (~className="", ~description="") => {
+  let tag =
+    <span className={`inline-flex shrink-0 items-center align-middle ${className}`}>
+      <TagBinding text="NEW" color=Primary variant=Subtle shape=Squarical size=Xs />
+    </span>
+  description->LogicUtils.isNonEmptyString
+    ? <ToolTip description toolTipFor=tag toolTipPosition=ToolTip.Top />
+    : tag
+}

--- a/src/components/NewFeatureTag.res
+++ b/src/components/NewFeatureTag.res
@@ -7,7 +7,7 @@ let make = (~className="", ~description="") => {
     </span>
   <>
     <RenderIf condition=hasDescription>
-      <ToolTip description toolTipFor=tag toolTipPosition=ToolTip.Top />
+      <ToolTip description toolTipFor=tag toolTipPosition=Top />
     </RenderIf>
     <RenderIf condition={!hasDescription}> tag </RenderIf>
   </>

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -441,65 +441,138 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-let csvHeaders = [
-  ("payment_id", "Payment ID"),
-  ("status", "Payment Status"),
-  ("amount", "Amount"),
-  ("currency", "Currency"),
-  ("connector", "Connector"),
-  ("payment_method", "Payment Method"),
-  ("payment_method_type", "Payment Method Type"),
-  ("profile_id", "Profile ID"),
-  ("merchant_id", "Merchant ID"),
-  ("customer_id", "Customer ID"),
-  ("active_attempt_id", "Active Attempt ID"),
-  ("merchant_connector_id", "Merchant Connector ID"),
-  ("card_last_4", "Card Last 4"),
-  ("card_network", "Card Network"),
-  ("card_issuer", "Card Issuer"),
-  ("refunds_status", "Refund Status"),
-  ("refunds_count", "Refund Count"),
-  ("dispute_status", "Dispute Status"),
-  ("dispute_count", "Dispute Count"),
-  ("routing_approach", "Routing Approach"),
-  ("unified_code", "Unified Code"),
-  ("unified_message", "Unified Message"),
-  ("created", "Created"),
-  ("modified", "Modified"),
+type openSearchCsvColumn =
+  | CsvPaymentId
+  | CsvStatus
+  | CsvAmount
+  | CsvCurrency
+  | CsvConnector
+  | CsvPaymentMethod
+  | CsvPaymentMethodType
+  | CsvProfileId
+  | CsvMerchantId
+  | CsvCustomerId
+  | CsvActiveAttemptId
+  | CsvMerchantConnectorId
+  | CsvCardLast4
+  | CsvCardNetwork
+  | CsvCardIssuer
+  | CsvRefundsStatus
+  | CsvRefundsCount
+  | CsvDisputeStatus
+  | CsvDisputeCount
+  | CsvRoutingApproach
+  | CsvUnifiedCode
+  | CsvUnifiedMessage
+  | CsvCreated
+  | CsvModified
+
+let openSearchCsvColumns = [
+  CsvPaymentId,
+  CsvStatus,
+  CsvAmount,
+  CsvCurrency,
+  CsvConnector,
+  CsvPaymentMethod,
+  CsvPaymentMethodType,
+  CsvProfileId,
+  CsvMerchantId,
+  CsvCustomerId,
+  CsvActiveAttemptId,
+  CsvMerchantConnectorId,
+  CsvCardLast4,
+  CsvCardNetwork,
+  CsvCardIssuer,
+  CsvRefundsStatus,
+  CsvRefundsCount,
+  CsvDisputeStatus,
+  CsvDisputeCount,
+  CsvRoutingApproach,
+  CsvUnifiedCode,
+  CsvUnifiedMessage,
+  CsvCreated,
+  CsvModified,
 ]
 
+let getOpenSearchCsvKey = column =>
+  switch column {
+  | CsvPaymentId => "payment_id"
+  | CsvStatus => "status"
+  | CsvAmount => "amount"
+  | CsvCurrency => "currency"
+  | CsvConnector => "connector"
+  | CsvPaymentMethod => "payment_method"
+  | CsvPaymentMethodType => "payment_method_type"
+  | CsvProfileId => "profile_id"
+  | CsvMerchantId => "merchant_id"
+  | CsvCustomerId => "customer_id"
+  | CsvActiveAttemptId => "active_attempt_id"
+  | CsvMerchantConnectorId => "merchant_connector_id"
+  | CsvCardLast4 => "card_last_4"
+  | CsvCardNetwork => "card_network"
+  | CsvCardIssuer => "card_issuer"
+  | CsvRefundsStatus => "refunds_status"
+  | CsvRefundsCount => "refunds_count"
+  | CsvDisputeStatus => "dispute_status"
+  | CsvDisputeCount => "dispute_count"
+  | CsvRoutingApproach => "routing_approach"
+  | CsvUnifiedCode => "unified_code"
+  | CsvUnifiedMessage => "unified_message"
+  | CsvCreated => "created"
+  | CsvModified => "modified"
+  }
+
+let getOpenSearchCsvHeader = column =>
+  switch column {
+  | CsvPaymentId => "Payment ID"
+  | CsvStatus => "Payment Status"
+  | CsvAmount => "Amount"
+  | CsvCurrency => "Currency"
+  | CsvConnector => "Connector"
+  | CsvPaymentMethod => "Payment Method"
+  | CsvPaymentMethodType => "Payment Method Type"
+  | CsvProfileId => "Profile ID"
+  | CsvMerchantId => "Merchant ID"
+  | CsvCustomerId => "Customer ID"
+  | CsvActiveAttemptId => "Active Attempt ID"
+  | CsvMerchantConnectorId => "Merchant Connector ID"
+  | CsvCardLast4 => "Card Last 4"
+  | CsvCardNetwork => "Card Network"
+  | CsvCardIssuer => "Card Issuer"
+  | CsvRefundsStatus => "Refund Status"
+  | CsvRefundsCount => "Refund Count"
+  | CsvDisputeStatus => "Dispute Status"
+  | CsvDisputeCount => "Dispute Count"
+  | CsvRoutingApproach => "Routing Approach"
+  | CsvUnifiedCode => "Unified Code"
+  | CsvUnifiedMessage => "Unified Message"
+  | CsvCreated => "Created"
+  | CsvModified => "Modified"
+  }
+
+let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, column) =>
+  switch column {
+  | CsvAmount => dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string
+  | CsvRefundsCount => dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string
+  | CsvDisputeCount => dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string
+  | CsvMerchantConnectorId =>
+    dict
+    ->getString("merchant_connector_id", dict->getString("connector_id", ""))
+    ->JSON.Encode.string
+  | CsvCreated => dict->getString("created_at", "")->JSON.Encode.string
+  | CsvModified => dict->getString("modified_at", "")->JSON.Encode.string
+  | column => dict->getString(column->getOpenSearchCsvKey, "")->JSON.Encode.string
+  }
+
+let csvHeaders =
+  openSearchCsvColumns->Array.map(column => (
+    column->getOpenSearchCsvKey,
+    column->getOpenSearchCsvHeader,
+  ))
+
 let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
-  [
-    ("payment_id", dict->getString("payment_id", "")->JSON.Encode.string),
-    ("status", dict->getString("status", "")->JSON.Encode.string),
-    ("amount", dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string),
-    ("currency", dict->getString("currency", "")->JSON.Encode.string),
-    ("connector", dict->getString("connector", "")->JSON.Encode.string),
-    ("payment_method", dict->getString("payment_method", "")->JSON.Encode.string),
-    ("payment_method_type", dict->getString("payment_method_type", "")->JSON.Encode.string),
-    ("profile_id", dict->getString("profile_id", "")->JSON.Encode.string),
-    ("merchant_id", dict->getString("merchant_id", "")->JSON.Encode.string),
-    ("customer_id", dict->getString("customer_id", "")->JSON.Encode.string),
-    ("active_attempt_id", dict->getString("active_attempt_id", "")->JSON.Encode.string),
-    (
-      "merchant_connector_id",
-      dict
-      ->getString("merchant_connector_id", dict->getString("connector_id", ""))
-      ->JSON.Encode.string,
-    ),
-    ("card_last_4", dict->getString("card_last_4", "")->JSON.Encode.string),
-    ("card_network", dict->getString("card_network", "")->JSON.Encode.string),
-    ("card_issuer", dict->getString("card_issuer", "")->JSON.Encode.string),
-    ("refunds_status", dict->getString("refunds_status", "")->JSON.Encode.string),
-    ("refunds_count", dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string),
-    ("dispute_status", dict->getString("dispute_status", "")->JSON.Encode.string),
-    ("dispute_count", dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string),
-    ("routing_approach", dict->getString("routing_approach", "")->JSON.Encode.string),
-    ("unified_code", dict->getString("unified_code", "")->JSON.Encode.string),
-    ("unified_message", dict->getString("unified_message", "")->JSON.Encode.string),
-    ("created", dict->getString("created_at", "")->JSON.Encode.string),
-    ("modified", dict->getString("modified_at", "")->JSON.Encode.string),
-  ]
+  openSearchCsvColumns
+  ->Array.map(column => (column->getOpenSearchCsvKey, getOpenSearchCsvValue(dict, column)))
   ->Dict.fromArray
   ->JSON.Encode.object
 
@@ -614,20 +687,17 @@ let formatActivityCount = (count, label) => {
 type activityTag = {label: string}
 
 let getActivityTags = order => {
-  let refundsCount = switch order.refunds_count {
-  | Some(count) => count
-  | None => order.refunds->Array.length
-  }
+  let refundsCount = order.refunds_count->Option.mapOr(order.refunds->Array.length, count => count)
   let disputeStatus = order.dispute_status->Option.getOr("")
-  let disputesCount = switch order.dispute_count {
-  | Some(count) => count
-  | None =>
-    order.disputes->Array.length > 0
-      ? order.disputes->Array.length
-      : disputeStatus->isNonEmptyString
-      ? 1
-      : 0
-  }
+  let disputesCount =
+    order.dispute_count->Option.mapOr(
+      order.disputes->isNonEmptyArray
+        ? order.disputes->Array.length
+        : disputeStatus->isNonEmptyString
+        ? 1
+        : 0,
+      count => count,
+    )
 
   let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
   let disputeTags =
@@ -638,30 +708,31 @@ let getActivityTags = order => {
 
 let getActivitiesCell = (order): Table.cell => {
   let activityTags = order->getActivityTags
-  if activityTags->Array.length == 0 {
-    CustomCell(
-      <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>,
-      "-",
-    )
-  } else {
-    let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
-    CustomCell(
-      <ToolTip
-        description=activityText
-        toolTipFor={<div className="w-40 overflow-hidden">
-          <div className="flex items-center gap-1 whitespace-nowrap">
-            {activityTags
-            ->Array.map(tag =>
-              <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
-            )
-            ->React.array}
-          </div>
-        </div>}
-        toolTipPosition=ToolTip.Top
-      />,
-      activityText,
-    )
-  }
+  let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
+
+  CustomCell(
+    <>
+      <RenderIf condition={activityTags->isEmptyArray}>
+        <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>
+      </RenderIf>
+      <RenderIf condition={activityTags->isNonEmptyArray}>
+        <ToolTip
+          description=activityText
+          toolTipFor={<div className="w-40 overflow-hidden">
+            <div className="flex items-center gap-1 whitespace-nowrap">
+              {activityTags
+              ->Array.map(tag =>
+                <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
+              )
+              ->React.array}
+            </div>
+          </div>}
+          toolTipPosition=ToolTip.Top
+        />
+      </RenderIf>
+    </>,
+    activityTags->isEmptyArray ? "-" : activityText,
+  )
 }
 
 let formatAdvancedDisplayValue = value => value->isNonEmptyString ? value->snakeToTitle : ""

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -2,6 +2,8 @@ open PaymentInterfaceTypes
 open LogicUtils
 open OrderTypes
 
+type activityTag = {label: string}
+
 module CurrencyCell = {
   @react.component
   let make = (~amount, ~currency) => {
@@ -336,7 +338,6 @@ let openSearchNewColumns = [
   CardIssuer,
   RefundsStatus,
   RefundsCount,
-  Activities,
   RoutingApproach,
   UnifiedCode,
   UnifiedMessage,
@@ -436,6 +437,7 @@ let openSearchBaseColumns: array<colType> = [
   Status,
   AttemptCount,
   CardNetwork,
+  Activities,
   ErrorMessage,
 ]
 
@@ -547,8 +549,7 @@ let csvHeaders =
 let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
   openSearchCsvColumns
   ->Array.map(column => (column->getOpenSearchCsvKey, getOpenSearchCsvValue(dict, column)))
-  ->Dict.fromArray
-  ->JSON.Encode.object
+  ->getJsonFromArrayOfJson
 
 let getHeading = (~devSortEnabled, colType: colType) => {
   switch colType {
@@ -654,24 +655,20 @@ let useGetStatus = (order: order) => {
 }
 
 let formatActivityCount = (count, label) => {
-  let suffix = count == 1 ? "" : "S"
-  `${count->Int.toString} ${label}${suffix}`
+  `${count->Int.toString} ${pluralize(~count, ~singular=label, ~plural=`${label}S`)}`
 }
-
-type activityTag = {label: string}
 
 let getActivityTags = (order: order) => {
   let refundsCount = order.refunds_count->Option.mapOr(order.refunds->Array.length, count => count)
   let disputeStatus = order.dispute_status->Option.getOr("")
-  let disputesCount =
-    order.dispute_count->Option.mapOr(
-      order.disputes->isNonEmptyArray
-        ? order.disputes->Array.length
-        : disputeStatus->isNonEmptyString
-        ? 1
-        : 0,
-      count => count,
-    )
+  let fallbackDisputesCount = if order.disputes->isNonEmptyArray {
+    order.disputes->Array.length
+  } else if disputeStatus->isNonEmptyString {
+    1
+  } else {
+    0
+  }
+  let disputesCount = order.dispute_count->Option.mapOr(fallbackDisputesCount, count => count)
 
   let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
   let disputeTags =
@@ -701,7 +698,7 @@ let getActivitiesCell = (order: order): Table.cell => {
               ->React.array}
             </div>
           </div>}
-          toolTipPosition=ToolTip.Top
+          toolTipPosition=Top
         />
       </RenderIf>
     </>,

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -314,6 +314,51 @@ let defaultColumns: array<colType> = [
   Created,
   Modified,
 ]
+
+let openSearchDefaultColumns: array<colType> = [
+  PaymentId,
+  Connector,
+  ProfileId,
+  Amount,
+  Status,
+  Activities,
+  PaymentMethod,
+  PaymentMethodType,
+  CardNetwork,
+  Created,
+  Modified,
+]
+
+let openSearchNewColumns = [
+  MerchantConnectorId,
+  ActiveAttemptId,
+  CardLast4,
+  CardIssuer,
+  RefundsStatus,
+  RefundsCount,
+  Activities,
+  RoutingApproach,
+  UnifiedCode,
+  UnifiedMessage,
+]
+
+let isOpenSearchNewColumn = colType => openSearchNewColumns->Array.includes(colType)
+
+let getOpenSearchNewColumnDescription = colType =>
+  switch colType {
+  | MerchantConnectorId => "Connector account used for this payment attempt."
+  | ActiveAttemptId => "Current active payment attempt linked to the payment."
+  | CardLast4 => "Last 4 digits of the card used for the payment."
+  | CardIssuer => "Bank or institution that issued the card."
+  | RefundsStatus => "Refund state derived from the payment refund lifecycle."
+  | RefundsCount => "Number of refunds linked to this payment."
+  | Activities => "Related refund and dispute activity for this payment."
+  | RoutingApproach => "Routing strategy used to select the connector."
+  | UnifiedCode => "Normalized error or status code from Hyperswitch."
+  | UnifiedMessage => "Normalized message explaining the payment outcome."
+  | _ => ""
+  }
+
 //Columns array for V1 Orders page
 let allColumnsV1 = [
   Amount,
@@ -369,6 +414,94 @@ let allColumnsV2 = [
   PaymentType,
   ErrorMessage,
 ]
+
+let openSearchBaseColumns: array<colType> = [
+  Amount,
+  AmountCapturable,
+  AmountReceived,
+  AuthenticationType,
+  ProfileId,
+  CaptureMethod,
+  Connector,
+  ConnectorTransactionID,
+  Created,
+  Modified,
+  Currency,
+  CustomerId,
+  MerchantOrderReferenceId,
+  PaymentId,
+  PaymentMethod,
+  PaymentMethodType,
+  SetupFutureUsage,
+  Status,
+  AttemptCount,
+  CardNetwork,
+  ErrorMessage,
+]
+
+let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
+
+let csvHeaders = [
+  ("payment_id", "Payment ID"),
+  ("status", "Payment Status"),
+  ("amount", "Amount"),
+  ("currency", "Currency"),
+  ("connector", "Connector"),
+  ("payment_method", "Payment Method"),
+  ("payment_method_type", "Payment Method Type"),
+  ("profile_id", "Profile ID"),
+  ("merchant_id", "Merchant ID"),
+  ("customer_id", "Customer ID"),
+  ("active_attempt_id", "Active Attempt ID"),
+  ("merchant_connector_id", "Merchant Connector ID"),
+  ("card_last_4", "Card Last 4"),
+  ("card_network", "Card Network"),
+  ("card_issuer", "Card Issuer"),
+  ("refunds_status", "Refund Status"),
+  ("refunds_count", "Refund Count"),
+  ("dispute_status", "Dispute Status"),
+  ("dispute_count", "Dispute Count"),
+  ("routing_approach", "Routing Approach"),
+  ("unified_code", "Unified Code"),
+  ("unified_message", "Unified Message"),
+  ("created", "Created"),
+  ("modified", "Modified"),
+]
+
+let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
+  [
+    ("payment_id", dict->getString("payment_id", "")->JSON.Encode.string),
+    ("status", dict->getString("status", "")->JSON.Encode.string),
+    ("amount", dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string),
+    ("currency", dict->getString("currency", "")->JSON.Encode.string),
+    ("connector", dict->getString("connector", "")->JSON.Encode.string),
+    ("payment_method", dict->getString("payment_method", "")->JSON.Encode.string),
+    ("payment_method_type", dict->getString("payment_method_type", "")->JSON.Encode.string),
+    ("profile_id", dict->getString("profile_id", "")->JSON.Encode.string),
+    ("merchant_id", dict->getString("merchant_id", "")->JSON.Encode.string),
+    ("customer_id", dict->getString("customer_id", "")->JSON.Encode.string),
+    ("active_attempt_id", dict->getString("active_attempt_id", "")->JSON.Encode.string),
+    (
+      "merchant_connector_id",
+      dict
+      ->getString("merchant_connector_id", dict->getString("connector_id", ""))
+      ->JSON.Encode.string,
+    ),
+    ("card_last_4", dict->getString("card_last_4", "")->JSON.Encode.string),
+    ("card_network", dict->getString("card_network", "")->JSON.Encode.string),
+    ("card_issuer", dict->getString("card_issuer", "")->JSON.Encode.string),
+    ("refunds_status", dict->getString("refunds_status", "")->JSON.Encode.string),
+    ("refunds_count", dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string),
+    ("dispute_status", dict->getString("dispute_status", "")->JSON.Encode.string),
+    ("dispute_count", dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string),
+    ("routing_approach", dict->getString("routing_approach", "")->JSON.Encode.string),
+    ("unified_code", dict->getString("unified_code", "")->JSON.Encode.string),
+    ("unified_message", dict->getString("unified_message", "")->JSON.Encode.string),
+    ("created", dict->getString("created_at", "")->JSON.Encode.string),
+    ("modified", dict->getString("modified_at", "")->JSON.Encode.string),
+  ]
+  ->Dict.fromArray
+  ->JSON.Encode.object
 
 let getHeading = (~devSortEnabled, colType: colType) => {
   switch colType {
@@ -426,6 +559,17 @@ let getHeading = (~devSortEnabled, colType: colType) => {
   | AttemptCount =>
     Table.makeHeaderInfo(~key="attempt_count", ~title="Attempt Count", ~showSort=true)
   | PaymentType => Table.makeHeaderInfo(~key="payment_type", ~title="Payment Type")
+  | MerchantConnectorId =>
+    Table.makeHeaderInfo(~key="merchant_connector_id", ~title="Merchant Connector ID")
+  | ActiveAttemptId => Table.makeHeaderInfo(~key="active_attempt_id", ~title="Active Attempt ID")
+  | CardLast4 => Table.makeHeaderInfo(~key="card_last_4", ~title="Card Last 4")
+  | CardIssuer => Table.makeHeaderInfo(~key="card_issuer", ~title="Card Issuer")
+  | RefundsStatus => Table.makeHeaderInfo(~key="refunds_status", ~title="Refund Status")
+  | RefundsCount => Table.makeHeaderInfo(~key="refunds_count", ~title="Refund Count")
+  | Activities => Table.makeHeaderInfo(~key="activities", ~title="Related Activity")
+  | RoutingApproach => Table.makeHeaderInfo(~key="routing_approach", ~title="Routing Approach")
+  | UnifiedCode => Table.makeHeaderInfo(~key="unified_code", ~title="Unified Code")
+  | UnifiedMessage => Table.makeHeaderInfo(~key="unified_message", ~title="Unified Message")
   }
 }
 
@@ -461,6 +605,66 @@ let useGetStatus = order => {
     </div>
   }
 }
+
+let formatActivityCount = (count, label) => {
+  let suffix = count == 1 ? "" : "S"
+  `${count->Int.toString} ${label}${suffix}`
+}
+
+type activityTag = {label: string}
+
+let getActivityTags = order => {
+  let refundsCount = switch order.refunds_count {
+  | Some(count) => count
+  | None => order.refunds->Array.length
+  }
+  let disputeStatus = order.dispute_status->Option.getOr("")
+  let disputesCount = switch order.dispute_count {
+  | Some(count) => count
+  | None =>
+    order.disputes->Array.length > 0
+      ? order.disputes->Array.length
+      : disputeStatus->isNonEmptyString
+      ? 1
+      : 0
+  }
+
+  let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
+  let disputeTags =
+    disputesCount > 0 ? [{label: formatActivityCount(disputesCount, "DISPUTE")}] : []
+
+  refundTags->Array.concat(disputeTags)
+}
+
+let getActivitiesCell = (order): Table.cell => {
+  let activityTags = order->getActivityTags
+  if activityTags->Array.length == 0 {
+    CustomCell(
+      <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>,
+      "-",
+    )
+  } else {
+    let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
+    CustomCell(
+      <ToolTip
+        description=activityText
+        toolTipFor={<div className="w-40 overflow-hidden">
+          <div className="flex items-center gap-1 whitespace-nowrap">
+            {activityTags
+            ->Array.map(tag =>
+              <TagBinding text=tag.label color=Primary variant=Subtle shape=Squarical size=Xs />
+            )
+            ->React.array}
+          </div>
+        </div>}
+        toolTipPosition=ToolTip.Top
+      />,
+      activityText,
+    )
+  }
+}
+
+let formatAdvancedDisplayValue = value => value->isNonEmptyString ? value->snakeToTitle : ""
 
 let getHeadingForSummary = summaryColType => {
   switch summaryColType {
@@ -833,20 +1037,24 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
       },
     )
   | CardNetwork => {
-      let cardNetwork = switch order.payment_method_data {
-      | Some(val) =>
-        switch val->JSON.Classify.classify {
-        | Object(value) => Some(value->getString("card_network", ""))
-        | String(value) =>
-          Some(
-            value
-            ->safeParse
-            ->getDictFromJsonObject
-            ->getStringFromNestedDict("card", "card_network", ""),
-          )
+      let cardNetwork = switch order.card_network {
+      | Some(value) if value->LogicUtils.isNonEmptyString => Some(value)
+      | _ =>
+        switch order.payment_method_data {
+        | Some(val) =>
+          switch val->JSON.Classify.classify {
+          | Object(value) => Some(value->getString("card_network", ""))
+          | String(value) =>
+            Some(
+              value
+              ->safeParse
+              ->getDictFromJsonObject
+              ->getStringFromNestedDict("card", "card_network", ""),
+            )
+          | _ => None
+          }
         | _ => None
         }
-      | _ => None
       }->Option.mapOr("", val => val)
 
       Text(cardNetwork)
@@ -859,6 +1067,43 @@ let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
     | Some(false) => Text("Standard")
     | None => Text("N/A")
     }
+  | MerchantConnectorId =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-44 truncate whitespace-nowrap"
+        displayValue=Some(order.connector_id)
+        showTooltip=true
+      />,
+      "",
+    )
+  | ActiveAttemptId =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-40 truncate whitespace-nowrap"
+        displayValue=Some(order.active_attempt_id->Option.getOr(""))
+        showTooltip=true
+      />,
+      order.active_attempt_id->Option.getOr(""),
+    )
+  | CardLast4 => EllipsisText(order.card_last_4->Option.getOr(""), "w-20")
+  | CardIssuer =>
+    CustomCell(
+      <CopyTextCustomComp
+        customTextCss="w-36 truncate whitespace-nowrap"
+        displayValue=Some(order.card_issuer->Option.getOr(""))
+        showTooltip=true
+      />,
+      "",
+    )
+  | RefundsStatus =>
+    EllipsisText(order.refunds_status->Option.getOr("")->formatAdvancedDisplayValue, "w-28")
+  | RefundsCount => EllipsisText(order.refunds_count->Option.getOr(0)->Int.toString, "w-20")
+  | Activities => order->getActivitiesCell
+  | RoutingApproach =>
+    EllipsisText(order.routing_approach->Option.getOr("")->formatAdvancedDisplayValue, "w-36")
+  | UnifiedCode =>
+    EllipsisText(order.unified_code->Option.getOr("")->formatAdvancedDisplayValue, "w-32")
+  | UnifiedMessage => EllipsisText(order.unified_message->Option.getOr(""), "w-40")
   }
 }
 
@@ -888,5 +1133,22 @@ let orderEntity = (merchantId, orgId, ~version: UserInfoTypes.version=V1, ~devSo
           )
         }
       }
+    },
+  )
+
+let openSearchOrderEntity = (merchantId, orgId, ~devSortEnabled) =>
+  EntityType.makeEntity(
+    ~uri=``,
+    ~getObjects=getOrders,
+    ~defaultColumns=openSearchDefaultColumns,
+    ~allColumns=openSearchAllColumns,
+    ~getHeading=colType => getHeading(~devSortEnabled, colType),
+    ~getCell=(order, colType) => getCell(order, colType, merchantId, orgId),
+    ~dataKey="",
+    ~getShowLink={
+      order =>
+        GlobalVars.appendDashboardPath(
+          ~url=`/payments/${order.payment_id}/${order.profile_id}/${merchantId}/${orgId}`,
+        )
     },
   )

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -441,33 +441,7 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-type openSearchCsvColumn =
-  | CsvPaymentId
-  | CsvStatus
-  | CsvAmount
-  | CsvCurrency
-  | CsvConnector
-  | CsvPaymentMethod
-  | CsvPaymentMethodType
-  | CsvProfileId
-  | CsvMerchantId
-  | CsvCustomerId
-  | CsvActiveAttemptId
-  | CsvMerchantConnectorId
-  | CsvCardLast4
-  | CsvCardNetwork
-  | CsvCardIssuer
-  | CsvRefundsStatus
-  | CsvRefundsCount
-  | CsvDisputeStatus
-  | CsvDisputeCount
-  | CsvRoutingApproach
-  | CsvUnifiedCode
-  | CsvUnifiedMessage
-  | CsvCreated
-  | CsvModified
-
-let openSearchCsvColumns = [
+let openSearchCsvColumns: array<openSearchCsvColumn> = [
   CsvPaymentId,
   CsvStatus,
   CsvAmount,

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -654,11 +654,11 @@ let useGetStatus = (order: order) => {
 }
 
 let formatActivityCount = (count, label) => {
-  `${count->Int.toString} ${pluralize(~count, ~singular=label, ~plural=`${label}S`)}`
+  `${count->Int.toString} ${pluralize(~count, ~singular=label)}`
 }
 
 let getActivityTags = (order: order) => {
-  let refundsCount = order.refunds_count->Option.mapOr(order.refunds->Array.length, count => count)
+  let refundsCount = order.refunds_count->Option.getOr(order.refunds->Array.length)
   let disputeStatus = order.dispute_status->Option.getOr("")
   let fallbackDisputesCount = if order.disputes->isNonEmptyArray {
     order.disputes->Array.length
@@ -667,7 +667,7 @@ let getActivityTags = (order: order) => {
   } else {
     0
   }
-  let disputesCount = order.dispute_count->Option.mapOr(fallbackDisputesCount, count => count)
+  let disputesCount = order.dispute_count->Option.getOr(fallbackDisputesCount)
 
   let refundTags = refundsCount > 0 ? [{label: formatActivityCount(refundsCount, "REFUND")}] : []
   let disputeTags =

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -323,7 +323,6 @@ let openSearchDefaultColumns: array<colType> = [
   ProfileId,
   Amount,
   Status,
-  Activities,
   PaymentMethod,
   PaymentMethodType,
   CardNetwork,
@@ -338,6 +337,7 @@ let openSearchNewColumns = [
   CardIssuer,
   RefundsStatus,
   RefundsCount,
+  Activities,
   RoutingApproach,
   UnifiedCode,
   UnifiedMessage,
@@ -437,7 +437,6 @@ let openSearchBaseColumns: array<colType> = [
   Status,
   AttemptCount,
   CardNetwork,
-  Activities,
   ErrorMessage,
 ]
 

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -620,7 +620,7 @@ let getHeading = (~devSortEnabled, colType: colType) => {
   }
 }
 
-let useGetStatus = order => {
+let useGetStatus = (order: order) => {
   let {globalUIConfig: {primaryColor}} = React.useContext(ThemeProvider.themeContext)
   let orderStatusLabel = order.status->String.toUpperCase
   let fixedStatusCss = "text-sm text-white font-bold px-3 py-2 rounded-md"
@@ -660,7 +660,7 @@ let formatActivityCount = (count, label) => {
 
 type activityTag = {label: string}
 
-let getActivityTags = order => {
+let getActivityTags = (order: order) => {
   let refundsCount = order.refunds_count->Option.mapOr(order.refunds->Array.length, count => count)
   let disputeStatus = order.dispute_status->Option.getOr("")
   let disputesCount =
@@ -680,7 +680,7 @@ let getActivityTags = order => {
   refundTags->Array.concat(disputeTags)
 }
 
-let getActivitiesCell = (order): Table.cell => {
+let getActivitiesCell = (order: order): Table.cell => {
   let activityTags = order->getActivityTags
   let activityText = activityTags->Array.map(tag => tag.label)->Array.joinWith(", ")
 
@@ -818,7 +818,7 @@ let getHeadingForOtherDetails = otherDetailsColType => {
   }
 }
 
-let getCellForSummary = (order, summaryColType): Table.cell => {
+let getCellForSummary = (order: order, summaryColType): Table.cell => {
   let conversionFactor = CurrencyUtils.getCurrencyConversionFactor(order.currency)
   switch summaryColType {
   | Created => Date(order.created_at)
@@ -867,7 +867,10 @@ let getCellForSummary = (order, summaryColType): Table.cell => {
   }
 }
 
-let getCellForAboutPayment = (order, aboutPaymentColType: aboutPaymentColType): Table.cell => {
+let getCellForAboutPayment = (
+  order: order,
+  aboutPaymentColType: aboutPaymentColType,
+): Table.cell => {
   open HelperComponents
   switch aboutPaymentColType {
   | Connector =>
@@ -901,7 +904,10 @@ let getCellForAboutPayment = (order, aboutPaymentColType: aboutPaymentColType): 
   }
 }
 
-let getCellForOtherDetails = (order, aboutPaymentColType: otherDetailsColType): Table.cell => {
+let getCellForOtherDetails = (
+  order: order,
+  aboutPaymentColType: otherDetailsColType,
+): Table.cell => {
   let conversionFactor = CurrencyUtils.getCurrencyConversionFactor(order.currency)
   let splitName = order.name->Option.getOr("")->String.split(" ")
   switch aboutPaymentColType {
@@ -969,7 +975,7 @@ let getAllColumns = (version: UserInfoTypes.version) =>
   | V2 => allColumnsV2
   }
 
-let getCell = (order, colType: colType, merchantId, orgId): Table.cell => {
+let getCell = (order: order, colType: colType, merchantId, orgId): Table.cell => {
   open HelperComponents
   let conversionFactor = CurrencyUtils.getCurrencyConversionFactor(order.currency)
   let orderStatus = order.status->HSwitchOrderUtils.statusVariantMapper

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -187,6 +187,11 @@ type paymentListSource =
 
 let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
+let paymentListSources = [Normal, Advanced]
+
+let getPaymentListSourceFromLabel = value =>
+  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
+
 let getPaymentListTableTitle = source =>
   switch source {
   | Normal => "Orders"

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -180,35 +180,57 @@ type optionObj = {
   label: string,
 }
 
+type filterTypes = {
+  connector: array<string>,
+  currency: array<string>,
+  authentication_type: array<string>,
+  payment_method: array<string>,
+  payment_method_type: array<string>,
+  status: array<string>,
+  connector_label: array<string>,
+  card_network: array<string>,
+  card_discovery: array<string>,
+  customer_id: array<string>,
+  amount: array<string>,
+  merchant_order_reference_id: array<string>,
+  customer_email: array<string>,
+  card_last_4: array<string>,
+  active_attempt_id: array<string>,
+  merchant_connector_id: array<string>,
+  refunds_status: array<string>,
+  dispute_status: array<string>,
+  routing_approach: array<string>,
+  card_issuer: array<string>,
+}
+
+type filter = [
+  | #connector
+  | #payment_method
+  | #currency
+  | #authentication_type
+  | #status
+  | #payment_method_type
+  | #connector_label
+  | #card_network
+  | #card_discovery
+  | #customer_id
+  | #amount
+  | #merchant_order_reference_id
+  | #customer_email
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #refunds_status
+  | #dispute_status
+  | #routing_approach
+  | #card_issuer
+  | #unknown
+]
+
 @unboxed
 type paymentListSource =
   | @as("Normal") Normal
   | @as("Advanced") Advanced
-
-let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
-
-let paymentListSources = [Normal, Advanced]
-
-let getPaymentListSourceFromLabel = value =>
-  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
-
-let getPaymentListTableTitle = source =>
-  switch source {
-  | Normal => "Orders"
-  | Advanced => "OrdersAdvanced"
-  }
-
-let getPaymentListSourceDisplayName = source =>
-  switch source {
-  | Normal => "Normal"
-  | Advanced => "Advanced"
-  }
-
-let getPaymentListSourceDescription = source =>
-  switch source {
-  | Normal => "Standard payments list."
-  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
-  }
 
 type openSearchCsvColumn =
   | CsvPaymentId
@@ -238,10 +260,6 @@ type openSearchCsvColumn =
 
 type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 
-let openSearchRefundStatuses: array<openSearchRefundStatus> = [#partial_refunded, #full_refunded]
-
-let openSearchRefundStatusValues = openSearchRefundStatuses->Array.map(status => (status :> string))
-
 type openSearchDisputeStatus = [
   | #dispute_present
   | #dispute_opened
@@ -253,19 +271,38 @@ type openSearchDisputeStatus = [
   | #dispute_expired
 ]
 
-let openSearchDisputeStatuses: array<openSearchDisputeStatus> = [
-  #dispute_present,
-  #dispute_opened,
-  #dispute_challenged,
-  #dispute_lost,
-  #dispute_won,
-  #dispute_accepted,
-  #dispute_cancelled,
-  #dispute_expired,
+type unsupportedAdvancedPaymentFilter = [#unified_code | #unified_message]
+
+type hiddenAdvancedPaymentFilter = [#first_attempt]
+
+type advancedPaymentTextListFilter = [
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #card_issuer
 ]
 
-let openSearchDisputeStatusValues =
-  openSearchDisputeStatuses->Array.map(status => (status :> string))
+type advancedRoutingApproach = [
+  | #default_fallback
+  | #straight_through_routing
+  | #rule_based_routing
+  | #volume_based_routing
+]
+
+type basePaymentListFilter = [
+  | #payment_id
+  | #payment_method
+  | #currency
+  | #status
+  | #connector
+  | #connector_label
+  | #payment_method_type
+  | #card_network
+  | #customer_id
+  | #authentication_type
+  | #card_discovery
+  | #merchant_order_reference_id
+]
 
 type frmStatus = [#APPROVE | #REJECT]
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -96,6 +96,16 @@ type colType =
   | MerchantOrderReferenceId
   | AttemptCount
   | PaymentType
+  | MerchantConnectorId
+  | ActiveAttemptId
+  | CardLast4
+  | CardIssuer
+  | RefundsStatus
+  | RefundsCount
+  | Activities
+  | RoutingApproach
+  | UnifiedCode
+  | UnifiedMessage
 
 type summaryColType =
   | Created
@@ -169,6 +179,47 @@ type optionObj = {
   urlKey: string,
   label: string,
 }
+
+type paymentListSource =
+  | Postgres
+  | OpenSearch
+
+let getPaymentListSourceLabel = source =>
+  switch source {
+  | Postgres => "Postgres"
+  | OpenSearch => "OpenSearch"
+  }
+
+let getPaymentListTableTitle = source =>
+  switch source {
+  | Postgres => "Orders"
+  | OpenSearch => "OrdersOpenSearch"
+  }
+
+let getPaymentListSourceDisplayName = source =>
+  switch source {
+  | Postgres => "Normal"
+  | OpenSearch => "Advanced"
+  }
+
+let getPaymentListSourceDescription = source =>
+  switch source {
+  | Postgres => "Standard payments list."
+  | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  }
+
+let openSearchRefundStatusValues = ["partial_refunded", "full_refunded"]
+
+let openSearchDisputeStatusValues = [
+  "dispute_present",
+  "dispute_opened",
+  "dispute_challenged",
+  "dispute_lost",
+  "dispute_won",
+  "dispute_accepted",
+  "dispute_cancelled",
+  "dispute_expired",
+]
 
 type frmStatus = [#APPROVE | #REJECT]
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -182,28 +182,54 @@ type optionObj = {
 
 @unboxed
 type paymentListSource =
-  | @as("Postgres") Postgres
-  | @as("OpenSearch") OpenSearch
+  | @as("Normal") Normal
+  | @as("Advanced") Advanced
 
 let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
 let getPaymentListTableTitle = source =>
   switch source {
-  | Postgres => "Orders"
-  | OpenSearch => "OrdersOpenSearch"
+  | Normal => "Orders"
+  | Advanced => "OrdersAdvanced"
   }
 
 let getPaymentListSourceDisplayName = source =>
   switch source {
-  | Postgres => "Normal"
-  | OpenSearch => "Advanced"
+  | Normal => "Normal"
+  | Advanced => "Advanced"
   }
 
 let getPaymentListSourceDescription = source =>
   switch source {
-  | Postgres => "Standard payments list."
-  | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  | Normal => "Standard payments list."
+  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
   }
+
+type openSearchCsvColumn =
+  | CsvPaymentId
+  | CsvStatus
+  | CsvAmount
+  | CsvCurrency
+  | CsvConnector
+  | CsvPaymentMethod
+  | CsvPaymentMethodType
+  | CsvProfileId
+  | CsvMerchantId
+  | CsvCustomerId
+  | CsvActiveAttemptId
+  | CsvMerchantConnectorId
+  | CsvCardLast4
+  | CsvCardNetwork
+  | CsvCardIssuer
+  | CsvRefundsStatus
+  | CsvRefundsCount
+  | CsvDisputeStatus
+  | CsvDisputeCount
+  | CsvRoutingApproach
+  | CsvUnifiedCode
+  | CsvUnifiedMessage
+  | CsvCreated
+  | CsvModified
 
 type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -180,15 +180,12 @@ type optionObj = {
   label: string,
 }
 
+@unboxed
 type paymentListSource =
-  | Postgres
-  | OpenSearch
+  | @as("Postgres") Postgres
+  | @as("OpenSearch") OpenSearch
 
-let getPaymentListSourceLabel = source =>
-  switch source {
-  | Postgres => "Postgres"
-  | OpenSearch => "OpenSearch"
-  }
+let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
 
 let getPaymentListTableTitle = source =>
   switch source {
@@ -208,18 +205,36 @@ let getPaymentListSourceDescription = source =>
   | OpenSearch => "Advanced payment list with expanded search, filters, columns, and CSV export."
   }
 
-let openSearchRefundStatusValues = ["partial_refunded", "full_refunded"]
+type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 
-let openSearchDisputeStatusValues = [
-  "dispute_present",
-  "dispute_opened",
-  "dispute_challenged",
-  "dispute_lost",
-  "dispute_won",
-  "dispute_accepted",
-  "dispute_cancelled",
-  "dispute_expired",
+let openSearchRefundStatuses: array<openSearchRefundStatus> = [#partial_refunded, #full_refunded]
+
+let openSearchRefundStatusValues = openSearchRefundStatuses->Array.map(status => (status :> string))
+
+type openSearchDisputeStatus = [
+  | #dispute_present
+  | #dispute_opened
+  | #dispute_challenged
+  | #dispute_lost
+  | #dispute_won
+  | #dispute_accepted
+  | #dispute_cancelled
+  | #dispute_expired
 ]
+
+let openSearchDisputeStatuses: array<openSearchDisputeStatus> = [
+  #dispute_present,
+  #dispute_opened,
+  #dispute_challenged,
+  #dispute_lost,
+  #dispute_won,
+  #dispute_accepted,
+  #dispute_cancelled,
+  #dispute_expired,
+]
+
+let openSearchDisputeStatusValues =
+  openSearchDisputeStatuses->Array.map(status => (status :> string))
 
 type frmStatus = [#APPROVE | #REJECT]
 

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -373,7 +373,9 @@ let unsupportedAdvancedPaymentFilterKeys = [
 
 type hiddenAdvancedPaymentFilter = [#first_attempt]
 
-let hiddenAdvancedPaymentFilterKeys = [(#first_attempt: hiddenAdvancedPaymentFilter :> string)]
+let firstAttemptFilterKey = (#first_attempt: hiddenAdvancedPaymentFilter :> string)
+
+let hiddenAdvancedPaymentFilterKeys = [firstAttemptFilterKey]
 
 let advancedPaymentFilterCleanupKeys =
   advancedPaymentOnlyFilterKeys
@@ -489,12 +491,8 @@ let isTextFilter = filter =>
   | _ => false
   }
 
-let copyFilterIfPresent = (~fromDict, ~toDict, key) => {
-  switch fromDict->Dict.get(key) {
-  | Some(value) => toDict->Dict.set(key, value)
-  | None => ()
-  }
-}
+let copyFilterIfPresent = (~fromDict, ~toDict, key) =>
+  fromDict->Dict.get(key)->Option.mapOr((), value => toDict->Dict.set(key, value))
 
 let normalizeStringListFilterValue = value => {
   switch value->JSON.Decode.array {
@@ -571,9 +569,10 @@ let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>
 
 let isAdvancedPaymentSearchTextEmail = value => RegExp.test(advancedPaymentSearchEmailRegex, value)
 
-let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
-  switch fromDict->Dict.get(key) {
-  | Some(value) =>
+let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
+  fromDict
+  ->Dict.get(key)
+  ->Option.mapOr((), value => {
     if key === "customer_email" {
       switch value->normalizeSingleStringFilterValue {
       | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
@@ -585,7 +584,7 @@ let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
       | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
       | None => ()
       }
-    } else if key === "first_attempt" {
+    } else if key === firstAttemptFilterKey {
       switch value->normalizeBoolListFilterValue {
       | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
       | None => ()
@@ -593,9 +592,7 @@ let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
     } else {
       toDict->Dict.set(key, value)
     }
-  | None => ()
-  }
-}
+  })
 
 let buildAdvancedPaymentListPayload = (
   ~filterParams: Dict.t<JSON.t>,

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,35 +1,7 @@
-type filterTypes = {
-  connector: array<string>,
-  currency: array<string>,
-  authentication_type: array<string>,
-  payment_method: array<string>,
-  payment_method_type: array<string>,
-  status: array<string>,
-  connector_label: array<string>,
-  card_network: array<string>,
-  card_discovery: array<string>,
-  customer_id: array<string>,
-  amount: array<string>,
-  merchant_order_reference_id: array<string>,
-}
+open LogicUtils
+open OrderTypes
 
-type filter = [
-  | #connector
-  | #payment_method
-  | #currency
-  | #authentication_type
-  | #status
-  | #payment_method_type
-  | #connector_label
-  | #card_network
-  | #card_discovery
-  | #customer_id
-  | #amount
-  | #merchant_order_reference_id
-  | #unknown
-]
-
-let getFilterTypeFromString = filterType => {
+let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector
   | "payment_method" => #payment_method
@@ -194,7 +166,6 @@ let endTimeFilterKey = (version: UserInfoTypes.version) =>
   }
 
 let filterByData = (txnArr, value) => {
-  open LogicUtils
   let searchText = value->getStringFromJson("")
 
   txnArr
@@ -233,8 +204,6 @@ let getValueFromFilterTypeV2 = (filter: filter) => {
 }
 
 let getConditionalFilter = (key, dict, filterValues) => {
-  open LogicUtils
-
   let filtersArr = switch key->getFilterTypeFromString {
   | #connector_label =>
     filterValues
@@ -266,7 +235,6 @@ let getConditionalFilter = (key, dict, filterValues) => {
 }
 
 let getOptionsForOrderFilters = (dict, filterValues) => {
-  open LogicUtils
   filterValues
   ->getArrayFromDict("connector", [])
   ->getStrArrayFromJsonArray
@@ -285,7 +253,6 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
 }
 
 let getAllPaymentMethodType = dict => {
-  open LogicUtils
   let paymentMethods = dict->getDictfromDict("payment_method")->Dict.keysToArray
   paymentMethods->Array.reduce([], (acc, item) => {
     Array.concat(
@@ -300,8 +267,7 @@ let getAllPaymentMethodType = dict => {
   })
 }
 
-let itemToObjMapper = dict => {
-  open LogicUtils
+let itemToObjMapper = (dict): filterTypes => {
   {
     connector: dict->getDictfromDict("connector")->Dict.keysToArray,
     currency: dict->getArrayFromDict("currency", [])->getStrArrayFromJsonArray,
@@ -317,12 +283,18 @@ let itemToObjMapper = dict => {
     customer_id: [],
     amount: [],
     merchant_order_reference_id: [],
+    customer_email: [],
+    card_last_4: [],
+    active_attempt_id: [],
+    merchant_connector_id: [],
+    refunds_status: dict->getArrayFromDict("refunds_status", [])->getStrArrayFromJsonArray,
+    dispute_status: dict->getArrayFromDict("dispute_status", [])->getStrArrayFromJsonArray,
+    routing_approach: dict->getArrayFromDict("routing_approach", [])->getStrArrayFromJsonArray,
+    card_issuer: dict->getArrayFromDict("card_issuer", [])->getStrArrayFromJsonArray,
   }
 }
 
 let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) => {
-  open LogicUtils
-
   let filterDict = json->getDictFromJsonObject
 
   let filterData = filterDict->itemToObjMapper

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -331,6 +331,19 @@ let advancedPaymentFilterCleanupKeys =
 
 let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
 
+let paymentListSources: array<paymentListSource> = [Normal, Advanced]
+
+let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
+
+let getPaymentListSourceFromLabel = value =>
+  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
+
+let getPaymentListSourceDescription = source =>
+  switch source {
+  | Normal => "Standard payments list."
+  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  }
+
 let getAdvancedPaymentFilterDescription = key =>
   switch key->getFilterTypeFromString {
   | #customer_email => "Filter payments by customer email."

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -348,7 +348,7 @@ let itemToObjMapper = dict => {
   }
 }
 
-let advancedPaymentFilterTypes = [
+let advancedPaymentFilterTypes: array<filter> = [
   #customer_email,
   #card_last_4,
   #active_attempt_id,
@@ -364,9 +364,16 @@ let advancedPaymentOnlyFilterKeys =
 
 let isAdvancedPaymentOnlyFilter = key => advancedPaymentOnlyFilterKeys->Array.includes(key)
 
-let unsupportedAdvancedPaymentFilterKeys = ["unified_code", "unified_message"]
+type unsupportedAdvancedPaymentFilter = [#unified_code | #unified_message]
 
-let hiddenAdvancedPaymentFilterKeys = ["first_attempt"]
+let unsupportedAdvancedPaymentFilterKeys = [
+  (#unified_code: unsupportedAdvancedPaymentFilter :> string),
+  (#unified_message: unsupportedAdvancedPaymentFilter :> string),
+]
+
+type hiddenAdvancedPaymentFilter = [#first_attempt]
+
+let hiddenAdvancedPaymentFilterKeys = [(#first_attempt: hiddenAdvancedPaymentFilter :> string)]
 
 let advancedPaymentFilterCleanupKeys =
   advancedPaymentOnlyFilterKeys
@@ -376,59 +383,96 @@ let advancedPaymentFilterCleanupKeys =
 let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
 
 let getAdvancedPaymentFilterDescription = key =>
-  switch key {
-  | "customer_email" => "Filter payments by customer email."
-  | "card_last_4" => "Find payments by the last 4 digits of the card."
-  | "active_attempt_id" => "Filter payments by the active payment attempt ID."
-  | "merchant_connector_id" => "Filter payments by the connector account used for processing."
-  | "refunds_status" => "Filter payments by refund state, such as partial or full refund."
-  | "dispute_status" => "Filter payments by dispute state."
-  | "routing_approach" => "Filter payments by the routing strategy used for connector selection."
-  | "card_issuer" => "Filter payments by the issuing bank or card institution."
+  switch key->getFilterTypeFromString {
+  | #customer_email => "Filter payments by customer email."
+  | #card_last_4 => "Find payments by the last 4 digits of the card."
+  | #active_attempt_id => "Filter payments by the active payment attempt ID."
+  | #merchant_connector_id => "Filter payments by the connector account used for processing."
+  | #refunds_status => "Filter payments by refund state, such as partial or full refund."
+  | #dispute_status => "Filter payments by dispute state."
+  | #routing_approach => "Filter payments by the routing strategy used for connector selection."
+  | #card_issuer => "Filter payments by the issuing bank or card institution."
   | _ => "Advanced OpenSearch-only payment filter."
   }
 
-let advancedPaymentTextListFilterKeys = [
-  "card_last_4",
-  "active_attempt_id",
-  "merchant_connector_id",
-  "card_issuer",
+type advancedPaymentTextListFilter = [
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #card_issuer
 ]
 
-let advancedRoutingApproachValues = [
-  "default_fallback",
-  "straight_through_routing",
-  "rule_based_routing",
-  "volume_based_routing",
+let advancedPaymentTextListFilterTypes: array<advancedPaymentTextListFilter> = [
+  #card_last_4,
+  #active_attempt_id,
+  #merchant_connector_id,
+  #card_issuer,
 ]
+
+let advancedPaymentTextListFilterKeys =
+  advancedPaymentTextListFilterTypes->Array.map(filter => (filter :> string))
+
+type advancedRoutingApproach = [
+  | #default_fallback
+  | #straight_through_routing
+  | #rule_based_routing
+  | #volume_based_routing
+]
+
+let advancedRoutingApproaches: array<advancedRoutingApproach> = [
+  #default_fallback,
+  #straight_through_routing,
+  #rule_based_routing,
+  #volume_based_routing,
+]
+
+let advancedRoutingApproachValues =
+  advancedRoutingApproaches->Array.map(routingApproach => (routingApproach :> string))
 
 let getAdvancedPaymentStaticFilterValues = key =>
-  switch key {
-  | "refunds_status" => OrderTypes.openSearchRefundStatusValues
-  | "dispute_status" => OrderTypes.openSearchDisputeStatusValues
-  | "routing_approach" => advancedRoutingApproachValues
+  switch key->getFilterTypeFromString {
+  | #refunds_status => OrderTypes.openSearchRefundStatusValues
+  | #dispute_status => OrderTypes.openSearchDisputeStatusValues
+  | #routing_approach => advancedRoutingApproachValues
   | _ => []
   }
 
-let basePaymentListFilterKeys = [
-  "payment_id",
-  "payment_method",
-  "currency",
-  "status",
-  "connector",
-  "connector_label",
-  "payment_method_type",
-  "card_network",
-  "customer_id",
-  "authentication_type",
-  "card_discovery",
-  "merchant_order_reference_id",
+type basePaymentListFilter = [
+  | #payment_id
+  | #payment_method
+  | #currency
+  | #status
+  | #connector
+  | #connector_label
+  | #payment_method_type
+  | #card_network
+  | #customer_id
+  | #authentication_type
+  | #card_discovery
+  | #merchant_order_reference_id
 ]
+
+let basePaymentListFilters: array<basePaymentListFilter> = [
+  #payment_id,
+  #payment_method,
+  #currency,
+  #status,
+  #connector,
+  #connector_label,
+  #payment_method_type,
+  #card_network,
+  #customer_id,
+  #authentication_type,
+  #card_discovery,
+  #merchant_order_reference_id,
+]
+
+let basePaymentListFilterKeys = basePaymentListFilters->Array.map(filter => (filter :> string))
 
 let advancedPaymentListFilterKeys =
   basePaymentListFilterKeys
   ->Array.concat(advancedPaymentOnlyFilterKeys)
-  ->Array.concat(["first_attempt"])
+  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
 
 let mergeUniqueFilterValues = (values, staticValues) =>
   Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
@@ -460,7 +504,7 @@ let normalizeStringListFilterValue = value => {
       ->getStrArrayFromJsonArray
       ->Array.map(value => value->String.trim)
       ->Array.filter(isNonEmptyString)
-    normalizedValues->Array.length > 0
+    normalizedValues->isNonEmptyArray
       ? Some(normalizedValues->Array.map(JSON.Encode.string)->JSON.Encode.array)
       : None
   | None =>
@@ -498,9 +542,11 @@ let getBoolFromJsonFilterValue = value =>
   | None =>
     switch value->JSON.Decode.string {
     | Some(value) =>
-      switch value->String.toLowerCase {
-      | "true" => Some(true)
-      | "false" => Some(false)
+      let normalizedValue = value->String.trim->String.toLowerCase
+      switch normalizedValue {
+      | "true"
+      | "false" =>
+        Some(normalizedValue->getBoolFromString(false))
       | _ => None
       }
     | None => None
@@ -511,7 +557,7 @@ let normalizeBoolListFilterValue = value =>
   switch value->JSON.Decode.array {
   | Some(values) =>
     let normalizedValues = values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
-    normalizedValues->Array.length > 0
+    normalizedValues->isNonEmptyArray
       ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
       : None
   | None =>
@@ -609,7 +655,7 @@ let initialFiltersWithSource = (
   }
 
   let connectorFilter = filterValues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
-  if connectorFilter->Array.length !== 0 {
+  if connectorFilter->isNonEmptyArray {
     filtersArray->Array.push(#connector_label->getLabelFromFilterType)
   }
 
@@ -629,9 +675,8 @@ let initialFiltersWithSource = (
     | #authentication_type => filterData.authentication_type
     | #status => filterData.status
     | #payment_method_type =>
-      getConditionalFilter(key, filterDict, filterValues)->Array.length > 0
-        ? getConditionalFilter(key, filterDict, filterValues)
-        : filterData.payment_method_type
+      let conditionalFilter = getConditionalFilter(key, filterDict, filterValues)
+      conditionalFilter->isNonEmptyArray ? conditionalFilter : filterData.payment_method_type
     | #connector_label => getConditionalFilter(key, filterDict, filterValues)
     | #card_network => filterData.card_network
     | #card_discovery => filterData.card_discovery

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,3 +1,5 @@
+open LogicUtils
+
 type filterTypes = {
   connector: array<string>,
   currency: array<string>,
@@ -11,6 +13,14 @@ type filterTypes = {
   customer_id: array<string>,
   amount: array<string>,
   merchant_order_reference_id: array<string>,
+  customer_email: array<string>,
+  card_last_4: array<string>,
+  active_attempt_id: array<string>,
+  merchant_connector_id: array<string>,
+  refunds_status: array<string>,
+  dispute_status: array<string>,
+  routing_approach: array<string>,
+  card_issuer: array<string>,
 }
 
 type filter = [
@@ -26,6 +36,14 @@ type filter = [
   | #customer_id
   | #amount
   | #merchant_order_reference_id
+  | #customer_email
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #refunds_status
+  | #dispute_status
+  | #routing_approach
+  | #card_issuer
   | #unknown
 ]
 
@@ -43,6 +61,14 @@ let getFilterTypeFromString = filterType => {
   | "customer_id" => #customer_id
   | "amount" => #amount
   | "merchant_order_reference_id" => #merchant_order_reference_id
+  | "customer_email" => #customer_email
+  | "card_last_4" => #card_last_4
+  | "active_attempt_id" => #active_attempt_id
+  | "merchant_connector_id" => #merchant_connector_id
+  | "refunds_status" => #refunds_status
+  | "dispute_status" => #dispute_status
+  | "routing_approach" => #routing_approach
+  | "card_issuer" => #card_issuer
   | _ => #unknown
   }
 }
@@ -194,7 +220,6 @@ let endTimeFilterKey = (version: UserInfoTypes.version) =>
   }
 
 let filterByData = (txnArr, value) => {
-  open LogicUtils
   let searchText = value->getStringFromJson("")
 
   txnArr
@@ -233,8 +258,6 @@ let getValueFromFilterTypeV2 = (filter: filter) => {
 }
 
 let getConditionalFilter = (key, dict, filterValues) => {
-  open LogicUtils
-
   let filtersArr = switch key->getFilterTypeFromString {
   | #connector_label =>
     filterValues
@@ -266,7 +289,6 @@ let getConditionalFilter = (key, dict, filterValues) => {
 }
 
 let getOptionsForOrderFilters = (dict, filterValues) => {
-  open LogicUtils
   filterValues
   ->getArrayFromDict("connector", [])
   ->getStrArrayFromJsonArray
@@ -276,7 +298,7 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
       let label = item->getDictFromJsonObject->getString("connector_label", "")
       let value = item->getDictFromJsonObject->getString("merchant_connector_id", "")
       let option: FilterSelectBox.dropdownOption = {
-        label: label->LogicUtils.snakeToTitle,
+        label: label->snakeToTitle,
         value,
       }
       option
@@ -285,7 +307,6 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
 }
 
 let getAllPaymentMethodType = dict => {
-  open LogicUtils
   let paymentMethods = dict->getDictfromDict("payment_method")->Dict.keysToArray
   paymentMethods->Array.reduce([], (acc, item) => {
     Array.concat(
@@ -301,7 +322,6 @@ let getAllPaymentMethodType = dict => {
 }
 
 let itemToObjMapper = dict => {
-  open LogicUtils
   {
     connector: dict->getDictfromDict("connector")->Dict.keysToArray,
     currency: dict->getArrayFromDict("currency", [])->getStrArrayFromJsonArray,
@@ -317,12 +337,268 @@ let itemToObjMapper = dict => {
     customer_id: [],
     amount: [],
     merchant_order_reference_id: [],
+    customer_email: [],
+    card_last_4: [],
+    active_attempt_id: [],
+    merchant_connector_id: [],
+    refunds_status: dict->getArrayFromDict("refunds_status", [])->getStrArrayFromJsonArray,
+    dispute_status: dict->getArrayFromDict("dispute_status", [])->getStrArrayFromJsonArray,
+    routing_approach: dict->getArrayFromDict("routing_approach", [])->getStrArrayFromJsonArray,
+    card_issuer: dict->getArrayFromDict("card_issuer", [])->getStrArrayFromJsonArray,
   }
 }
 
-let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) => {
-  open LogicUtils
+let advancedPaymentFilterTypes = [
+  #customer_email,
+  #card_last_4,
+  #active_attempt_id,
+  #merchant_connector_id,
+  #refunds_status,
+  #dispute_status,
+  #routing_approach,
+  #card_issuer,
+]
 
+let advancedPaymentOnlyFilterKeys =
+  advancedPaymentFilterTypes->Array.map(filterType => filterType->getValueFromFilterType)
+
+let isAdvancedPaymentOnlyFilter = key => advancedPaymentOnlyFilterKeys->Array.includes(key)
+
+let unsupportedAdvancedPaymentFilterKeys = ["unified_code", "unified_message"]
+
+let hiddenAdvancedPaymentFilterKeys = ["first_attempt"]
+
+let advancedPaymentFilterCleanupKeys =
+  advancedPaymentOnlyFilterKeys
+  ->Array.concat(unsupportedAdvancedPaymentFilterKeys)
+  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
+
+let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
+
+let getAdvancedPaymentFilterDescription = key =>
+  switch key {
+  | "customer_email" => "Filter payments by customer email."
+  | "card_last_4" => "Find payments by the last 4 digits of the card."
+  | "active_attempt_id" => "Filter payments by the active payment attempt ID."
+  | "merchant_connector_id" => "Filter payments by the connector account used for processing."
+  | "refunds_status" => "Filter payments by refund state, such as partial or full refund."
+  | "dispute_status" => "Filter payments by dispute state."
+  | "routing_approach" => "Filter payments by the routing strategy used for connector selection."
+  | "card_issuer" => "Filter payments by the issuing bank or card institution."
+  | _ => "Advanced OpenSearch-only payment filter."
+  }
+
+let advancedPaymentTextListFilterKeys = [
+  "card_last_4",
+  "active_attempt_id",
+  "merchant_connector_id",
+  "card_issuer",
+]
+
+let advancedRoutingApproachValues = [
+  "default_fallback",
+  "straight_through_routing",
+  "rule_based_routing",
+  "volume_based_routing",
+]
+
+let getAdvancedPaymentStaticFilterValues = key =>
+  switch key {
+  | "refunds_status" => OrderTypes.openSearchRefundStatusValues
+  | "dispute_status" => OrderTypes.openSearchDisputeStatusValues
+  | "routing_approach" => advancedRoutingApproachValues
+  | _ => []
+  }
+
+let basePaymentListFilterKeys = [
+  "payment_id",
+  "payment_method",
+  "currency",
+  "status",
+  "connector",
+  "connector_label",
+  "payment_method_type",
+  "card_network",
+  "customer_id",
+  "authentication_type",
+  "card_discovery",
+  "merchant_order_reference_id",
+]
+
+let advancedPaymentListFilterKeys =
+  basePaymentListFilterKeys
+  ->Array.concat(advancedPaymentOnlyFilterKeys)
+  ->Array.concat(["first_attempt"])
+
+let mergeUniqueFilterValues = (values, staticValues) =>
+  Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
+
+let isTextFilter = filter =>
+  switch filter {
+  | #customer_id
+  | #merchant_order_reference_id
+  | #customer_email
+  | #card_last_4
+  | #active_attempt_id
+  | #merchant_connector_id
+  | #card_issuer => true
+  | _ => false
+  }
+
+let copyFilterIfPresent = (~fromDict, ~toDict, key) => {
+  switch fromDict->Dict.get(key) {
+  | Some(value) => toDict->Dict.set(key, value)
+  | None => ()
+  }
+}
+
+let normalizeStringListFilterValue = value => {
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    let normalizedValues =
+      values
+      ->getStrArrayFromJsonArray
+      ->Array.map(value => value->String.trim)
+      ->Array.filter(isNonEmptyString)
+    normalizedValues->Array.length > 0
+      ? Some(normalizedValues->Array.map(JSON.Encode.string)->JSON.Encode.array)
+      : None
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      let trimmedValue = value->String.trim
+      trimmedValue->isNonEmptyString
+        ? Some([trimmedValue->JSON.Encode.string]->JSON.Encode.array)
+        : None
+    | None => None
+    }
+  }
+}
+
+let normalizeSingleStringFilterValue = value => {
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    values
+    ->getStrArrayFromJsonArray
+    ->Array.map(value => value->String.trim)
+    ->Array.find(isNonEmptyString)
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      let trimmedValue = value->String.trim
+      trimmedValue->isNonEmptyString ? Some(trimmedValue) : None
+    | None => None
+    }
+  }
+}
+
+let getBoolFromJsonFilterValue = value =>
+  switch value->JSON.Decode.bool {
+  | Some(value) => Some(value)
+  | None =>
+    switch value->JSON.Decode.string {
+    | Some(value) =>
+      switch value->String.toLowerCase {
+      | "true" => Some(true)
+      | "false" => Some(false)
+      | _ => None
+      }
+    | None => None
+    }
+  }
+
+let normalizeBoolListFilterValue = value =>
+  switch value->JSON.Decode.array {
+  | Some(values) =>
+    let normalizedValues = values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
+    normalizedValues->Array.length > 0
+      ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
+      : None
+  | None =>
+    switch value->getBoolFromJsonFilterValue {
+    | Some(value) => Some([value->JSON.Encode.bool]->JSON.Encode.array)
+    | None => None
+    }
+  }
+
+let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>()[\]\.,;:\s@"{}\/\\]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/`)
+
+let isAdvancedPaymentSearchTextEmail = value => RegExp.test(advancedPaymentSearchEmailRegex, value)
+
+let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) => {
+  switch fromDict->Dict.get(key) {
+  | Some(value) =>
+    if key === "customer_email" {
+      switch value->normalizeSingleStringFilterValue {
+      | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
+        toDict->Dict.set(key, email->JSON.Encode.string)
+      | _ => ()
+      }
+    } else if advancedPaymentTextListFilterKeys->Array.includes(key) {
+      switch value->normalizeStringListFilterValue {
+      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
+      | None => ()
+      }
+    } else if key === "first_attempt" {
+      switch value->normalizeBoolListFilterValue {
+      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
+      | None => ()
+      }
+    } else {
+      toDict->Dict.set(key, value)
+    }
+  | None => ()
+  }
+}
+
+let buildAdvancedPaymentListPayload = (
+  ~filterParams: Dict.t<JSON.t>,
+  ~searchText,
+  ~startTimeKey,
+  ~endTimeKey,
+) => {
+  let body = Dict.make()
+  let trimmedSearchText = searchText->String.trim
+
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "offset")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "limit")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "order")
+  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "amount_filter")
+
+  if trimmedSearchText->isEmptyString {
+    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, startTimeKey)
+    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, endTimeKey)
+  }
+
+  advancedPaymentListFilterKeys->Array.forEach(key => {
+    copyAdvancedPaymentFilterIfPresent(~fromDict=filterParams, ~toDict=body, key)
+  })
+
+  if trimmedSearchText->isNonEmptyString {
+    trimmedSearchText->isAdvancedPaymentSearchTextEmail
+      ? {
+          body->Dict.set("customer_email", trimmedSearchText->JSON.Encode.string)
+          body->Dict.delete("query")
+        }
+      : {
+          body->Dict.set("query", trimmedSearchText->JSON.Encode.string)
+        }
+  }
+
+  body
+}
+
+let filterNewTag = description => <NewFeatureTag className="ml-2" description />
+
+let initialFiltersWithSource = (
+  ~isOpenSearchSource=false,
+  json,
+  filterValues,
+  removeKeys,
+  filterKeys,
+  setfilterKeys,
+  version,
+) => {
   let filterDict = json->getDictFromJsonObject
 
   let filterData = filterDict->itemToObjMapper
@@ -338,14 +614,15 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
   }
 
   let additionalFilters =
-    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]->Array.map(
-      getLabelFromFilterType,
-    )
+    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]
+    ->Array.concat(isOpenSearchSource ? advancedPaymentFilterTypes : [])
+    ->Array.map(getLabelFromFilterType)
 
   let allFiltersArray = filtersArray->Array.concat(additionalFilters)
 
   allFiltersArray->Array.map((key): EntityType.initialFilters<'t> => {
-    let values = switch key->getFilterTypeFromString {
+    let filterType = key->getFilterTypeFromString
+    let values = switch filterType {
     | #connector => filterData.connector
     | #payment_method => filterData.payment_method
     | #currency => filterData.currency
@@ -358,20 +635,28 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
     | #connector_label => getConditionalFilter(key, filterDict, filterValues)
     | #card_network => filterData.card_network
     | #card_discovery => filterData.card_discovery
+    | #refunds_status => filterData.refunds_status
+    | #dispute_status => filterData.dispute_status
+    | #routing_approach => filterData.routing_approach
+    | #card_issuer => filterData.card_issuer
     | _ => []
     }
+    let values = isOpenSearchSource
+      ? values->mergeUniqueFilterValues(
+          getAdvancedPaymentStaticFilterValues(getValueFromFilterType(filterType)),
+        )
+      : values
 
     let title = `Select ${key->snakeToTitle}`
 
-    let options = switch key->getFilterTypeFromString {
+    let options = switch filterType {
     | #connector_label => getOptionsForOrderFilters(filterDict, filterValues)
     | #connector => values->ConnectorUtils.getConnectorFilterOptions
     | _ => values->FilterSelectBox.makeOptions(~isTitle=true)
     }
 
-    let customInput = switch key->getFilterTypeFromString {
-    | #customer_id
-    | #merchant_order_reference_id =>
+    let customInput = switch filterType {
+    | filterType if filterType->isTextFilter =>
       (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder as _) =>
         InputFields.textInput(
           ~rightIcon=<div
@@ -398,6 +683,12 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
         (),
       )
     }
+    let filterKey = getValueFromFilterType(key->getFilterTypeFromString)
+    let labelRightComponent =
+      isOpenSearchSource && filterKey->isAdvancedPaymentOnlyFilter
+        ? Some(filterNewTag(filterKey->getAdvancedPaymentFilterDescription))
+        : None
+
     {
       field: FormRenderer.makeFieldInfo(
         ~label=key,
@@ -408,11 +699,23 @@ let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys,
           }
         },
         ~customInput,
+        ~labelRightComponent?,
       ),
       localFilter: Some(filterByData),
     }
   })
 }
+
+let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) =>
+  initialFiltersWithSource(
+    ~isOpenSearchSource=false,
+    json,
+    filterValues,
+    removeKeys,
+    filterKeys,
+    setfilterKeys,
+    version,
+  )
 
 let initialFixedFilter = (version: UserInfoTypes.version, ~disable=false) => [
   (

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -494,73 +494,45 @@ let isTextFilter = filter =>
 let copyFilterIfPresent = (~fromDict, ~toDict, key) =>
   fromDict->Dict.get(key)->Option.mapOr((), value => toDict->Dict.set(key, value))
 
-let normalizeStringListFilterValue = value => {
-  switch value->JSON.Decode.array {
-  | Some(values) =>
-    let normalizedValues =
-      values
-      ->getStrArrayFromJsonArray
-      ->Array.map(value => value->String.trim)
-      ->Array.filter(isNonEmptyString)
-    normalizedValues->isNonEmptyArray
-      ? Some(normalizedValues->Array.map(JSON.Encode.string)->JSON.Encode.array)
-      : None
-  | None =>
-    switch value->JSON.Decode.string {
-    | Some(value) =>
-      let trimmedValue = value->String.trim
-      trimmedValue->isNonEmptyString
-        ? Some([trimmedValue->JSON.Encode.string]->JSON.Encode.array)
-        : None
-    | None => None
-    }
-  }
-}
-
-let normalizeSingleStringFilterValue = value => {
-  switch value->JSON.Decode.array {
-  | Some(values) =>
+let getTrimmedStringFilterValues = value => {
+  switch value->JSON.Classify.classify {
+  | Array(values) =>
     values
     ->getStrArrayFromJsonArray
     ->Array.map(value => value->String.trim)
-    ->Array.find(isNonEmptyString)
-  | None =>
-    switch value->JSON.Decode.string {
-    | Some(value) =>
-      let trimmedValue = value->String.trim
-      trimmedValue->isNonEmptyString ? Some(trimmedValue) : None
-    | None => None
-    }
+    ->Array.filter(isNonEmptyString)
+  | String(value) =>
+    let trimmedValue = value->String.trim
+    trimmedValue->isNonEmptyString ? [trimmedValue] : []
+  | _ => []
   }
 }
 
+let normalizeStringListFilterValue = value => {
+  let normalizedValues = value->getTrimmedStringFilterValues
+  normalizedValues->isNonEmptyArray ? Some(normalizedValues->getJsonFromArrayOfString) : None
+}
+
 let getBoolFromJsonFilterValue = value =>
-  switch value->JSON.Decode.bool {
-  | Some(value) => Some(value)
-  | None =>
-    switch value->JSON.Decode.string {
-    | Some(value) =>
-      let normalizedValue = value->String.trim->String.toLowerCase
-      normalizedValue === "true" || normalizedValue === "false"
-        ? Some(normalizedValue->getBoolFromString(false))
-        : None
-    | None => None
-    }
+  switch value->JSON.Classify.classify {
+  | Bool(value) => Some(value)
+  | String(value) =>
+    let normalizedValue = value->String.trim->String.toLowerCase
+    normalizedValue === "true" || normalizedValue === "false"
+      ? Some(normalizedValue->getBoolFromString(false))
+      : None
+  | _ => None
   }
 
-let normalizeBoolListFilterValue = value =>
-  switch value->JSON.Decode.array {
-  | Some(values) =>
-    let normalizedValues = values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
-    normalizedValues->isNonEmptyArray
-      ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
-      : None
-  | None =>
-    switch value->getBoolFromJsonFilterValue {
-    | Some(value) => Some([value->JSON.Encode.bool]->JSON.Encode.array)
-    | None => None
-    }
+let normalizeBoolListFilterValue = value => {
+  let normalizedValues = switch value->JSON.Classify.classify {
+  | Array(values) => values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
+  | _ => value->getBoolFromJsonFilterValue->Option.mapOr([], value => [value])
   }
+  normalizedValues->isNonEmptyArray
+    ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
+    : None
+}
 
 let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>()[\]\.,;:\s@"{}\/\\]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/`)
 
@@ -571,7 +543,7 @@ let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
   ->Dict.get(key)
   ->Option.mapOr((), value => {
     if key === "customer_email" {
-      switch value->normalizeSingleStringFilterValue {
+      switch value->getTrimmedStringFilterValues->Array.get(0) {
       | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
         toDict->Dict.set(key, email->JSON.Encode.string)
       | _ => ()

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -406,57 +406,46 @@ let advancedPaymentListFilterKeys =
 
 let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
   fromDict
-  ->Dict.get(key)
+  ->getOptionValFromDict(key)
   ->Option.mapOr((), value => {
-    let stringValues = switch value->JSON.Classify.classify {
-    | Array(values) =>
+    let stringValues = switch value->JSON.Decode.array {
+    | Some(values) =>
       values
       ->getStrArrayFromJsonArray
       ->Array.map(value => value->String.trim)
-      ->Array.filter(isNonEmptyString)
-    | String(value) =>
-      let trimmedValue = value->String.trim
-      trimmedValue->isNonEmptyString ? [trimmedValue] : []
-    | _ => []
+      ->Belt.Array.keepMap(getNonEmptyString)
+    | None =>
+      let value = value->getStringFromJson("")->String.trim
+      value->isNonEmptyString ? [value] : []
     }
 
     if key === "customer_email" {
       switch stringValues->Array.get(0) {
       | Some(email) if !(email->CommonAuthUtils.isValidEmail) =>
-        toDict->Dict.set(key, email->JSON.Encode.string)
+        toDict->setOptionString(key, Some(email))
       | _ => ()
       }
     } else if advancedPaymentTextListFilterKeys->Array.includes(key) {
       if stringValues->isNonEmptyArray {
-        toDict->Dict.set(key, stringValues->getJsonFromArrayOfString)
+        toDict->setOptionJson(key, Some(stringValues->getJsonFromArrayOfString))
       }
     } else if key === firstAttemptFilterKey {
-      let boolValues = switch value->JSON.Classify.classify {
-      | Array(values) =>
-        values->Belt.Array.keepMap(value => {
-          switch value->JSON.Classify.classify {
-          | Bool(value) => Some(value)
-          | String(value) =>
-            let normalizedValue = value->String.trim->String.toLowerCase
-            normalizedValue === "true" || normalizedValue === "false"
-              ? Some(normalizedValue->getBoolFromString(false))
-              : None
-          | _ => None
-          }
-        })
-      | Bool(value) => [value]
-      | String(value) =>
-        let normalizedValue = value->String.trim->String.toLowerCase
-        normalizedValue === "true" || normalizedValue === "false"
-          ? [normalizedValue->getBoolFromString(false)]
-          : []
-      | _ => []
+      let getBoolFilterValue = value =>
+        switch value->JSON.Decode.bool {
+        | Some(value) => Some(value)
+        | None =>
+          let value = value->getStringFromJson("")->String.trim->String.toLowerCase
+          value === "true" || value === "false" ? Some(value->getBoolFromString(false)) : None
+        }
+      let boolValues = switch value->JSON.Decode.array {
+      | Some(values) => values->Belt.Array.keepMap(getBoolFilterValue)
+      | None => value->getBoolFilterValue->Option.mapOr([], value => [value])
       }
       if boolValues->isNonEmptyArray {
-        toDict->Dict.set(key, boolValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
+        toDict->setOptionArray(key, Some(boolValues->Array.map(JSON.Encode.bool)))
       }
     } else {
-      toDict->Dict.set(key, value)
+      toDict->setOptionJson(key, Some(value))
     }
   })
 

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,6 +1,35 @@
-open LogicUtils
-open OrderTypes
-let getFilterTypeFromString = (filterType): filter => {
+type filterTypes = {
+  connector: array<string>,
+  currency: array<string>,
+  authentication_type: array<string>,
+  payment_method: array<string>,
+  payment_method_type: array<string>,
+  status: array<string>,
+  connector_label: array<string>,
+  card_network: array<string>,
+  card_discovery: array<string>,
+  customer_id: array<string>,
+  amount: array<string>,
+  merchant_order_reference_id: array<string>,
+}
+
+type filter = [
+  | #connector
+  | #payment_method
+  | #currency
+  | #authentication_type
+  | #status
+  | #payment_method_type
+  | #connector_label
+  | #card_network
+  | #card_discovery
+  | #customer_id
+  | #amount
+  | #merchant_order_reference_id
+  | #unknown
+]
+
+let getFilterTypeFromString = filterType => {
   switch filterType {
   | "connector" => #connector
   | "payment_method" => #payment_method
@@ -14,14 +43,6 @@ let getFilterTypeFromString = (filterType): filter => {
   | "customer_id" => #customer_id
   | "amount" => #amount
   | "merchant_order_reference_id" => #merchant_order_reference_id
-  | "customer_email" => #customer_email
-  | "card_last_4" => #card_last_4
-  | "active_attempt_id" => #active_attempt_id
-  | "merchant_connector_id" => #merchant_connector_id
-  | "refunds_status" => #refunds_status
-  | "dispute_status" => #dispute_status
-  | "routing_approach" => #routing_approach
-  | "card_issuer" => #card_issuer
   | _ => #unknown
   }
 }
@@ -173,6 +194,7 @@ let endTimeFilterKey = (version: UserInfoTypes.version) =>
   }
 
 let filterByData = (txnArr, value) => {
+  open LogicUtils
   let searchText = value->getStringFromJson("")
 
   txnArr
@@ -211,6 +233,8 @@ let getValueFromFilterTypeV2 = (filter: filter) => {
 }
 
 let getConditionalFilter = (key, dict, filterValues) => {
+  open LogicUtils
+
   let filtersArr = switch key->getFilterTypeFromString {
   | #connector_label =>
     filterValues
@@ -242,6 +266,7 @@ let getConditionalFilter = (key, dict, filterValues) => {
 }
 
 let getOptionsForOrderFilters = (dict, filterValues) => {
+  open LogicUtils
   filterValues
   ->getArrayFromDict("connector", [])
   ->getStrArrayFromJsonArray
@@ -251,7 +276,7 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
       let label = item->getDictFromJsonObject->getString("connector_label", "")
       let value = item->getDictFromJsonObject->getString("merchant_connector_id", "")
       let option: FilterSelectBox.dropdownOption = {
-        label: label->snakeToTitle,
+        label: label->LogicUtils.snakeToTitle,
         value,
       }
       option
@@ -260,6 +285,7 @@ let getOptionsForOrderFilters = (dict, filterValues) => {
 }
 
 let getAllPaymentMethodType = dict => {
+  open LogicUtils
   let paymentMethods = dict->getDictfromDict("payment_method")->Dict.keysToArray
   paymentMethods->Array.reduce([], (acc, item) => {
     Array.concat(
@@ -274,7 +300,8 @@ let getAllPaymentMethodType = dict => {
   })
 }
 
-let itemToObjMapper = (dict): filterTypes => {
+let itemToObjMapper = dict => {
+  open LogicUtils
   {
     connector: dict->getDictfromDict("connector")->Dict.keysToArray,
     currency: dict->getArrayFromDict("currency", [])->getStrArrayFromJsonArray,
@@ -290,224 +317,12 @@ let itemToObjMapper = (dict): filterTypes => {
     customer_id: [],
     amount: [],
     merchant_order_reference_id: [],
-    customer_email: [],
-    card_last_4: [],
-    active_attempt_id: [],
-    merchant_connector_id: [],
-    refunds_status: dict->getArrayFromDict("refunds_status", [])->getStrArrayFromJsonArray,
-    dispute_status: dict->getArrayFromDict("dispute_status", [])->getStrArrayFromJsonArray,
-    routing_approach: dict->getArrayFromDict("routing_approach", [])->getStrArrayFromJsonArray,
-    card_issuer: dict->getArrayFromDict("card_issuer", [])->getStrArrayFromJsonArray,
   }
 }
 
-let advancedPaymentFilterTypes: array<filter> = [
-  #customer_email,
-  #card_last_4,
-  #active_attempt_id,
-  #merchant_connector_id,
-  #refunds_status,
-  #dispute_status,
-  #routing_approach,
-  #card_issuer,
-]
+let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) => {
+  open LogicUtils
 
-let advancedPaymentOnlyFilterKeys =
-  advancedPaymentFilterTypes->Array.map(filterType => filterType->getValueFromFilterType)
-
-let unsupportedAdvancedPaymentFilterKeys = [
-  (#unified_code: unsupportedAdvancedPaymentFilter :> string),
-  (#unified_message: unsupportedAdvancedPaymentFilter :> string),
-]
-
-let firstAttemptFilterKey = (#first_attempt: hiddenAdvancedPaymentFilter :> string)
-
-let hiddenAdvancedPaymentFilterKeys = [firstAttemptFilterKey]
-
-let advancedPaymentFilterCleanupKeys =
-  advancedPaymentOnlyFilterKeys
-  ->Array.concat(unsupportedAdvancedPaymentFilterKeys)
-  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
-
-let advancedPaymentSearchDescription = "Advanced search checks OpenSearch payment fields such as payment ID, card last 4, amount, attempt ID, connector account, error details, and full customer email."
-
-let paymentListSources: array<paymentListSource> = [Normal, Advanced]
-
-let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
-
-let getPaymentListSourceFromLabel = value =>
-  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
-
-let getPaymentListSourceDescription = source =>
-  switch source {
-  | Normal => "Standard payments list."
-  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
-  }
-
-let getAdvancedPaymentFilterDescription = key =>
-  switch key->getFilterTypeFromString {
-  | #customer_email => "Filter payments by customer email."
-  | #card_last_4 => "Find payments by the last 4 digits of the card."
-  | #active_attempt_id => "Filter payments by the active payment attempt ID."
-  | #merchant_connector_id => "Filter payments by the connector account used for processing."
-  | #refunds_status => "Filter payments by refund state, such as partial or full refund."
-  | #dispute_status => "Filter payments by dispute state."
-  | #routing_approach => "Filter payments by the routing strategy used for connector selection."
-  | #card_issuer => "Filter payments by the issuing bank or card institution."
-  | _ => "Advanced OpenSearch-only payment filter."
-  }
-
-let advancedPaymentTextListFilterTypes: array<filter> = [
-  #card_last_4,
-  #active_attempt_id,
-  #merchant_connector_id,
-  #card_issuer,
-]
-
-let advancedPaymentTextListFilterKeys =
-  advancedPaymentTextListFilterTypes->Array.map(filter => (filter :> string))
-
-let advancedRoutingApproaches: array<advancedRoutingApproach> = [
-  #default_fallback,
-  #straight_through_routing,
-  #rule_based_routing,
-  #volume_based_routing,
-]
-
-let advancedRoutingApproachValues =
-  advancedRoutingApproaches->Array.map(routingApproach => (routingApproach :> string))
-
-let openSearchRefundStatuses: array<openSearchRefundStatus> = [#partial_refunded, #full_refunded]
-
-let openSearchRefundStatusValues = openSearchRefundStatuses->Array.map(status => (status :> string))
-
-let openSearchDisputeStatuses: array<openSearchDisputeStatus> = [
-  #dispute_present,
-  #dispute_opened,
-  #dispute_challenged,
-  #dispute_lost,
-  #dispute_won,
-  #dispute_accepted,
-  #dispute_cancelled,
-  #dispute_expired,
-]
-
-let openSearchDisputeStatusValues =
-  openSearchDisputeStatuses->Array.map(status => (status :> string))
-
-let basePaymentListFilters: array<basePaymentListFilter> = [
-  #payment_id,
-  #payment_method,
-  #currency,
-  #status,
-  #connector,
-  #connector_label,
-  #payment_method_type,
-  #card_network,
-  #customer_id,
-  #authentication_type,
-  #card_discovery,
-  #merchant_order_reference_id,
-]
-
-let basePaymentListFilterKeys = basePaymentListFilters->Array.map(filter => (filter :> string))
-
-let advancedPaymentListFilterKeys =
-  basePaymentListFilterKeys
-  ->Array.concat(advancedPaymentOnlyFilterKeys)
-  ->Array.concat(hiddenAdvancedPaymentFilterKeys)
-
-let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
-  fromDict
-  ->getOptionValFromDict(key)
-  ->Option.mapOr((), value => {
-    let stringValues = switch value->JSON.Decode.array {
-    | Some(values) =>
-      values
-      ->getStrArrayFromJsonArray
-      ->Array.map(value => value->String.trim)
-      ->Belt.Array.keepMap(getNonEmptyString)
-    | None =>
-      let value = value->getStringFromJson("")->String.trim
-      value->isNonEmptyString ? [value] : []
-    }
-
-    if key === "customer_email" {
-      switch stringValues->Array.get(0) {
-      | Some(email) if !(email->CommonAuthUtils.isValidEmail) =>
-        toDict->setOptionString(key, Some(email))
-      | _ => ()
-      }
-    } else if advancedPaymentTextListFilterKeys->Array.includes(key) {
-      if stringValues->isNonEmptyArray {
-        toDict->setOptionJson(key, Some(stringValues->getJsonFromArrayOfString))
-      }
-    } else if key === firstAttemptFilterKey {
-      let getBoolFilterValue = value =>
-        switch value->JSON.Decode.bool {
-        | Some(value) => Some(value)
-        | None =>
-          let value = value->getStringFromJson("")->String.trim->String.toLowerCase
-          value === "true" || value === "false" ? Some(value->getBoolFromString(false)) : None
-        }
-      let boolValues = switch value->JSON.Decode.array {
-      | Some(values) => values->Belt.Array.keepMap(getBoolFilterValue)
-      | None => value->getBoolFilterValue->Option.mapOr([], value => [value])
-      }
-      if boolValues->isNonEmptyArray {
-        toDict->setOptionArray(key, Some(boolValues->Array.map(JSON.Encode.bool)))
-      }
-    } else {
-      toDict->setOptionJson(key, Some(value))
-    }
-  })
-
-let buildAdvancedPaymentListPayload = (
-  ~filterParams: Dict.t<JSON.t>,
-  ~searchText,
-  ~startTimeKey,
-  ~endTimeKey,
-) => {
-  let body = Dict.make()
-  let trimmedSearchText = searchText->String.trim
-
-  body->setOptionJson("offset", filterParams->Dict.get("offset"))
-  body->setOptionJson("limit", filterParams->Dict.get("limit"))
-  body->setOptionJson("order", filterParams->Dict.get("order"))
-  body->setOptionJson("amount_filter", filterParams->Dict.get("amount_filter"))
-
-  if trimmedSearchText->isEmptyString {
-    body->setOptionJson(startTimeKey, filterParams->Dict.get(startTimeKey))
-    body->setOptionJson(endTimeKey, filterParams->Dict.get(endTimeKey))
-  }
-
-  advancedPaymentListFilterKeys->Array.forEach(key => {
-    copyAdvancedPaymentFilterIfPresent(~fromDict=filterParams, ~toDict=body, key)
-  })
-
-  if trimmedSearchText->isNonEmptyString {
-    !(trimmedSearchText->CommonAuthUtils.isValidEmail)
-      ? {
-          body->Dict.set("customer_email", trimmedSearchText->JSON.Encode.string)
-          body->Dict.delete("query")
-        }
-      : {
-          body->Dict.set("query", trimmedSearchText->JSON.Encode.string)
-        }
-  }
-
-  body
-}
-
-let initialFiltersWithSource = (
-  ~isOpenSearchSource=false,
-  json,
-  filterValues,
-  removeKeys,
-  filterKeys,
-  setfilterKeys,
-  version,
-) => {
   let filterDict = json->getDictFromJsonObject
 
   let filterData = filterDict->itemToObjMapper
@@ -518,63 +333,45 @@ let initialFiltersWithSource = (
   }
 
   let connectorFilter = filterValues->getArrayFromDict("connector", [])->getStrArrayFromJsonArray
-  if connectorFilter->isNonEmptyArray {
+  if connectorFilter->Array.length !== 0 {
     filtersArray->Array.push(#connector_label->getLabelFromFilterType)
   }
 
   let additionalFilters =
-    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]
-    ->Array.concat(isOpenSearchSource ? advancedPaymentFilterTypes : [])
-    ->Array.map(getLabelFromFilterType)
+    [#payment_method_type, #customer_id, #amount, #merchant_order_reference_id]->Array.map(
+      getLabelFromFilterType,
+    )
 
   let allFiltersArray = filtersArray->Array.concat(additionalFilters)
 
   allFiltersArray->Array.map((key): EntityType.initialFilters<'t> => {
-    let filterType = key->getFilterTypeFromString
-    let values = switch filterType {
+    let values = switch key->getFilterTypeFromString {
     | #connector => filterData.connector
     | #payment_method => filterData.payment_method
     | #currency => filterData.currency
     | #authentication_type => filterData.authentication_type
     | #status => filterData.status
     | #payment_method_type =>
-      let conditionalFilter = getConditionalFilter(key, filterDict, filterValues)
-      conditionalFilter->isNonEmptyArray ? conditionalFilter : filterData.payment_method_type
+      getConditionalFilter(key, filterDict, filterValues)->Array.length > 0
+        ? getConditionalFilter(key, filterDict, filterValues)
+        : filterData.payment_method_type
     | #connector_label => getConditionalFilter(key, filterDict, filterValues)
     | #card_network => filterData.card_network
     | #card_discovery => filterData.card_discovery
-    | #refunds_status => filterData.refunds_status
-    | #dispute_status => filterData.dispute_status
-    | #routing_approach => filterData.routing_approach
-    | #card_issuer => filterData.card_issuer
     | _ => []
     }
-    let staticValues = switch filterType {
-    | #refunds_status => openSearchRefundStatusValues
-    | #dispute_status => openSearchDisputeStatusValues
-    | #routing_approach => advancedRoutingApproachValues
-    | _ => []
-    }
-    let values = isOpenSearchSource
-      ? Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
-      : values
 
     let title = `Select ${key->snakeToTitle}`
 
-    let options = switch filterType {
+    let options = switch key->getFilterTypeFromString {
     | #connector_label => getOptionsForOrderFilters(filterDict, filterValues)
     | #connector => values->ConnectorUtils.getConnectorFilterOptions
     | _ => values->FilterSelectBox.makeOptions(~isTitle=true)
     }
 
-    let customInput = switch filterType {
+    let customInput = switch key->getFilterTypeFromString {
     | #customer_id
-    | #merchant_order_reference_id
-    | #customer_email
-    | #card_last_4
-    | #active_attempt_id
-    | #merchant_connector_id
-    | #card_issuer =>
+    | #merchant_order_reference_id =>
       (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder as _) =>
         InputFields.textInput(
           ~rightIcon=<div
@@ -601,16 +398,6 @@ let initialFiltersWithSource = (
         (),
       )
     }
-    let filterKey = getValueFromFilterType(key->getFilterTypeFromString)
-    let labelRightComponent =
-      isOpenSearchSource && advancedPaymentOnlyFilterKeys->Array.includes(filterKey)
-        ? Some(
-            <NewFeatureTag
-              className="ml-2" description={filterKey->getAdvancedPaymentFilterDescription}
-            />,
-          )
-        : None
-
     {
       field: FormRenderer.makeFieldInfo(
         ~label=key,
@@ -621,23 +408,11 @@ let initialFiltersWithSource = (
           }
         },
         ~customInput,
-        ~labelRightComponent?,
       ),
       localFilter: Some(filterByData),
     }
   })
 }
-
-let initialFilters = (json, filterValues, removeKeys, filterKeys, setfilterKeys, version) =>
-  initialFiltersWithSource(
-    ~isOpenSearchSource=false,
-    json,
-    filterValues,
-    removeKeys,
-    filterKeys,
-    setfilterKeys,
-    version,
-  )
 
 let initialFixedFilter = (version: UserInfoTypes.version, ~disable=false) => [
   (

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,53 +1,6 @@
 open LogicUtils
-
-type filterTypes = {
-  connector: array<string>,
-  currency: array<string>,
-  authentication_type: array<string>,
-  payment_method: array<string>,
-  payment_method_type: array<string>,
-  status: array<string>,
-  connector_label: array<string>,
-  card_network: array<string>,
-  card_discovery: array<string>,
-  customer_id: array<string>,
-  amount: array<string>,
-  merchant_order_reference_id: array<string>,
-  customer_email: array<string>,
-  card_last_4: array<string>,
-  active_attempt_id: array<string>,
-  merchant_connector_id: array<string>,
-  refunds_status: array<string>,
-  dispute_status: array<string>,
-  routing_approach: array<string>,
-  card_issuer: array<string>,
-}
-
-type filter = [
-  | #connector
-  | #payment_method
-  | #currency
-  | #authentication_type
-  | #status
-  | #payment_method_type
-  | #connector_label
-  | #card_network
-  | #card_discovery
-  | #customer_id
-  | #amount
-  | #merchant_order_reference_id
-  | #customer_email
-  | #card_last_4
-  | #active_attempt_id
-  | #merchant_connector_id
-  | #refunds_status
-  | #dispute_status
-  | #routing_approach
-  | #card_issuer
-  | #unknown
-]
-
-let getFilterTypeFromString = filterType => {
+open OrderTypes
+let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector
   | "payment_method" => #payment_method
@@ -321,7 +274,7 @@ let getAllPaymentMethodType = dict => {
   })
 }
 
-let itemToObjMapper = dict => {
+let itemToObjMapper = (dict): filterTypes => {
   {
     connector: dict->getDictfromDict("connector")->Dict.keysToArray,
     currency: dict->getArrayFromDict("currency", [])->getStrArrayFromJsonArray,
@@ -362,16 +315,10 @@ let advancedPaymentFilterTypes: array<filter> = [
 let advancedPaymentOnlyFilterKeys =
   advancedPaymentFilterTypes->Array.map(filterType => filterType->getValueFromFilterType)
 
-let isAdvancedPaymentOnlyFilter = key => advancedPaymentOnlyFilterKeys->Array.includes(key)
-
-type unsupportedAdvancedPaymentFilter = [#unified_code | #unified_message]
-
 let unsupportedAdvancedPaymentFilterKeys = [
   (#unified_code: unsupportedAdvancedPaymentFilter :> string),
   (#unified_message: unsupportedAdvancedPaymentFilter :> string),
 ]
-
-type hiddenAdvancedPaymentFilter = [#first_attempt]
 
 let firstAttemptFilterKey = (#first_attempt: hiddenAdvancedPaymentFilter :> string)
 
@@ -397,14 +344,7 @@ let getAdvancedPaymentFilterDescription = key =>
   | _ => "Advanced OpenSearch-only payment filter."
   }
 
-type advancedPaymentTextListFilter = [
-  | #card_last_4
-  | #active_attempt_id
-  | #merchant_connector_id
-  | #card_issuer
-]
-
-let advancedPaymentTextListFilterTypes: array<advancedPaymentTextListFilter> = [
+let advancedPaymentTextListFilterTypes: array<filter> = [
   #card_last_4,
   #active_attempt_id,
   #merchant_connector_id,
@@ -413,13 +353,6 @@ let advancedPaymentTextListFilterTypes: array<advancedPaymentTextListFilter> = [
 
 let advancedPaymentTextListFilterKeys =
   advancedPaymentTextListFilterTypes->Array.map(filter => (filter :> string))
-
-type advancedRoutingApproach = [
-  | #default_fallback
-  | #straight_through_routing
-  | #rule_based_routing
-  | #volume_based_routing
-]
 
 let advancedRoutingApproaches: array<advancedRoutingApproach> = [
   #default_fallback,
@@ -431,28 +364,23 @@ let advancedRoutingApproaches: array<advancedRoutingApproach> = [
 let advancedRoutingApproachValues =
   advancedRoutingApproaches->Array.map(routingApproach => (routingApproach :> string))
 
-let getAdvancedPaymentStaticFilterValues = key =>
-  switch key->getFilterTypeFromString {
-  | #refunds_status => OrderTypes.openSearchRefundStatusValues
-  | #dispute_status => OrderTypes.openSearchDisputeStatusValues
-  | #routing_approach => advancedRoutingApproachValues
-  | _ => []
-  }
+let openSearchRefundStatuses: array<openSearchRefundStatus> = [#partial_refunded, #full_refunded]
 
-type basePaymentListFilter = [
-  | #payment_id
-  | #payment_method
-  | #currency
-  | #status
-  | #connector
-  | #connector_label
-  | #payment_method_type
-  | #card_network
-  | #customer_id
-  | #authentication_type
-  | #card_discovery
-  | #merchant_order_reference_id
+let openSearchRefundStatusValues = openSearchRefundStatuses->Array.map(status => (status :> string))
+
+let openSearchDisputeStatuses: array<openSearchDisputeStatus> = [
+  #dispute_present,
+  #dispute_opened,
+  #dispute_challenged,
+  #dispute_lost,
+  #dispute_won,
+  #dispute_accepted,
+  #dispute_cancelled,
+  #dispute_expired,
 ]
+
+let openSearchDisputeStatusValues =
+  openSearchDisputeStatuses->Array.map(status => (status :> string))
 
 let basePaymentListFilters: array<basePaymentListFilter> = [
   #payment_id,
@@ -476,87 +404,56 @@ let advancedPaymentListFilterKeys =
   ->Array.concat(advancedPaymentOnlyFilterKeys)
   ->Array.concat(hiddenAdvancedPaymentFilterKeys)
 
-let mergeUniqueFilterValues = (values, staticValues) =>
-  Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
-
-let isTextFilter = filter =>
-  switch filter {
-  | #customer_id
-  | #merchant_order_reference_id
-  | #customer_email
-  | #card_last_4
-  | #active_attempt_id
-  | #merchant_connector_id
-  | #card_issuer => true
-  | _ => false
-  }
-
-let copyFilterIfPresent = (~fromDict, ~toDict, key) =>
-  fromDict->Dict.get(key)->Option.mapOr((), value => toDict->Dict.set(key, value))
-
-let getTrimmedStringFilterValues = value => {
-  switch value->JSON.Classify.classify {
-  | Array(values) =>
-    values
-    ->getStrArrayFromJsonArray
-    ->Array.map(value => value->String.trim)
-    ->Array.filter(isNonEmptyString)
-  | String(value) =>
-    let trimmedValue = value->String.trim
-    trimmedValue->isNonEmptyString ? [trimmedValue] : []
-  | _ => []
-  }
-}
-
-let normalizeStringListFilterValue = value => {
-  let normalizedValues = value->getTrimmedStringFilterValues
-  normalizedValues->isNonEmptyArray ? Some(normalizedValues->getJsonFromArrayOfString) : None
-}
-
-let getBoolFromJsonFilterValue = value =>
-  switch value->JSON.Classify.classify {
-  | Bool(value) => Some(value)
-  | String(value) =>
-    let normalizedValue = value->String.trim->String.toLowerCase
-    normalizedValue === "true" || normalizedValue === "false"
-      ? Some(normalizedValue->getBoolFromString(false))
-      : None
-  | _ => None
-  }
-
-let normalizeBoolListFilterValue = value => {
-  let normalizedValues = switch value->JSON.Classify.classify {
-  | Array(values) => values->Belt.Array.keepMap(getBoolFromJsonFilterValue)
-  | _ => value->getBoolFromJsonFilterValue->Option.mapOr([], value => [value])
-  }
-  normalizedValues->isNonEmptyArray
-    ? Some(normalizedValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
-    : None
-}
-
-let advancedPaymentSearchEmailRegex = %re(`/^(([^<>()[\]\.,;:\s@"{}\/\\]+(\.[^<>()[\]\.,;:\s@"{}\/\\]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/`)
-
-let isAdvancedPaymentSearchTextEmail = value => RegExp.test(advancedPaymentSearchEmailRegex, value)
-
 let copyAdvancedPaymentFilterIfPresent = (~fromDict, ~toDict, key) =>
   fromDict
   ->Dict.get(key)
   ->Option.mapOr((), value => {
+    let stringValues = switch value->JSON.Classify.classify {
+    | Array(values) =>
+      values
+      ->getStrArrayFromJsonArray
+      ->Array.map(value => value->String.trim)
+      ->Array.filter(isNonEmptyString)
+    | String(value) =>
+      let trimmedValue = value->String.trim
+      trimmedValue->isNonEmptyString ? [trimmedValue] : []
+    | _ => []
+    }
+
     if key === "customer_email" {
-      switch value->getTrimmedStringFilterValues->Array.get(0) {
-      | Some(email) if email->isAdvancedPaymentSearchTextEmail =>
+      switch stringValues->Array.get(0) {
+      | Some(email) if !(email->CommonAuthUtils.isValidEmail) =>
         toDict->Dict.set(key, email->JSON.Encode.string)
       | _ => ()
       }
     } else if advancedPaymentTextListFilterKeys->Array.includes(key) {
-      switch value->normalizeStringListFilterValue {
-      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
-      | None => ()
+      if stringValues->isNonEmptyArray {
+        toDict->Dict.set(key, stringValues->getJsonFromArrayOfString)
       }
     } else if key === firstAttemptFilterKey {
-      switch value->normalizeBoolListFilterValue {
-      | Some(normalizedValue) => toDict->Dict.set(key, normalizedValue)
-      | None => ()
+      let boolValues = switch value->JSON.Classify.classify {
+      | Array(values) =>
+        values->Belt.Array.keepMap(value => {
+          switch value->JSON.Classify.classify {
+          | Bool(value) => Some(value)
+          | String(value) =>
+            let normalizedValue = value->String.trim->String.toLowerCase
+            normalizedValue === "true" || normalizedValue === "false"
+              ? Some(normalizedValue->getBoolFromString(false))
+              : None
+          | _ => None
+          }
+        })
+      | Bool(value) => [value]
+      | String(value) =>
+        let normalizedValue = value->String.trim->String.toLowerCase
+        normalizedValue === "true" || normalizedValue === "false"
+          ? [normalizedValue->getBoolFromString(false)]
+          : []
+      | _ => []
+      }
+      if boolValues->isNonEmptyArray {
+        toDict->Dict.set(key, boolValues->Array.map(JSON.Encode.bool)->JSON.Encode.array)
       }
     } else {
       toDict->Dict.set(key, value)
@@ -572,14 +469,14 @@ let buildAdvancedPaymentListPayload = (
   let body = Dict.make()
   let trimmedSearchText = searchText->String.trim
 
-  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "offset")
-  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "limit")
-  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "order")
-  copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, "amount_filter")
+  body->setOptionJson("offset", filterParams->Dict.get("offset"))
+  body->setOptionJson("limit", filterParams->Dict.get("limit"))
+  body->setOptionJson("order", filterParams->Dict.get("order"))
+  body->setOptionJson("amount_filter", filterParams->Dict.get("amount_filter"))
 
   if trimmedSearchText->isEmptyString {
-    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, startTimeKey)
-    copyFilterIfPresent(~fromDict=filterParams, ~toDict=body, endTimeKey)
+    body->setOptionJson(startTimeKey, filterParams->Dict.get(startTimeKey))
+    body->setOptionJson(endTimeKey, filterParams->Dict.get(endTimeKey))
   }
 
   advancedPaymentListFilterKeys->Array.forEach(key => {
@@ -587,7 +484,7 @@ let buildAdvancedPaymentListPayload = (
   })
 
   if trimmedSearchText->isNonEmptyString {
-    trimmedSearchText->isAdvancedPaymentSearchTextEmail
+    !(trimmedSearchText->CommonAuthUtils.isValidEmail)
       ? {
           body->Dict.set("customer_email", trimmedSearchText->JSON.Encode.string)
           body->Dict.delete("query")
@@ -599,8 +496,6 @@ let buildAdvancedPaymentListPayload = (
 
   body
 }
-
-let filterNewTag = description => <NewFeatureTag className="ml-2" description />
 
 let initialFiltersWithSource = (
   ~isOpenSearchSource=false,
@@ -652,10 +547,14 @@ let initialFiltersWithSource = (
     | #card_issuer => filterData.card_issuer
     | _ => []
     }
+    let staticValues = switch filterType {
+    | #refunds_status => openSearchRefundStatusValues
+    | #dispute_status => openSearchDisputeStatusValues
+    | #routing_approach => advancedRoutingApproachValues
+    | _ => []
+    }
     let values = isOpenSearchSource
-      ? values->mergeUniqueFilterValues(
-          getAdvancedPaymentStaticFilterValues(getValueFromFilterType(filterType)),
-        )
+      ? Array.concat(values, staticValues)->Array.filter(isNonEmptyString)->getUniqueArray
       : values
 
     let title = `Select ${key->snakeToTitle}`
@@ -667,7 +566,13 @@ let initialFiltersWithSource = (
     }
 
     let customInput = switch filterType {
-    | filterType if filterType->isTextFilter =>
+    | #customer_id
+    | #merchant_order_reference_id
+    | #customer_email
+    | #card_last_4
+    | #active_attempt_id
+    | #merchant_connector_id
+    | #card_issuer =>
       (~input: ReactFinalForm.fieldRenderPropsInput, ~placeholder as _) =>
         InputFields.textInput(
           ~rightIcon=<div
@@ -696,8 +601,12 @@ let initialFiltersWithSource = (
     }
     let filterKey = getValueFromFilterType(key->getFilterTypeFromString)
     let labelRightComponent =
-      isOpenSearchSource && filterKey->isAdvancedPaymentOnlyFilter
-        ? Some(filterNewTag(filterKey->getAdvancedPaymentFilterDescription))
+      isOpenSearchSource && advancedPaymentOnlyFilterKeys->Array.includes(filterKey)
+        ? Some(
+            <NewFeatureTag
+              className="ml-2" description={filterKey->getAdvancedPaymentFilterDescription}
+            />,
+          )
         : None
 
     {

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -541,12 +541,9 @@ let getBoolFromJsonFilterValue = value =>
     switch value->JSON.Decode.string {
     | Some(value) =>
       let normalizedValue = value->String.trim->String.toLowerCase
-      switch normalizedValue {
-      | "true"
-      | "false" =>
-        Some(normalizedValue->getBoolFromString(false))
-      | _ => None
-      }
+      normalizedValue === "true" || normalizedValue === "false"
+        ? Some(normalizedValue->getBoolFromString(false))
+        : None
     | None => None
     }
   }

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -1,35 +1,21 @@
+open OrderTypes
+open OrderUIUtils
 module SourceTabs = {
-  let getPaymentListSourceLabel = (source: OrderTypes.paymentListSource) => (source :> string)
-
-  let paymentListSources: array<OrderTypes.paymentListSource> = [
-    OrderTypes.Normal,
-    OrderTypes.Advanced,
-  ]
-
-  let getPaymentListSourceFromLabel = value =>
-    paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
-
-  let getPaymentListSourceDescription = source =>
-    switch source {
-    | OrderTypes.Normal => "Standard payments list."
-    | OrderTypes.Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
-    }
-
   @react.component
   let make = (
-    ~source: OrderTypes.paymentListSource,
-    ~setSource: (OrderTypes.paymentListSource => OrderTypes.paymentListSource) => unit,
+    ~source: paymentListSource,
+    ~setSource: (paymentListSource => paymentListSource) => unit,
     ~advancedEnabled,
   ) => {
     <TabsBinding
       value={source->getPaymentListSourceLabel}
       onValueChange={value => {
         switch value->getPaymentListSourceFromLabel {
-        | Some(OrderTypes.Advanced) =>
+        | Some(Advanced) =>
           if advancedEnabled {
-            setSource(_ => OrderTypes.Advanced)
+            setSource(_ => Advanced)
           }
-        | Some(OrderTypes.Normal) => setSource(_ => OrderTypes.Normal)
+        | Some(Normal) => setSource(_ => Normal)
         | None => ()
         }
       }}
@@ -39,7 +25,7 @@ module SourceTabs = {
         {paymentListSources
         ->Array.map(item => {
           let value = item->getPaymentListSourceLabel
-          let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
+          let isDisabled = item === Advanced && !advancedEnabled
           <TabsBinding.Trigger
             key=value
             value

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -3,26 +3,26 @@ module SourceTabs = {
   let make = (
     ~source: OrderTypes.paymentListSource,
     ~setSource: (OrderTypes.paymentListSource => OrderTypes.paymentListSource) => unit,
-    ~openSearchEnabled,
+    ~advancedEnabled,
   ) => {
     <TabsBinding
       value={source->OrderTypes.getPaymentListSourceLabel}
       onValueChange={value => {
         switch value {
-        | "OpenSearch" =>
-          if openSearchEnabled {
-            setSource(_ => OrderTypes.OpenSearch)
+        | "Advanced" =>
+          if advancedEnabled {
+            setSource(_ => OrderTypes.Advanced)
           }
-        | _ => setSource(_ => OrderTypes.Postgres)
+        | _ => setSource(_ => OrderTypes.Normal)
         }
       }}
       variant=Boxed
       size=Md>
       <TabsBinding.List variant=Boxed size=Md fitContent=true>
-        {[OrderTypes.Postgres, OrderTypes.OpenSearch]
+        {[OrderTypes.Normal, OrderTypes.Advanced]
         ->Array.map(item => {
           let value = item->OrderTypes.getPaymentListSourceLabel
-          let isDisabled = item === OrderTypes.OpenSearch && !openSearchEnabled
+          let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
           <TabsBinding.Trigger
             key=value
             value

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -1,5 +1,18 @@
 open OrderTypes
-open OrderUIUtils
+
+let paymentListSources: array<paymentListSource> = [Normal, Advanced]
+
+let getPaymentListSourceLabel = (source: paymentListSource) => (source :> string)
+
+let getPaymentListSourceFromLabel = value =>
+  paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
+
+let getPaymentListSourceDescription = source =>
+  switch source {
+  | Normal => "Standard payments list."
+  | Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
+  }
+
 module SourceTabs = {
   @react.component
   let make = (

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -9,12 +9,6 @@ module SourceTabs = {
   let getPaymentListSourceFromLabel = value =>
     paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
 
-  let getPaymentListSourceDisplayName = source =>
-    switch source {
-    | OrderTypes.Normal => "Normal"
-    | OrderTypes.Advanced => "Advanced"
-    }
-
   let getPaymentListSourceDescription = source =>
     switch source {
     | OrderTypes.Normal => "Standard payments list."
@@ -55,7 +49,7 @@ module SourceTabs = {
             className="min-w-20 justify-center">
             <ToolTip
               description={item->getPaymentListSourceDescription}
-              toolTipFor={<span> {item->getPaymentListSourceDisplayName->React.string} </span>}
+              toolTipFor={<span> {(item :> string)->React.string} </span>}
               toolTipPosition=ToolTip.Top
             />
           </TabsBinding.Trigger>

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -1,0 +1,79 @@
+module SourceTabs = {
+  @react.component
+  let make = (
+    ~source: OrderTypes.paymentListSource,
+    ~setSource: (OrderTypes.paymentListSource => OrderTypes.paymentListSource) => unit,
+    ~openSearchEnabled,
+  ) => {
+    <TabsBinding
+      value={source->OrderTypes.getPaymentListSourceLabel}
+      onValueChange={value => {
+        switch value {
+        | "OpenSearch" =>
+          if openSearchEnabled {
+            setSource(_ => OrderTypes.OpenSearch)
+          }
+        | _ => setSource(_ => OrderTypes.Postgres)
+        }
+      }}
+      variant=Boxed
+      size=Md>
+      <TabsBinding.List variant=Boxed size=Md fitContent=true>
+        {[OrderTypes.Postgres, OrderTypes.OpenSearch]
+        ->Array.map(item => {
+          let value = item->OrderTypes.getPaymentListSourceLabel
+          let isDisabled = item === OrderTypes.OpenSearch && !openSearchEnabled
+          <TabsBinding.Trigger
+            key=value
+            value
+            variant=Boxed
+            size=Md
+            disabled=isDisabled
+            className="min-w-[75px] justify-center">
+            <ToolTip
+              description={item->OrderTypes.getPaymentListSourceDescription}
+              toolTipFor={<span>
+                {item->OrderTypes.getPaymentListSourceDisplayName->React.string}
+              </span>}
+              toolTipPosition=ToolTip.Top
+            />
+          </TabsBinding.Trigger>
+        })
+        ->React.array}
+      </TabsBinding.List>
+    </TabsBinding>
+  }
+}
+
+module ExportButton = {
+  @react.component
+  let make = (
+    ~selectedRowsCount,
+    ~canExportSelectedRows,
+    ~buttonState: Button.buttonState,
+    ~disabledCountClass,
+    ~onExport,
+  ) => {
+    let countClass = canExportSelectedRows
+      ? "border-white bg-white text-primary"
+      : `border-transparent bg-transparent ${disabledCountClass}`
+
+    <div className="relative shrink-0">
+      <Button
+        text="Export"
+        buttonType=Primary
+        buttonState
+        buttonSize=Small
+        customButtonStyle="!w-[128px] justify-start"
+        customIconMargin="ml-2"
+        customTextPaddingClass="!pl-2 !pr-8"
+        leftIcon={Button.CustomIcon(<Icon name="nd-download-bar-down" size=16 />)}
+        onClick={_ => canExportSelectedRows ? onExport() : ()}
+      />
+      <span
+        className={`pointer-events-none absolute right-2 top-1/2 flex h-5 min-w-5 -translate-y-1/2 items-center justify-center rounded-full border px-1 text-xs font-semibold leading-none ${countClass}`}>
+        {selectedRowsCount->Int.toString->React.string}
+      </span>
+    </div>
+  }
+}

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -1,4 +1,26 @@
 module SourceTabs = {
+  let getPaymentListSourceLabel = (source: OrderTypes.paymentListSource) => (source :> string)
+
+  let paymentListSources: array<OrderTypes.paymentListSource> = [
+    OrderTypes.Normal,
+    OrderTypes.Advanced,
+  ]
+
+  let getPaymentListSourceFromLabel = value =>
+    paymentListSources->Array.find(source => source->getPaymentListSourceLabel == value)
+
+  let getPaymentListSourceDisplayName = source =>
+    switch source {
+    | OrderTypes.Normal => "Normal"
+    | OrderTypes.Advanced => "Advanced"
+    }
+
+  let getPaymentListSourceDescription = source =>
+    switch source {
+    | OrderTypes.Normal => "Standard payments list."
+    | OrderTypes.Advanced => "Advanced payment list with expanded search, filters, columns, and CSV export."
+    }
+
   @react.component
   let make = (
     ~source: OrderTypes.paymentListSource,
@@ -6,9 +28,9 @@ module SourceTabs = {
     ~advancedEnabled,
   ) => {
     <TabsBinding
-      value={source->OrderTypes.getPaymentListSourceLabel}
+      value={source->getPaymentListSourceLabel}
       onValueChange={value => {
-        switch value->OrderTypes.getPaymentListSourceFromLabel {
+        switch value->getPaymentListSourceFromLabel {
         | Some(OrderTypes.Advanced) =>
           if advancedEnabled {
             setSource(_ => OrderTypes.Advanced)
@@ -20,9 +42,9 @@ module SourceTabs = {
       variant=Boxed
       size=Md>
       <TabsBinding.List variant=Boxed size=Md fitContent=true>
-        {OrderTypes.paymentListSources
+        {paymentListSources
         ->Array.map(item => {
-          let value = item->OrderTypes.getPaymentListSourceLabel
+          let value = item->getPaymentListSourceLabel
           let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
           <TabsBinding.Trigger
             key=value
@@ -32,10 +54,8 @@ module SourceTabs = {
             disabled=isDisabled
             className="min-w-20 justify-center">
             <ToolTip
-              description={item->OrderTypes.getPaymentListSourceDescription}
-              toolTipFor={<span>
-                {item->OrderTypes.getPaymentListSourceDisplayName->React.string}
-              </span>}
+              description={item->getPaymentListSourceDescription}
+              toolTipFor={<span> {item->getPaymentListSourceDisplayName->React.string} </span>}
               toolTipPosition=ToolTip.Top
             />
           </TabsBinding.Trigger>

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -49,43 +49,12 @@ module SourceTabs = {
             <ToolTip
               description={item->getPaymentListSourceDescription}
               toolTipFor={<span> {(item :> string)->React.string} </span>}
-              toolTipPosition=ToolTip.Top
+              toolTipPosition=Top
             />
           </TabsBinding.Trigger>
         })
         ->React.array}
       </TabsBinding.List>
     </TabsBinding>
-  }
-}
-
-module ExportButton = {
-  @react.component
-  let make = (
-    ~selectedRowsCount,
-    ~canExportSelectedRows,
-    ~buttonState: Button.buttonState,
-    ~onExport,
-  ) => {
-    let selectedRowsCountClass = canExportSelectedRows ? "text-white" : "text-nd_gray-500"
-
-    <div className="shrink-0">
-      <Button
-        text="Export"
-        buttonType=Primary
-        buttonState
-        buttonSize=Small
-        customButtonStyle="justify-start"
-        customIconMargin="ml-2"
-        customTextPaddingClass="!pl-2 !pr-1"
-        leftIcon={Button.CustomIcon(<Icon name="nd-download-bar-down" size=16 />)}
-        rightIcon={Button.CustomIcon(
-          <span className={`${Typography.body.sm.semibold} ${selectedRowsCountClass}`}>
-            {selectedRowsCount->Int.toString->React.string}
-          </span>,
-        )}
-        onClick={_ => canExportSelectedRows ? onExport() : ()}
-      />
-    </div>
   }
 }

--- a/src/screens/Transaction/Order/PaymentListSourceControls.res
+++ b/src/screens/Transaction/Order/PaymentListSourceControls.res
@@ -8,18 +8,19 @@ module SourceTabs = {
     <TabsBinding
       value={source->OrderTypes.getPaymentListSourceLabel}
       onValueChange={value => {
-        switch value {
-        | "Advanced" =>
+        switch value->OrderTypes.getPaymentListSourceFromLabel {
+        | Some(OrderTypes.Advanced) =>
           if advancedEnabled {
             setSource(_ => OrderTypes.Advanced)
           }
-        | _ => setSource(_ => OrderTypes.Normal)
+        | Some(OrderTypes.Normal) => setSource(_ => OrderTypes.Normal)
+        | None => ()
         }
       }}
       variant=Boxed
       size=Md>
       <TabsBinding.List variant=Boxed size=Md fitContent=true>
-        {[OrderTypes.Normal, OrderTypes.Advanced]
+        {OrderTypes.paymentListSources
         ->Array.map(item => {
           let value = item->OrderTypes.getPaymentListSourceLabel
           let isDisabled = item === OrderTypes.Advanced && !advancedEnabled
@@ -29,7 +30,7 @@ module SourceTabs = {
             variant=Boxed
             size=Md
             disabled=isDisabled
-            className="min-w-[75px] justify-center">
+            className="min-w-20 justify-center">
             <ToolTip
               description={item->OrderTypes.getPaymentListSourceDescription}
               toolTipFor={<span>
@@ -51,29 +52,27 @@ module ExportButton = {
     ~selectedRowsCount,
     ~canExportSelectedRows,
     ~buttonState: Button.buttonState,
-    ~disabledCountClass,
     ~onExport,
   ) => {
-    let countClass = canExportSelectedRows
-      ? "border-white bg-white text-primary"
-      : `border-transparent bg-transparent ${disabledCountClass}`
+    let selectedRowsCountClass = canExportSelectedRows ? "text-white" : "text-nd_gray-500"
 
-    <div className="relative shrink-0">
+    <div className="shrink-0">
       <Button
         text="Export"
         buttonType=Primary
         buttonState
         buttonSize=Small
-        customButtonStyle="!w-[128px] justify-start"
+        customButtonStyle="justify-start"
         customIconMargin="ml-2"
-        customTextPaddingClass="!pl-2 !pr-8"
+        customTextPaddingClass="!pl-2 !pr-1"
         leftIcon={Button.CustomIcon(<Icon name="nd-download-bar-down" size=16 />)}
+        rightIcon={Button.CustomIcon(
+          <span className={`${Typography.body.sm.semibold} ${selectedRowsCountClass}`}>
+            {selectedRowsCount->Int.toString->React.string}
+          </span>,
+        )}
         onClick={_ => canExportSelectedRows ? onExport() : ()}
       />
-      <span
-        className={`pointer-events-none absolute right-2 top-1/2 flex h-5 min-w-5 -translate-y-1/2 items-center justify-center rounded-full border px-1 text-xs font-semibold leading-none ${countClass}`}>
-        {selectedRowsCount->Int.toString->React.string}
-      </span>
     </div>
   }
 }

--- a/src/screens/TransactionViews/TransactionViewTypes.res
+++ b/src/screens/TransactionViews/TransactionViewTypes.res
@@ -10,6 +10,10 @@ type viewTypes =
   | Expired
   | Reversed
   | RequiresCapture
+  | FirstAttemptSuccess
+  | RetrySuccess
+  | Refunded
+  | Disputed
   | None
 
 type clickhouseAggregateMetric = {

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -1,6 +1,5 @@
 open TransactionViewTypes
 open LogicUtils
-open OrderUIUtils
 let paymentViewsArray: array<viewTypes> = [
   All,
   Succeeded,
@@ -9,30 +8,6 @@ let paymentViewsArray: array<viewTypes> = [
   Cancelled,
   RequiresCapture,
 ]
-
-let advancedPaymentViewsArray: array<viewTypes> = [
-  All,
-  Succeeded,
-  Failed,
-  Dropoffs,
-  Cancelled,
-  RequiresCapture,
-  Refunded,
-  FirstAttemptSuccess,
-  RetrySuccess,
-  Disputed,
-]
-
-let isAdvancedPaymentOnlyView = view => !(paymentViewsArray->Array.includes(view))
-
-let getAdvancedPaymentViewDescription = view =>
-  switch view {
-  | Refunded => "Payments that have partial or full refunds."
-  | Disputed => "Payments that have a dispute state present."
-  | FirstAttemptSuccess => "Succeeded payments completed on the first attempt."
-  | RetrySuccess => "Succeeded payments completed after more than one attempt."
-  | _ => ""
-  }
 
 let refundViewsArray: array<viewTypes> = [All, Succeeded, Failed, Pending]
 
@@ -92,10 +67,6 @@ let getViewsDisplayName = (view: viewTypes) => {
   | Expired => "Expired"
   | Reversed => "Reversed"
   | RequiresCapture => "Requires Capture"
-  | FirstAttemptSuccess => "First Attempt Success"
-  | RetrySuccess => "Retry Success"
-  | Refunded => "Refunded"
-  | Disputed => "Disputed"
   | _ => ""
   }
 }
@@ -138,49 +109,13 @@ let getViewTypeFromString = (view, entity) => {
   }
 }
 
-let buildAllStatusFilterStringForKey = (obj, key) => {
+let buildAllStatusFilterString = obj => {
   obj
   ->getDictFromJsonObject
-  ->getDictfromDict(key)
+  ->getDictfromDict("status_with_count")
   ->Dict.keysToArray
   ->Array.joinWith(",")
 }
-
-let refundedStatusValues = openSearchRefundStatusValues
-
-let disputedStatusValues = openSearchDisputeStatusValues
-
-let buildAllowedStatusFilterStringWithFallback = (obj, key, allowedStatuses, fallbackValue) => {
-  let statusDict = obj->getDictFromJsonObject->getDictfromDict(key)
-  let filterValue =
-    allowedStatuses
-    ->Array.filter(status => statusDict->Dict.get(status)->Option.isSome)
-    ->Array.joinWith(",")
-  filterValue->isNonEmptyString ? filterValue : fallbackValue
-}
-
-let sumAllowedStatusCount = (dict, key, allowedStatuses) => {
-  let statusDict = dict->getDictfromDict(key)
-  allowedStatuses->Array.reduce(0, (acc, status) =>
-    (acc->Int.toFloat +. statusDict->getFloat(status, 0.0))->Float.toInt
-  )
-}
-
-let getSankeyCountMetric = (dict, key) => dict->getFloat(key, 0.0)->Float.toInt
-
-let getSankeyRowCount = dict => dict->getFloat("count", dict->getFloat("payment_intent_count", 0.0))
-
-let getSankeyFirstAttempt = dict =>
-  switch dict->Dict.get("first_attempt") {
-  | Some(value) =>
-    switch value->JSON.Decode.bool {
-    | Some(isFirstAttempt) => isFirstAttempt
-    | None => value->getIntFromJson(0) == 1
-    }
-  | None => false
-  }
-
-let buildAllStatusFilterString = obj => buildAllStatusFilterStringForKey(obj, "status_with_count")
 
 let getViewFilterValue = (view, obj, entity) => {
   switch entity {
@@ -193,16 +128,6 @@ let getViewFilterValue = (view, obj, entity) => {
     | Cancelled => "cancelled"
     | Pending => "pending"
     | RequiresCapture => "requires_capture"
-    | FirstAttemptSuccess
-    | RetrySuccess => "succeeded"
-    | Refunded => refundedStatusValues->Array.joinWith(",")
-    | Disputed =>
-      buildAllowedStatusFilterStringWithFallback(
-        obj,
-        "dispute_status_with_count",
-        disputedStatusValues,
-        "dispute_present,dispute_opened,dispute_challenged,dispute_lost,dispute_won,dispute_accepted,dispute_cancelled,dispute_expired",
-      )
     | _ => ""
     }
   | Refunds =>
@@ -246,17 +171,11 @@ let calculateTotalViewCount = obj => {
 }
 
 let getViewCount = (view, obj, entity) => {
-  let dict = obj->getDictFromJsonObject
-  switch (view, entity) {
-  | (All, _) => calculateTotalViewCount(obj)
-  | (Refunded, Orders) =>
-    sumAllowedStatusCount(dict, "refunds_status_with_count", refundedStatusValues)
-  | (Disputed, Orders) =>
-    sumAllowedStatusCount(dict, "dispute_status_with_count", disputedStatusValues)
-  | (FirstAttemptSuccess, Orders) => getSankeyCountMetric(dict, "first_attempt_success_count")
-  | (RetrySuccess, Orders) => getSankeyCountMetric(dict, "retry_success_count")
+  switch view {
+  | All => calculateTotalViewCount(obj)
   | _ =>
-    dict
+    obj
+    ->getDictFromJsonObject
     ->getDictfromDict("status_with_count")
     ->getInt(view->getViewFilterValue(obj, entity), 0)
   }
@@ -297,60 +216,17 @@ let metricsResponseToStatusWithCount = (~statusField, ~countField, response) => 
   [("status_with_count", statusWithCount->JSON.Encode.object)]->getJsonFromArrayOfJson
 }
 
-let sankeyResponseToStatusWithCount = response => {
-  let statusWithCount = Dict.make()
-  let refundsStatusWithCount = Dict.make()
-  let disputeStatusWithCount = Dict.make()
-  let firstAttemptSuccessCount = ref(0.0)
-  let retrySuccessCount = ref(0.0)
-
-  response
-  ->getArrayFromJson([])
-  ->Array.forEach(row => {
-    let dict = row->getDictFromJsonObject
-    let count = dict->getSankeyRowCount
-    let status = dict->getString("status", "")->String.toLowerCase
-    let refundsStatus = dict->getString("refunds_status", "")
-    let disputeStatus = dict->getString("dispute_status", "")
-    let isFirstAttempt = dict->getSankeyFirstAttempt
-
-    if status->isNonEmptyString {
-      let previous = statusWithCount->getFloat(status, 0.0)
-      statusWithCount->Dict.set(status, (previous +. count)->JSON.Encode.float)
-    }
-    if status === "succeeded" && isFirstAttempt {
-      firstAttemptSuccessCount := firstAttemptSuccessCount.contents +. count
-    }
-    if status === "succeeded" && !isFirstAttempt {
-      retrySuccessCount := retrySuccessCount.contents +. count
-    }
-    if refundsStatus->isNonEmptyString {
-      let previous = refundsStatusWithCount->getFloat(refundsStatus, 0.0)
-      refundsStatusWithCount->Dict.set(refundsStatus, (previous +. count)->JSON.Encode.float)
-    }
-    if disputeStatus->isNonEmptyString {
-      let previous = disputeStatusWithCount->getFloat(disputeStatus, 0.0)
-      disputeStatusWithCount->Dict.set(disputeStatus, (previous +. count)->JSON.Encode.float)
-    }
-  })
-
-  [
-    ("status_with_count", statusWithCount->JSON.Encode.object),
-    ("refunds_status_with_count", refundsStatusWithCount->JSON.Encode.object),
-    ("dispute_status_with_count", disputeStatusWithCount->JSON.Encode.object),
-    ("first_attempt_success_count", firstAttemptSuccessCount.contents->JSON.Encode.float),
-    ("retry_success_count", retrySuccessCount.contents->JSON.Encode.float),
-  ]->getJsonFromArrayOfJson
-}
-
 let getStartAndEndTime = (filterValueJson, version) => {
   filterValueJson->isEmptyDict
     ? ("", "")
     : {
         let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
         (
-          filterValueJson->getString(startTimeFilterKey(version), defaultDate.start_time),
-          filterValueJson->getString(endTimeFilterKey(version), defaultDate.end_time),
+          filterValueJson->getString(
+            OrderUIUtils.startTimeFilterKey(version),
+            defaultDate.start_time,
+          ),
+          filterValueJson->getString(OrderUIUtils.endTimeFilterKey(version), defaultDate.end_time),
         )
       }
 }

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -1,5 +1,6 @@
 open TransactionViewTypes
 open LogicUtils
+open OrderUIUtils
 let paymentViewsArray: array<viewTypes> = [
   All,
   Succeeded,
@@ -9,11 +10,40 @@ let paymentViewsArray: array<viewTypes> = [
   RequiresCapture,
 ]
 
+let advancedPaymentViewsArray: array<viewTypes> = [
+  All,
+  Succeeded,
+  Failed,
+  Dropoffs,
+  Cancelled,
+  RequiresCapture,
+  Refunded,
+  FirstAttemptSuccess,
+  RetrySuccess,
+  Disputed,
+]
+
+let isAdvancedPaymentOnlyView = view => !(paymentViewsArray->Array.includes(view))
+
+let getAdvancedPaymentViewDescription = view =>
+  switch view {
+  | Refunded => "Payments that have partial or full refunds."
+  | Disputed => "Payments that have a dispute state present."
+  | FirstAttemptSuccess => "Succeeded payments completed on the first attempt."
+  | RetrySuccess => "Succeeded payments completed after more than one attempt."
+  | _ => ""
+  }
+
 let refundViewsArray: array<viewTypes> = [All, Succeeded, Failed, Pending]
 
 let disputeViewsArray: array<viewTypes> = [All, Succeeded, Failed, Pending]
 
 let payoutViewsArray: array<viewTypes> = [All, Succeeded, Failed, Cancelled, Expired, Reversed]
+
+let getTransactionViewGridClass = viewsCount =>
+  viewsCount >= 6
+    ? "grid lg:grid-cols-6 md:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-4"
+    : "grid lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-4"
 
 let getCustomFilterKey = entity =>
   switch entity {
@@ -67,6 +97,10 @@ let getViewsDisplayName = (view: viewTypes) => {
   | Expired => "Expired"
   | Reversed => "Reversed"
   | RequiresCapture => "Requires Capture"
+  | FirstAttemptSuccess => "First Attempt Success"
+  | RetrySuccess => "Retry Success"
+  | Refunded => "Refunded"
+  | Disputed => "Disputed"
   | _ => ""
   }
 }
@@ -109,13 +143,49 @@ let getViewTypeFromString = (view, entity) => {
   }
 }
 
-let buildAllStatusFilterString = obj => {
+let buildAllStatusFilterStringForKey = (obj, key) => {
   obj
   ->getDictFromJsonObject
-  ->getDictfromDict("status_with_count")
+  ->getDictfromDict(key)
   ->Dict.keysToArray
   ->Array.joinWith(",")
 }
+
+let refundedStatusValues = openSearchRefundStatusValues
+
+let disputedStatusValues = openSearchDisputeStatusValues
+
+let buildAllowedStatusFilterStringWithFallback = (obj, key, allowedStatuses, fallbackValue) => {
+  let statusDict = obj->getDictFromJsonObject->getDictfromDict(key)
+  let filterValue =
+    allowedStatuses
+    ->Array.filter(status => statusDict->Dict.get(status)->Option.isSome)
+    ->Array.joinWith(",")
+  filterValue->isNonEmptyString ? filterValue : fallbackValue
+}
+
+let sumAllowedStatusCount = (dict, key, allowedStatuses) => {
+  let statusDict = dict->getDictfromDict(key)
+  allowedStatuses->Array.reduce(0, (acc, status) =>
+    (acc->Int.toFloat +. statusDict->getFloat(status, 0.0))->Float.toInt
+  )
+}
+
+let getSankeyCountMetric = (dict, key) => dict->getFloat(key, 0.0)->Float.toInt
+
+let getSankeyRowCount = dict => dict->getFloat("count", dict->getFloat("payment_intent_count", 0.0))
+
+let getSankeyFirstAttempt = dict =>
+  switch dict->Dict.get("first_attempt") {
+  | Some(value) =>
+    switch value->JSON.Decode.bool {
+    | Some(isFirstAttempt) => isFirstAttempt
+    | None => value->getIntFromJson(0) == 1
+    }
+  | None => false
+  }
+
+let buildAllStatusFilterString = obj => buildAllStatusFilterStringForKey(obj, "status_with_count")
 
 let getViewFilterValue = (view, obj, entity) => {
   switch entity {
@@ -128,6 +198,16 @@ let getViewFilterValue = (view, obj, entity) => {
     | Cancelled => "cancelled"
     | Pending => "pending"
     | RequiresCapture => "requires_capture"
+    | FirstAttemptSuccess
+    | RetrySuccess => "succeeded"
+    | Refunded => refundedStatusValues->Array.joinWith(",")
+    | Disputed =>
+      buildAllowedStatusFilterStringWithFallback(
+        obj,
+        "dispute_status_with_count",
+        disputedStatusValues,
+        "dispute_present,dispute_opened,dispute_challenged,dispute_lost,dispute_won,dispute_accepted,dispute_cancelled,dispute_expired",
+      )
     | _ => ""
     }
   | Refunds =>
@@ -171,11 +251,17 @@ let calculateTotalViewCount = obj => {
 }
 
 let getViewCount = (view, obj, entity) => {
-  switch view {
-  | All => calculateTotalViewCount(obj)
+  let dict = obj->getDictFromJsonObject
+  switch (view, entity) {
+  | (All, _) => calculateTotalViewCount(obj)
+  | (Refunded, Orders) =>
+    sumAllowedStatusCount(dict, "refunds_status_with_count", refundedStatusValues)
+  | (Disputed, Orders) =>
+    sumAllowedStatusCount(dict, "dispute_status_with_count", disputedStatusValues)
+  | (FirstAttemptSuccess, Orders) => getSankeyCountMetric(dict, "first_attempt_success_count")
+  | (RetrySuccess, Orders) => getSankeyCountMetric(dict, "retry_success_count")
   | _ =>
-    obj
-    ->getDictFromJsonObject
+    dict
     ->getDictfromDict("status_with_count")
     ->getInt(view->getViewFilterValue(obj, entity), 0)
   }
@@ -216,17 +302,60 @@ let metricsResponseToStatusWithCount = (~statusField, ~countField, response) => 
   [("status_with_count", statusWithCount->JSON.Encode.object)]->getJsonFromArrayOfJson
 }
 
+let sankeyResponseToStatusWithCount = response => {
+  let statusWithCount = Dict.make()
+  let refundsStatusWithCount = Dict.make()
+  let disputeStatusWithCount = Dict.make()
+  let firstAttemptSuccessCount = ref(0.0)
+  let retrySuccessCount = ref(0.0)
+
+  response
+  ->getArrayFromJson([])
+  ->Array.forEach(row => {
+    let dict = row->getDictFromJsonObject
+    let count = dict->getSankeyRowCount
+    let status = dict->getString("status", "")->String.toLowerCase
+    let refundsStatus = dict->getString("refunds_status", "")
+    let disputeStatus = dict->getString("dispute_status", "")
+    let isFirstAttempt = dict->getSankeyFirstAttempt
+
+    if status->isNonEmptyString {
+      let previous = statusWithCount->getFloat(status, 0.0)
+      statusWithCount->Dict.set(status, (previous +. count)->JSON.Encode.float)
+    }
+    if status === "succeeded" && isFirstAttempt {
+      firstAttemptSuccessCount := firstAttemptSuccessCount.contents +. count
+    }
+    if status === "succeeded" && !isFirstAttempt {
+      retrySuccessCount := retrySuccessCount.contents +. count
+    }
+    if refundsStatus->isNonEmptyString {
+      let previous = refundsStatusWithCount->getFloat(refundsStatus, 0.0)
+      refundsStatusWithCount->Dict.set(refundsStatus, (previous +. count)->JSON.Encode.float)
+    }
+    if disputeStatus->isNonEmptyString {
+      let previous = disputeStatusWithCount->getFloat(disputeStatus, 0.0)
+      disputeStatusWithCount->Dict.set(disputeStatus, (previous +. count)->JSON.Encode.float)
+    }
+  })
+
+  [
+    ("status_with_count", statusWithCount->JSON.Encode.object),
+    ("refunds_status_with_count", refundsStatusWithCount->JSON.Encode.object),
+    ("dispute_status_with_count", disputeStatusWithCount->JSON.Encode.object),
+    ("first_attempt_success_count", firstAttemptSuccessCount.contents->JSON.Encode.float),
+    ("retry_success_count", retrySuccessCount.contents->JSON.Encode.float),
+  ]->getJsonFromArrayOfJson
+}
+
 let getStartAndEndTime = (filterValueJson, version) => {
   filterValueJson->isEmptyDict
     ? ("", "")
     : {
         let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
         (
-          filterValueJson->getString(
-            OrderUIUtils.startTimeFilterKey(version),
-            defaultDate.start_time,
-          ),
-          filterValueJson->getString(OrderUIUtils.endTimeFilterKey(version), defaultDate.end_time),
+          filterValueJson->getString(startTimeFilterKey(version), defaultDate.start_time),
+          filterValueJson->getString(endTimeFilterKey(version), defaultDate.end_time),
         )
       }
 }

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -40,11 +40,6 @@ let disputeViewsArray: array<viewTypes> = [All, Succeeded, Failed, Pending]
 
 let payoutViewsArray: array<viewTypes> = [All, Succeeded, Failed, Cancelled, Expired, Reversed]
 
-let getTransactionViewGridClass = viewsCount =>
-  viewsCount >= 6
-    ? "grid lg:grid-cols-6 md:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-4"
-    : "grid lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-4"
-
 let getCustomFilterKey = entity =>
   switch entity {
   | Orders => "status"

--- a/src/utils/LogicUtils.res
+++ b/src/utils/LogicUtils.res
@@ -587,14 +587,8 @@ let getTitle = name => {
   ->Array.joinWith(" ")
 }
 
-let pluralize = (~count, ~singular, ~plural=?) => {
-  let pluralValue = plural->Option.getOr(`${singular}s`)
-  if count == 1 {
-    singular
-  } else {
-    pluralValue
-  }
-}
+let pluralize = (~count, ~singular, ~plural=?) =>
+  count == 1 ? singular : plural->Option.getOr(`${singular}s`)
 
 // Regex to check if a string contains a substring
 let regex = (positionToCheckFrom, searchString) => {

--- a/src/utils/LogicUtils.res
+++ b/src/utils/LogicUtils.res
@@ -587,6 +587,15 @@ let getTitle = name => {
   ->Array.joinWith(" ")
 }
 
+let pluralize = (~count, ~singular, ~plural=?) => {
+  let pluralValue = plural->Option.getOr(`${singular}s`)
+  if count == 1 {
+    singular
+  } else {
+    pluralValue
+  }
+}
+
 // Regex to check if a string contains a substring
 let regex = (positionToCheckFrom, searchString) => {
   let searchStringNew =


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds the hidden foundation for the advanced payment list flow without enabling user-facing rendering in this PR.

Changes include:
- Payment analytics/OpenSearch field mappings, CSV metadata, and advanced payment list table metadata.
- Typed payment list source primitives and reusable source-control UI support.
- Dormant transaction-view helpers for advanced payment activity cards.
- Optional table customization support for marking newly added columns while preserving existing behavior by default.

This PR does not wire the feature into the Payments page, does not enable a route or feature flag, and does not change visible behavior by itself. The follow-up PR will wire the UI and make the feature available.

## Motivation and Context

The advanced payment list work is being split into a foundation PR and a visible feature PR to reduce review load and keep rollout risk controlled. This foundation PR lets reviewers validate the data mapping, types, reusable helpers, and non-rendered components independently before the follow-up PR activates the full experience.

## How did you test it?

- Ran `npm run re:format`
- Ran `git diff --check`
- Ran `npm run re:build`

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
