### PR TITLE
fix: redirect payout volume routing after save

### DIFF
--- a/src/screens/Routing/VolumeSplitRouting/VolumeSplitRouting.res
+++ b/src/screens/Routing/VolumeSplitRouting/VolumeSplitRouting.res
@@ -342,7 +342,7 @@ let make = (
       )
       setScreenState(_ => Success)
       if isSaveRule {
-        RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
+        RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url=baseUrlForRedirection))
       }
       Nullable.make(res)
     } catch {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Redirects a newly saved payout volume-routing rule to the payout routing page.

The shared volume-routing component now uses its supplied redirection base URL instead of a hard-coded pay-in routing path.

## Motivation and Context

Fixes #4947.

Saving a payout volume routing rule previously redirected to the pay-in routing page because the save path was hard-coded to `/routing`, even when the component was rendered by payout routing.

## How did you test it?

- Ran `npm run re:build`
- Ran `git diff --check`

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
