### PR TITLE
fix: show toast for surcharge processor submit

### DIFF
--- a/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorHome.res
+++ b/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorHome.res
@@ -204,6 +204,10 @@ let make = () => {
       let _ = await fetchConnectorListResponse()
       setInitialValues(_ => response)
       setCurrentStep(_ => Summary)
+      showToast(
+        ~message=!isUpdateFlow ? "Connector Created Successfully!" : "Details Updated!",
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(e) => {
         let err = Exn.message(e)->Option.getOr("Something went wrong")


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds the standard success toast after surcharge processor create/update succeeds.

The toast message follows the existing connector submit pattern:

- `Connector Created Successfully!` for create flow
- `Details Updated!` for update flow

## Motivation and Context

Fixes #5043.

When a new surcharge connector was configured successfully, the UI moved to the summary screen but did not show a success toast.

## How did you test it?

- Ran `npm run re:build`

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
