### PR TITLE
fix: remove payment settings from configure pmts show route

### DIFF
--- a/src/container/ConnectorContainer.res
+++ b/src/container/ConnectorContainer.res
@@ -153,10 +153,7 @@ let make = () => {
         isEnabled={featureFlagDetails.configurePmts}>
         <FilterContext key="ConfigurePmts" index="ConfigurePmts">
           <EntityScaffold
-            entityName="ConfigurePMTs"
-            remainingPath
-            renderList={() => <PaymentMethodList />}
-            renderShow={(_, _) => <PaymentSettings webhookOnly=false showFormOnly=false />}
+            entityName="ConfigurePMTs" remainingPath renderList={() => <PaymentMethodList />}
           />
         </FilterContext>
       </AccessControl>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removes the `PaymentSettings` renderer from the Configure PMTs entity scaffold show route.

Configure PMTs should continue using the existing list and modal-based configuration flow instead of rendering the Payment Settings detail screen from the generated entity show route.

## Motivation and Context

Fixes #2812.

Opening Configure PMTs through the entity scaffold show route could render the wrong payment settings experience. This keeps Configure PMTs on its intended configuration path.

## How did you test it?

- Ran `npm run re:build`

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
