### PR TITLE
fix: preserve acquirer BIN values and keep modal actions visible

### DIFF
--- a/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigEntity.res
+++ b/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigEntity.res
@@ -47,11 +47,18 @@ let merchantName = makeAlphanumericInputField(
   ~placeholder="Enter Merchant Name",
 )
 
-let acquirerBin = makeNumericInputField(
+let acquirerBin = makeFieldInfo(
   ~label="Acquirer Bin",
   ~name="acquirer_bin",
   ~placeholder="Enter Acquirer Bin",
-  ~maxLength=20,
+  ~customInput=InputFields.textInput(~inputMode="numeric", ~maxLength=20, ~autoComplete="off"),
+  ~parse=(~value, ~name as _) =>
+    value
+    ->JSON.Decode.string
+    ->Option.getOr("")
+    ->String.replaceRegExp(%re("/[^0-9]/g"), "")
+    ->JSON.Encode.string,
+  ~isRequired=true,
 )
 
 let acquirerFraudRate = makeNumericInputField(

--- a/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigSettings.res
+++ b/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigSettings.res
@@ -45,12 +45,7 @@ module SettingsForm = {
       : ("Save", "Close")
 
     let prepareFormData = values => {
-      let valuesDict = values->getDictFromJsonObject
-      let acquirerBinValue = valuesDict->getFloat("acquirer_bin", 0.0)
-      if acquirerBinValue > 0.0 {
-        valuesDict->Dict.set("acquirer_bin", acquirerBinValue->Float.toString->JSON.Encode.string)
-      }
-      valuesDict
+      values->getDictFromJsonObject
     }
 
     let handleApiError = e => {

--- a/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigUtils.res
+++ b/src/screens/Developer/PaymentSettings/AcquirerConfigSettings/AcquirerConfigUtils.res
@@ -56,18 +56,11 @@ let validateAcquirerConfigForm = (values, keys) => {
       }
 
     | "acquirer_bin" =>
-      let binValue = valuesDict->getOptionFloat(key)
-      switch binValue {
-      | Some(binValue) =>
-        if binValue->Float.toString->String.includes(".") {
-          key->setFieldError("Acquirer BIN must be a whole number")
-        } else {
-          let binLength = binValue->Float.toString->String.length
-          if binLength < 5 || binLength > 20 {
-            key->setFieldError("Acquirer BIN must be between 5 and 20 digits")
-          }
-        }
-      | None => key->setFieldError("This field is required")
+      let binValue = valuesDict->getString(key, "")
+      if binValue->LogicUtils.isEmptyString {
+        key->setFieldError("This field is required")
+      } else if binValue->String.length < 5 || binValue->String.length > 20 {
+        key->setFieldError("Acquirer BIN must be between 5 and 20 digits")
       }
     | _ =>
       if value === "" {

--- a/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigEntityRevamp.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigEntityRevamp.res
@@ -47,11 +47,18 @@ let merchantName = makeAlphanumericInputField(
   ~placeholder="Enter Merchant Name",
 )
 
-let acquirerBin = makeNumericInputField(
+let acquirerBin = makeFieldInfo(
   ~label="Acquirer Bin",
   ~name="acquirer_bin",
   ~placeholder="Enter Acquirer Bin",
-  ~maxLength=20,
+  ~customInput=InputFields.textInput(~inputMode="numeric", ~maxLength=20, ~autoComplete="off"),
+  ~parse=(~value, ~name as _) =>
+    value
+    ->JSON.Decode.string
+    ->Option.getOr("")
+    ->String.replaceRegExp(%re("/[^0-9]/g"), "")
+    ->JSON.Encode.string,
+  ~isRequired=true,
 )
 
 let acquirerFraudRate = makeNumericInputField(

--- a/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigSettingsRevamp.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigSettingsRevamp.res
@@ -46,12 +46,7 @@ module SettingsForm = {
       : ("Save", "Close")
 
     let prepareFormData = values => {
-      let valuesDict = values->getDictFromJsonObject
-      let acquirerBinValue = valuesDict->getFloat("acquirer_bin", 0.0)
-      if acquirerBinValue > 0.0 {
-        valuesDict->Dict.set("acquirer_bin", acquirerBinValue->Float.toString->JSON.Encode.string)
-      }
-      valuesDict
+      values->getDictFromJsonObject
     }
 
     let handleApiError = e => {

--- a/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigUtilsRevamp.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/AcquirerConfigSettingsRevamp/AcquirerConfigUtilsRevamp.res
@@ -56,18 +56,11 @@ let validateAcquirerConfigForm = (values, keys) => {
       }
 
     | "acquirer_bin" =>
-      let binValue = valuesDict->getOptionFloat(key)
-      switch binValue {
-      | Some(binValue) =>
-        if binValue->Float.toString->String.includes(".") {
-          key->setFieldError("Acquirer BIN must be a whole number")
-        } else {
-          let binLength = binValue->Float.toString->String.length
-          if binLength < 5 || binLength > 20 {
-            key->setFieldError("Acquirer BIN must be between 5 and 20 digits")
-          }
-        }
-      | None => key->setFieldError("This field is required")
+      let binValue = valuesDict->getString(key, "")
+      if binValue->LogicUtils.isEmptyString {
+        key->setFieldError("This field is required")
+      } else if binValue->String.length < 5 || binValue->String.length > 20 {
+        key->setFieldError("Acquirer BIN must be between 5 and 20 digits")
       }
     | _ =>
       if value === "" {

--- a/src/screens/Developer/PaymentSettingsRevamped/MerchantAcquirerDetails/MerchantAcquirerDetailsModals.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/MerchantAcquirerDetails/MerchantAcquirerDetailsModals.res
@@ -57,21 +57,27 @@ module AddAcquirerModal = {
       closeOnOutsideClick=true
       modalHeading="Add Acquirer Configuration"
       modalClass="flex flex-col justify-start h-screen w-420-px float-right overflow-hidden !bg-white"
-      childClass="">
+      headingClass="shrink-0"
+      childClass="flex-1 min-h-0">
       <Form
         onSubmit
         initialValues={JSON.Encode.null}
         validate={values => validateForm(~requiredKeys, values)}
-        formClass="flex flex-col gap-4 p-6">
-        <FieldRenderer field=merchantNameField />
-        <FieldRenderer field=merchantIdField />
-        <hr className="my-2 border-nd_gray-200" />
-        <FieldRenderer field={networkField(~options=AcquirerConfigUtils.networkDropDownOptions)} />
-        <FieldRenderer field=binField />
-        <FieldRenderer field=icaField />
-        <FieldRenderer field=fraudRateField />
-        <FieldRenderer field=countryField />
-        <div className="flex justify-end gap-2 pt-4 border-t border-nd_gray-200 mt-4">
+        formClass="flex h-full min-h-0 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+          <FieldRenderer field=merchantNameField />
+          <FieldRenderer field=merchantIdField />
+          <hr className="my-2 border-nd_gray-200" />
+          <FieldRenderer
+            field={networkField(~options=AcquirerConfigUtils.networkDropDownOptions)}
+          />
+          <FieldRenderer field=binField />
+          <FieldRenderer field=icaField />
+          <FieldRenderer field=fraudRateField />
+          <FieldRenderer field=countryField />
+        </div>
+        <div
+          className="flex shrink-0 justify-end gap-2 border-t border-nd_gray-200 bg-white px-6 py-4">
           <Button
             buttonType=Button.Secondary text="Cancel" onClick={_ => setShowModal(_ => false)}
           />
@@ -125,7 +131,8 @@ module AddNetworkModal = {
       modalHeading="Add Network Configuration"
       modalHeadingDescriptionElement={acquirerIdHeading(~bucket)}
       modalClass="flex flex-col justify-start h-screen w-420-px float-right overflow-hidden !bg-white"
-      childClass="">
+      headingClass="shrink-0"
+      childClass="flex-1 min-h-0">
       <RenderIf condition={allNetworksUsed}>
         <div className="p-6 flex flex-col gap-4">
           <div className={`${body.md.regular} text-nd_gray-500`}>
@@ -143,13 +150,16 @@ module AddNetworkModal = {
           onSubmit
           initialValues={JSON.Encode.null}
           validate={values => validateForm(~requiredKeys, values)}
-          formClass="flex flex-col gap-4 p-6">
-          <FieldRenderer field={networkField(~options=availableNetworks)} />
-          <FieldRenderer field=binField />
-          <FieldRenderer field=icaField />
-          <FieldRenderer field=fraudRateField />
-          <FieldRenderer field=countryField />
-          <div className="flex justify-end gap-2 pt-4 border-t border-nd_gray-200 mt-4">
+          formClass="flex h-full min-h-0 flex-col">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+            <FieldRenderer field={networkField(~options=availableNetworks)} />
+            <FieldRenderer field=binField />
+            <FieldRenderer field=icaField />
+            <FieldRenderer field=fraudRateField />
+            <FieldRenderer field=countryField />
+          </div>
+          <div
+            className="flex shrink-0 justify-end gap-2 border-t border-nd_gray-200 bg-white px-6 py-4">
             <Button
               buttonType=Button.Secondary text="Cancel" onClick={_ => setShowModal(_ => false)}
             />
@@ -239,18 +249,22 @@ module EditNetworkModal = {
       modalHeading="Edit Network Configuration"
       modalHeadingDescriptionElement={acquirerIdHeading(~bucket)}
       modalClass="flex flex-col justify-start h-screen w-420-px float-right overflow-hidden !bg-white"
-      childClass="">
+      headingClass="shrink-0"
+      childClass="flex-1 min-h-0">
       <Form
         onSubmit
         initialValues
         validate={values => validateForm(~requiredKeys, values)}
-        formClass="flex flex-col gap-4 p-6">
-        <FieldRenderer field=lockedNetworkField />
-        <FieldRenderer field=binField />
-        <FieldRenderer field=icaField />
-        <FieldRenderer field=fraudRateField />
-        <FieldRenderer field=countryField />
-        <div className="flex justify-end gap-2 pt-4 border-t border-nd_gray-200 mt-4">
+        formClass="flex h-full min-h-0 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+          <FieldRenderer field=lockedNetworkField />
+          <FieldRenderer field=binField />
+          <FieldRenderer field=icaField />
+          <FieldRenderer field=fraudRateField />
+          <FieldRenderer field=countryField />
+        </div>
+        <div
+          className="flex shrink-0 justify-end gap-2 border-t border-nd_gray-200 bg-white px-6 py-4">
           <Button buttonType=Button.Secondary text="Cancel" onClick={_ => setEntry(_ => None)} />
           <SubmitButton text="Update" buttonType=Button.Primary />
         </div>

--- a/src/screens/Developer/PaymentSettingsRevamped/MerchantAcquirerDetails/MerchantAcquirerDetailsUtils.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/MerchantAcquirerDetails/MerchantAcquirerDetailsUtils.res
@@ -33,7 +33,13 @@ let binField = makeFieldInfo(
   ~label="Acquirer BIN",
   ~name="acquirer_bin",
   ~placeholder="e.g. 56688",
-  ~customInput=InputFields.numericTextInput(~removeLeadingZeroes=true, ~maxLength=20, ~precision=0),
+  ~customInput=InputFields.textInput(~inputMode="numeric", ~maxLength=20, ~autoComplete="off"),
+  ~parse=(~value, ~name as _) =>
+    value
+    ->JSON.Decode.string
+    ->Option.getOr("")
+    ->String.replaceRegExp(%re("/[^0-9]/g"), "")
+    ->JSON.Encode.string,
   ~isRequired=true,
 )
 
@@ -120,7 +126,7 @@ let stampProfileId = (body: Dict.t<JSON.t>, ~profileId: string) => {
 }
 
 let normalizeNumericStringFields = (body: Dict.t<JSON.t>) => {
-  [AcquirerBin, AcquirerIca]->Array.forEach(field => {
+  [AcquirerIca]->Array.forEach(field => {
     let key = (field :> string)
     let value = body->getFloat(key, 0.0)
     if value > 0.0 {
@@ -137,23 +143,18 @@ let validateForm = (~requiredKeys: array<acquirerField>, values: JSON.t): JSON.t
 
   requiredKeys->Array.forEach(field => {
     let key = (field :> string)
-    let present = switch field {
-    | AcquirerBin => valuesDict->getOptionFloat(key)->Option.isSome
-    | _ => valuesDict->getString(key, "")->isNonEmptyString
-    }
+    let present = valuesDict->getString(key, "")->isNonEmptyString
     if !present {
       setErr(key, "This field is required")
     }
   })
 
-  valuesDict
-  ->getOptionFloat((AcquirerBin :> string))
-  ->mapOptionOrDefault((), binFloat => {
-    let binStr = binFloat->Float.toString
+  let binStr = valuesDict->getString((AcquirerBin :> string), "")
+  if binStr->isNonEmptyString {
     if binStr->String.length < 4 || binStr->String.length > 20 {
       setErr((AcquirerBin :> string), "Acquirer BIN must be between 4 and 20 digits")
     }
-  })
+  }
 
   valuesDict
   ->getOptionFloat((AcquirerFraudRate :> string))


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Keep Acquirer BIN values as digit-only strings across Payment Settings, Payment Settings Revamped, and Merchant Acquirer Details.
- Remove float-based BIN normalization and validate BIN length from the preserved string value.
- Keep Add/Edit Acquirer drawer actions visible while the form fields scroll within the available height.

## Motivation and Context

The original BIN inputs passed values through JavaScript numbers, so values beyond the IEEE 754 safe integer range lost precision and ended with zeroes. The issue's follow-up recording also showed that at the reported 13-inch viewport (`1280 × 750`), the fixed-height drawer clipped the Save and Cancel actions below the usable area.

This change fixes both symptoms and covers the sibling settings screens requested during review of #4939.

Fixes #4118

## How did you test it?

- Inspected all three issue recordings, including the original precision failure, the successful precision retest, and the `1280 × 750` action-footer regression.
- Ran `npm run re:format`.
- Ran `npm run re:build` successfully; the active ReScript watcher also regenerated every changed module after final formatting.
- Ran `git diff --check`.
- Validated the drawer with the compiled application styles in Chromium at `1280 × 750`:
  - the fields region scrolls when its content exceeds the available height;
  - Save and Cancel remain inside the viewport before and after scrolling;
  - a 20-digit BIN remains unchanged.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible