### PR TITLE
fix: use Blend Toast and error code mapping for clone connector

### DIFF
--- a/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthTypes.res
@@ -45,5 +45,6 @@ type subCode =
   | UR_35
   | UR_37
   | UR_39
+  | UR_59
 
 type modeType = TestButtonMode | LiveButtonMode

--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -136,6 +136,7 @@ let errorSubCodeMapper = (subCode: string) => {
   | "UR_06" => UR_06
   | "UR_37" => UR_37
   | "UR_39" => UR_39
+  | "UR_59" => UR_59
 
   | _ => UR_00
   }

--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModal.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModal.res
@@ -6,7 +6,7 @@ open CloneConnectorModalUtils
 let make = (~connectorInfo: ConnectorTypes.connectorPayload) => {
   open APIUtils
   let updateDetails = useUpdateMethod(~showErrorToast=false)
-  let showToast = ToastState.useShowToast()
+  let showToast = ToastAdapter.useShowToast()
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let getURL = useGetURL()
   let featureFlag = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
@@ -66,14 +66,21 @@ let make = (~connectorInfo: ConnectorTypes.connectorPayload) => {
       let _ = await updateDetails(url, body, Post)
       setShowModal(_ => false)
       showToast(~message="Connector cloned successfully.", ~toastType=ToastSuccess)
+      Nullable.null
     } catch {
     | Exn.Error(e) =>
       let err = Exn.message(e)->Option.getOr("Failed to clone connector")
-      let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")
+      let errorCode = err->safeParse->getDictFromJsonObject->getString("code", "")->CommonAuthUtils.errorSubCodeMapper
       let message = errorCode->getCloneErrorMessage
       showToast(~message, ~toastType=ToastError)
+      switch errorCode {
+      | UR_59 =>
+        let errors = Dict.make()
+        Dict.set(errors, "connector_label", message->JSON.Encode.string)
+        errors->JSON.Encode.object->Nullable.make
+      | _ => Nullable.null
+      }
     }
-    Nullable.null
   }
 
   <RenderIf condition={showCloneButton}>

--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalUtils.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalUtils.res
@@ -1,5 +1,6 @@
 open LogicUtils
 open ConnectorTypes
+open CommonAuthTypes
 
 let getCloneConnectorPayload = (values, connectorInfo) => {
   let valuesDict = values->getDictFromJsonObject
@@ -13,9 +14,10 @@ let getCloneConnectorPayload = (values, connectorInfo) => {
 }
 
 let getCloneErrorMessage = errorCode =>
-  errorCode === "HE_01"
-    ? "Connector label already exists. Try a different one."
-    : "Failed to clone connector."
+  switch errorCode {
+  | UR_59 => "Connector label already exists."
+  | _ => "Failed to clone connector."
+  }
 
 let getDestinationOptions = (profileList: array<OMPSwitchTypes.ompListTypes>, ~sourceProfileId) =>
   profileList->Array.filterMap(profile =>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

https://github.com/user-attachments/assets/14b698d5-8cbe-4912-903a-89500f40162d



Use Blend design system Toast component and add type-safe error code handling for clone connector feature. When duplicate connector label error (UR_59) occurs, return field-level errors from form submission.

## Motivation and Context

Fixes issue #19582 - Toast component was using old design system instead of Blend. Also improved error handling by mapping error codes to user-friendly messages and enabling field-level validation display.

## How did you test it?

- `npm run re:build` - verified ReScript compilation passes
- Tested error code mapping with UR_59 (duplicate label scenario)
- Verified Toast uses Blend design system via ToastAdapter

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible