### PR TITLE
fix: center search result table content

### DIFF
--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -742,6 +742,13 @@ let make = (
     acc
   })
 
+  // Keep row content aligned with centered headings, including custom and date cells.
+  let alignCellContent = if headingCenter {
+    Some(`flex flex-col items-center text-center ${alignCellContent->Option.getOr("")}`)
+  } else {
+    alignCellContent
+  }
+
   let getRowDetails = (rowIndex: int) => {
     switch actualData {
     | Some(actualData) =>

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTable.res
@@ -40,8 +40,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTable.res
@@ -40,6 +40,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentAttempt/PaymentAttemptTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentAttempt/PaymentAttemptTable.res
@@ -39,6 +39,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentAttempt/PaymentAttemptTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentAttempt/PaymentAttemptTable.res
@@ -39,8 +39,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentIntent/PaymentIntentTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentIntent/PaymentIntentTable.res
@@ -40,8 +40,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentIntent/PaymentIntentTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PaymentIntent/PaymentIntentTable.res
@@ -40,6 +40,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PayoutAttempts/PayoutAttemptTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PayoutAttempts/PayoutAttemptTable.res
@@ -39,6 +39,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PayoutAttempts/PayoutAttemptTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/PayoutAttempts/PayoutAttemptTable.res
@@ -39,8 +39,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
@@ -41,6 +41,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Payouts/PayoutTable.res
@@ -41,8 +41,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTable.res
@@ -40,8 +40,7 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
-      headingCenter=searchResultsHeadingCenter
-      alignCellContent=searchResultsCellAlignmentClass
+      headingCenter=true
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTable.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Refunds/RefundsTable.res
@@ -40,6 +40,8 @@ module PreviewTable = {
       showResultsPerPageSelector=false
       paginationClass="hidden"
       showAutoScroll=true
+      headingCenter=searchResultsHeadingCenter
+      alignCellContent=searchResultsCellAlignmentClass
     />
   }
 }

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
@@ -1,5 +1,9 @@
 let tableBorderClass = "border-collapse border border-jp-gray-940 border-solid border-2 border-opacity-30 dark:border-jp-gray-dark_table_border_color dark:border-opacity-30"
 
+// Search-result previews should present every column consistently, regardless of the cell type.
+let searchResultsCellAlignmentClass = "flex flex-col items-center text-center"
+let searchResultsHeadingCenter = true
+
 let useGetData = () => {
   open LogicUtils
   let getURL = APIUtils.useGetURL()

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/ResultsTableUtils.res
@@ -1,9 +1,5 @@
 let tableBorderClass = "border-collapse border border-jp-gray-940 border-solid border-2 border-opacity-30 dark:border-jp-gray-dark_table_border_color dark:border-opacity-30"
 
-// Search-result previews should present every column consistently, regardless of the cell type.
-let searchResultsCellAlignmentClass = "flex flex-col items-center text-center"
-let searchResultsHeadingCenter = true
-
 let useGetData = () => {
   open LogicUtils
   let getURL = APIUtils.useGetURL()


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Updates the shared table component so its existing `headingCenter` option centers both column headings and row content.

Global search result previews opt into this table-level behavior for payment intents, payment attempts, payouts, payout attempts, refunds, and disputes. The table component handles text, date, and custom cells consistently, without search-specific alignment CSS.

## Motivation and Context

Fixes #4956.

Search result tables previously centered neither side consistently because header and cell alignment were controlled independently. Keeping both under one table-level option prevents headers and values from drifting out of alignment.

## How did you test it?

- Ran `npm run re:build`
- Ran `git diff --check`

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
