### PR TITLE
fix: add authentication analytics heading spacing

### DIFF
--- a/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
+++ b/src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res
@@ -366,7 +366,7 @@ let make = () => {
   ]
   <PageLoaderWrapper screenState customUI={<HSAnalyticsUtils.NoData title />}>
     <InsightsHelper.SampleDataBanner applySampleDateFilters />
-    <PageUtils.PageHeading title />
+    <PageUtils.PageHeading customHeadingStyle="mt-4" title />
     <HSAnalyticsUtils.PlatformAggregatedDataBanner />
     <div className="flex justify-end mr-4">
       <GenerateReport entityName={V1(AUTHENTICATION_REPORT)} disableReport={isSampleDataEnabled} />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds the same top margin used by Insights between the sample-data banner and the page heading to Authentication Analytics.

## Motivation and Context

The Authentication Analytics heading was touching the sample-data banner, making the layout inconsistent with Insights.

Fixes #4907.

## How did you test it?

- Ran `npx rescript format src/screens/NewAnalytics/Insights/NewAuthenticationAnalytics/NewAuthenticationAnalytics.res`
- Ran `npm run re:build` successfully in an isolated clean worktree
- Ran `git diff --check`
- Compared the implementation with the existing Insights heading spacing convention

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


<img width="1552" height="922" alt="Screenshot 2026-07-14 at 4 54 27 PM" src="https://github.com/user-attachments/assets/1fea87a8-f2d1-4c9e-b77b-5b5cad8f1d0a" />


