### PR TITLE
fix: standardize connector toggle toasts

### DIFF
--- a/src/screens/ConnectorV2/PaymentProcessorSummary.res
+++ b/src/screens/ConnectorV2/PaymentProcessorSummary.res
@@ -202,9 +202,15 @@ let make = (
       let _ = await fetchConnectorListResponse()
       setInitialValues(_ => res)
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message=`Successfully Saved the Changes`, ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(isConnectorDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
-    | Exn.Error(_) => setScreenState(_ => PageLoaderWrapper.Error("Failed to Disable connector!"))
+    | Exn.Error(_) =>
+      setScreenState(_ => PageLoaderWrapper.Error(
+        ConnectorUtils.getConnectorToggleFailureMessage(isConnectorDisabled),
+      ))
     }
   }
 

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -1799,6 +1799,12 @@ let getDisableConnectorPayloadV2 = (connectorType, previousConnectorState, merch
   ]->getJsonFromArrayOfJson
 }
 
+let getConnectorToggleSuccessMessage = wasConnectorDisabled =>
+  `Connector has been successfully ${wasConnectorDisabled ? "Enabled" : "Disabled"}`
+
+let getConnectorToggleFailureMessage = wasConnectorDisabled =>
+  `Failed to ${wasConnectorDisabled ? "enable" : "disable"} connector!`
+
 let getWebHookRequiredFields = (connector: connectorTypes, fieldName: string) => {
   switch (connector, fieldName) {
   | (Processors(ADYEN), "merchant_secret") => true

--- a/src/screens/Connectors/FraudAndRisk/FRMSummary.res
+++ b/src/screens/Connectors/FraudAndRisk/FRMSummary.res
@@ -121,9 +121,16 @@ let make = (
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message=`Successfully Saved the Changes`, ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(isFRMDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
-    | Exn.Error(_) => showToast(~message=`Failed to Disable connector!`, ~toastType=ToastError)
+    | Exn.Error(_) =>
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleFailureMessage(isFRMDisabled),
+        ~toastType=ToastError,
+      )
     }
   }
 

--- a/src/screens/Connectors/PMAuthenticationProcessor/PMAuthenticationHome.res
+++ b/src/screens/Connectors/PMAuthenticationProcessor/PMAuthenticationHome.res
@@ -95,10 +95,16 @@ let make = () => {
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message="Successfully Saved the Changes", ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(_) => {
-        showToast(~message="Failed to Disable connector!", ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }

--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/ConnectorPreview.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/ConnectorPreview.res
@@ -400,12 +400,15 @@ let make = (
       setInitialValues(_ => res)
       setScreenState(_ => PageLoaderWrapper.Success)
       showToast(
-        ~message=`Connector has been successfully ${currentIsDisabled ? "Enabled" : "Disabled"}`,
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
         ~toastType=ToastSuccess,
       )
     } catch {
     | Exn.Error(_) => {
-        showToast(~message=`Failed to Disable connector!`, ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }

--- a/src/screens/Connectors/PayoutProcessor/PayoutProcessorHome.res
+++ b/src/screens/Connectors/PayoutProcessor/PayoutProcessorHome.res
@@ -182,10 +182,16 @@ let make = (~showStepIndicator=true, ~showBreadCrumb=true) => {
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message="Successfully Saved the Changes", ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(_) => {
-        showToast(~message="Failed to Disable connector!", ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }

--- a/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorHome.res
+++ b/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorHome.res
@@ -48,12 +48,16 @@ let make = () => {
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message="Successfully Saved the Changes", ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(_) => {
-        let action = currentIsDisabled ? "enable" : "disable"
-
-        showToast(~message=`Failed to ${action} connector!`, ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }

--- a/src/screens/Connectors/TaxProcessor/TaxProcessorHome.res
+++ b/src/screens/Connectors/TaxProcessor/TaxProcessorHome.res
@@ -93,10 +93,16 @@ let make = () => {
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message="Successfully Saved the Changes", ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(_) => {
-        showToast(~message="Failed to Disable connector!", ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }

--- a/src/screens/Connectors/ThreeDsProcessors/ThreeDsProcessorHome.res
+++ b/src/screens/Connectors/ThreeDsProcessors/ThreeDsProcessorHome.res
@@ -148,10 +148,16 @@ let make = () => {
       setInitialValues(_ => res)
       let _ = await fetchConnectorListResponse()
       setScreenState(_ => PageLoaderWrapper.Success)
-      showToast(~message="Successfully Saved the Changes", ~toastType=ToastSuccess)
+      showToast(
+        ~message=ConnectorUtils.getConnectorToggleSuccessMessage(currentIsDisabled),
+        ~toastType=ToastSuccess,
+      )
     } catch {
     | Exn.Error(_) => {
-        showToast(~message="Failed to Disable connector!", ~toastType=ToastError)
+        showToast(
+          ~message=ConnectorUtils.getConnectorToggleFailureMessage(currentIsDisabled),
+          ~toastType=ToastError,
+        )
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Standardizes the result messages shown after connector enable/disable actions.

- Adds shared helpers for result-specific success and failure messages.
- Applies the same success wording used by Payin connectors to Payout, Tax, 3DS authentication, payment-method authentication, Surcharge, Fraud and Risk, and V2 connector summaries.
- Makes failure messages action-specific so an enable failure no longer says that disabling failed.
- Leaves unrelated connector create, edit, and save messages unchanged.

## Motivation and Context

Non-Payin connector toggles showed the generic `Successfully Saved the Changes` toast instead of stating whether the connector was enabled or disabled. This made the same action behave differently across connector types.

Fixes #5031.

## How did you test it?

- Ran `npx rescript format` on all changed ReScript files.
- Ran the full `npm run re:build` successfully (3,940 modules).
- Ran `git diff --check`.
- Audited every V1 and V2 enable/disable payload handler to confirm it uses the shared success and failure message mapping.
- Confirmed the unrelated Billing processor save toast remains unchanged.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
