### PR TITLE
feat: fetch platform aggregate payments list

### DIFF
--- a/src/screens/Transaction/Order/AnalyticsOrdersHook.res
+++ b/src/screens/Transaction/Order/AnalyticsOrdersHook.res
@@ -7,22 +7,33 @@ let useFetchAnalyticsOrdersHook = () => {
   let fetchDetails = useCancellableGetMethod()
   let {queryV2} = React.useContext(FilterContext.filterContext)
 
-  async (~payload, ~version: UserInfoTypes.version, ~signal=?) => {
+  async (~payload, ~version: UserInfoTypes.version, ~isPlatformMerchant=false, ~signal=?) => {
     try {
       switch version {
       | V1 =>
-        try {
-          let url = getURL(~entityName=V1(PAYMENTS_LIST), ~methodType=Post)
-          let res = await updateDetails(url, payload, Post, ~signal?)
-          res->mapAnalyticsResponseToOrdersObject
-        } catch {
-        | AbortControllerHook.AbortError => raise(AbortControllerHook.AbortError)
-        | _ if signal->Option.mapOr(false, AbortControllerHook.isAborted) =>
-          raise(AbortControllerHook.AbortError)
-        | _ => {
-            let url = getURL(~entityName=V1(ORDERS), ~methodType=Post)
+        if isPlatformMerchant {
+          let queryParameters = payload->OrdersHook.payloadToQueryParameters
+          let url = getURL(
+            ~entityName=V1(PLATFORM_ORDERS),
+            ~methodType=Get,
+            ~queryParameters=Some(queryParameters),
+          )
+          let res = await fetchDetails(url, ~signal?)
+          res->mapJsonToOrdersObject(paymentInterfaceV1)
+        } else {
+          try {
+            let url = getURL(~entityName=V1(PAYMENTS_LIST), ~methodType=Post)
             let res = await updateDetails(url, payload, Post, ~signal?)
-            res->mapJsonToOrdersObject(paymentInterfaceV1)
+            res->mapAnalyticsResponseToOrdersObject
+          } catch {
+          | AbortControllerHook.AbortError => raise(AbortControllerHook.AbortError)
+          | _ if signal->Option.mapOr(false, AbortControllerHook.isAborted) =>
+            raise(AbortControllerHook.AbortError)
+          | _ => {
+              let url = getURL(~entityName=V1(ORDERS), ~methodType=Post)
+              let res = await updateDetails(url, payload, Post, ~signal?)
+              res->mapJsonToOrdersObject(paymentInterfaceV1)
+            }
           }
         }
       | V2 => {

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -10,6 +10,7 @@ let make = (~previewOnly=false) => {
   let {devOpensearch, devSavedViews, transactionView} =
     HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
+  let {isCurrentMerchantPlatform} = OMPSwitchHooks.useOMPType()
   let {getCommonSessionDetails, getResolvedUserInfo, checkUserEntity} = React.useContext(
     UserInfoProvider.defaultContext,
   )
@@ -18,9 +19,17 @@ let make = (~previewOnly=false) => {
 
   let {userHasResourceAccess} = GroupACLHooks.useUserGroupACLHook()
   let fetchOrdersWithStrategy = (~payload, ~version, ~signal) => {
-    devOpensearch && userHasResourceAccess(~resourceAccess=Analytics) === Access
-      ? fetchAnalyticsOrdersHook(~payload, ~version, ~signal)
-      : fetchOrdersHook(~payload, ~version, ~signal)
+    let isPlatformV1 = switch version {
+    | UserInfoTypes.V1 => isCurrentMerchantPlatform
+    | UserInfoTypes.V2 => false
+    }
+    if isPlatformV1 {
+      fetchOrdersHook(~payload, ~version, ~isPlatformMerchant=true, ~signal)
+    } else if devOpensearch && userHasResourceAccess(~resourceAccess=Analytics) === Access {
+      fetchAnalyticsOrdersHook(~payload, ~version, ~isPlatformMerchant=false, ~signal)
+    } else {
+      fetchOrdersHook(~payload, ~version, ~isPlatformMerchant=false, ~signal)
+    }
   }
 
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
@@ -205,7 +214,8 @@ let make = (~previewOnly=false) => {
         ? <SavedViewsComponent version entity=SavedViewTypes.Payment />
         : React.null}
       entityName={switch version {
-      | V1 => V1(ORDER_FILTERS)
+      | V1 =>
+        isCurrentMerchantPlatform ? V1(PLATFORM_ORDER_FILTERS) : V1(ORDER_FILTERS)
       | V2 => V2(V2_ORDER_FILTERS)
       }}
       version

--- a/src/screens/Transaction/Order/OrdersHook.res
+++ b/src/screens/Transaction/Order/OrdersHook.res
@@ -1,5 +1,31 @@
 open APIUtils
 open PaymentListInterface
+open LogicUtils
+
+let rec jsonToQueryValue = value =>
+  switch value->JSON.Classify.classify {
+  | String(str) => str
+  | Number(num) => num->Float.toString
+  | Bool(bool) => bool->getStringFromBool
+  | Array(arr) =>
+    arr
+    ->Array.map(jsonToQueryValue)
+    ->Array.filter(value => value->isNonEmptyString)
+    ->Array.joinWith(",")
+  | _ => ""
+  }
+
+let payloadToQueryParameters = payload =>
+  payload
+  ->JSON.Decode.object
+  ->Option.getOr(Dict.make())
+  ->Dict.toArray
+  ->Array.filterMap(item => {
+    let (key, value) = item
+    let queryValue = value->jsonToQueryValue
+    queryValue->isNonEmptyString ? Some(`${key}=${queryValue->encodeURIComponent}`) : None
+  })
+  ->Array.joinWith("&")
 
 let useFetchOrdersHook = () => {
   let getURL = useGetURL()
@@ -7,12 +33,22 @@ let useFetchOrdersHook = () => {
   let fetchDetails = useCancellableGetMethod()
   let {queryV2} = React.useContext(FilterContext.filterContext)
 
-  async (~payload, ~version: UserInfoTypes.version, ~signal=?) => {
+  async (~payload, ~version: UserInfoTypes.version, ~isPlatformMerchant=false, ~signal=?) => {
     try {
       switch version {
       | V1 => {
-          let ordersUrl = getURL(~entityName=V1(ORDERS), ~methodType=Post)
-          let res = await updateDetails(ordersUrl, payload, Post, ~signal?)
+          let res = if isPlatformMerchant {
+            let queryParameters = payload->payloadToQueryParameters
+            let ordersUrl = getURL(
+              ~entityName=V1(PLATFORM_ORDERS),
+              ~methodType=Get,
+              ~queryParameters=Some(queryParameters),
+            )
+            await fetchDetails(ordersUrl, ~signal?)
+          } else {
+            let ordersUrl = getURL(~entityName=V1(ORDERS), ~methodType=Post)
+            await updateDetails(ordersUrl, payload, Post, ~signal?)
+          }
           res->mapJsonToOrdersObject(paymentInterfaceV1)
         }
       | V2 => {


### PR DESCRIPTION
## Summary

- Route V1 platform merchant Payments list requests to the platform aggregate endpoint added in #5129.
- Bypass the existing analytics/OpenSearch `PAYMENTS_LIST` path for platform V1, including when `devOpensearch` is enabled.
- Use the platform filter route for existing V1 Payments filter dimensions without adding merchant/profile ownership filters.
- Keep standard merchant, connected merchant, profile, and V2 Payments fetch behavior unchanged.

## Stack

Stacked on #5129 because this PR uses the `PLATFORM_ORDERS` and `PLATFORM_ORDER_FILTERS` route variants from that PR.

## Scope boundaries

- Does not add Merchant ID/Profile ID columns.
- Does not change row detail link construction.
- Does not add ownership filters.
- Does not change Refunds or Disputes.
- Does not add client-side fan-out across connected merchants.

## Implementation notes

- `Orders.res` now detects current platform merchant context and sends V1 platform list requests through the platform list hook path.
- `OrdersHook.res` converts the existing V1 filter payload into query parameters for `GET /payments/platform/list`.
- `AnalyticsOrdersHook.res` bypasses `PAYMENTS_LIST` for platform V1 so platform merchants do not receive merchant-scoped analytics/OpenSearch data under `devOpensearch`.
- V2 is intentionally unchanged.

## Verification

- `npm run re:build`
- `git diff --cached --check`

Closes #5119
