### PR TITLE
fix: sync react qr lock metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-dom": "18.3.1",
         "react-final-form": "^6.5.9",
         "react-ga4": "^2.0.0",
-        "react-qr-code": "^2.0.12",
+        "react-qr-code": "2.0.21",
         "react-syntax-highlighter": "^15.5.0",
         "react-window": "^1.8.8",
         "recoil": "^0.1.2",


### PR DESCRIPTION
## Summary

Closes #5084.

This PR syncs the root dependency metadata in `package-lock.json` with the existing `package.json` declaration for `react-qr-code`.

`package.json` already declares:

```json
"react-qr-code": "2.0.21"
```

The resolved package entry in the lockfile is also already `node_modules/react-qr-code@2.0.21`. The only stale part was the root lockfile metadata under `packages[""].dependencies`, which still declared `^2.0.12`.

## Why

Running `npm install` rewrites this one lockfile line repeatedly, creating a noisy diff even when no dependency change is intended. Keeping the root lockfile metadata aligned with `package.json` makes npm installs stable and makes future dependency diffs easier to review.

## Changes

- Updated `package-lock.json` root metadata for `react-qr-code` from `^2.0.12` to `2.0.21`.
- Left the resolved `node_modules/react-qr-code` lockfile entry unchanged at `2.0.21`.

## Testing

- Not run, per request.
- This is a lockfile metadata-only change; build validation can be handled separately.