### PR TITLE
fix: update broken platform docs URL in API keys screen

### DIFF
--- a/src/screens/Developer/APIKeys/DeveloperUtils.res
+++ b/src/screens/Developer/APIKeys/DeveloperUtils.res
@@ -1,6 +1,6 @@
 open HSwitchSettingTypes
 
-let platformDocsUrl = "https://docs.hyperswitch.io/explore-hyperswitch/account-management/multiple-accounts-and-profiles/platform-org-and-merchant-setup"
+let platformDocsUrl = "https://docs.hyperswitch.io/integration-guide/account-management/multiple-accounts-and-profiles/platform-organization-concepts#the-platform-api-key"
 
 let validateAPIKeyForm = (
   values: JSON.t,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [x] Documentation
- [ ] CI/CD

## Description

The `platformDocsUrl` link in the API Keys screen pointed to a dead docs page (`explore-hyperswitch/.../platform-org-and-merchant-setup`), breaking the "Learn more" links shown next to elevated-privilege API key messaging (e.g. "Your API keys have elevated privileges..."). Updated the single source-of-truth constant to the live docs page.

`src/screens/Developer/APIKeys/DeveloperUtils.res` — `platformDocsUrl` now points to `https://docs.hyperswitch.io/integration-guide/account-management/multiple-accounts-and-profiles/platform-organization-concepts#the-platform-api-key`

This constant is consumed by `OMPSwitchHelper.res` and `KeyManagement.res`, so this one change fixes every affected link.

## Motivation and Context

The old docs URL returns a broken page. Reported by a merchant using the control center. One-line fix to restore working documentation links across all API key / platform surfaces.

## How did you test it?

Ran `npm run re:build` — compiles clean (3049/3049 modules). Change is a URL string constant only; no logic changed.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

## Feature Flag

- [x] No feature flag changes