### PR TITLE
chore: align package manager metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,5 @@
     "rescript-webapi": "0.10.0",
     "tailwindcss": "^3.0.0"
   },
-  "packageManager": "yarn@3.2.1"
+  "packageManager": "npm@11.11.0"
 }


### PR DESCRIPTION
## Summary

Closes #5085.

This PR aligns the `packageManager` field in `package.json` with the dependency lockfile that is actually committed in the repository.

The repo currently commits `package-lock.json` with `lockfileVersion: 3`, but `package.json` still declares Yarn 3:

```json
"packageManager": "yarn@3.2.1"
```

There is no committed `yarn.lock`, so Corepack-aware tooling can point developers toward Yarn even though the reproducible dependency state is npm-based.

## Why

Keeping `packageManager` aligned with the committed lockfile avoids ambiguity for contributors and automation. npm users should not be left with npm lockfile changes while project metadata advertises Yarn as the expected package manager.

## Changes

- Changed `packageManager` from `yarn@3.2.1` to `npm@11.11.0`.
- Left `package-lock.json` unchanged.

## Notes

The npm version is based on the npm version available in the workspace used to prepare this PR. The existing lockfile is already an npm v3 lockfile.

## Testing

- Not run, per request.
- This is a package metadata-only change; build validation can be handled separately.