### PR TITLE
fix: validate payment settings URLs and label connectors

### DIFF
--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -114,6 +114,25 @@ test.describe("Payment Settings", () => {
       );
     });
 
+    test("should reject malformed return and webhook URLs", async ({
+      page,
+    }) => {
+      const paymentSettings = new PaymentSettings(page);
+
+      await paymentSettings.fillReturnUrl("https://");
+      await paymentSettings.fillWebhookUrl("https://%%%");
+
+      await expect(paymentSettings.returnUrlError).toBeVisible();
+      await expect(paymentSettings.webhookUrlError).toBeVisible();
+      await expect(paymentSettings.updateButton).toBeDisabled();
+
+      await paymentSettings.fillReturnUrl("https://example.com/return");
+      await paymentSettings.fillWebhookUrl("https://example.com/webhook");
+
+      await expect(paymentSettings.returnUrlError).toHaveCount(0);
+      await expect(paymentSettings.webhookUrlError).toHaveCount(0);
+    });
+
     test("should save toggle, form, and dropdown values when Update is clicked", async ({
       page,
     }) => {
@@ -451,11 +470,22 @@ test.describe("Payment Settings", () => {
       const requestorAppUrl = "https://example.com/3ds-requestor-app";
 
       await paymentSettings.selectFieldDropdown().click();
+      await expect(paymentSettings.dropdownValue(connectorName)).toContainText(
+        `${connectorName} - threeds_tab_connector`,
+      );
       await paymentSettings.dropdownValue(connectorName).click();
       await page.keyboard.press("Escape");
 
+      await paymentSettings.threeDsRequestorUrlInput.fill("https://");
+      await paymentSettings.threeDsRequestorAppUrlInput.fill("https://%%%");
+      await expect(paymentSettings.threeDsRequestorUrlError).toBeVisible();
+      await expect(paymentSettings.threeDsRequestorAppUrlError).toBeVisible();
+      await expect(paymentSettings.updateButton).toBeDisabled();
+
       await paymentSettings.threeDsRequestorUrlInput.fill(requestorUrl);
       await paymentSettings.threeDsRequestorAppUrlInput.fill(requestorAppUrl);
+      await expect(paymentSettings.threeDsRequestorUrlError).toHaveCount(0);
+      await expect(paymentSettings.threeDsRequestorAppUrlError).toHaveCount(0);
 
       await paymentSettings.clickUpdate();
       await expect(paymentSettings.detailsUpdatedToast).toBeVisible({

--- a/playwright-tests/support/pages/developers/PaymentSettings.ts
+++ b/playwright-tests/support/pages/developers/PaymentSettings.ts
@@ -91,6 +91,14 @@ export class PaymentSettings {
     return this.page.getByPlaceholder("Enter Webhook URL");
   }
 
+  get returnUrlError(): Locator {
+    return this.page.getByText("Please Enter Valid Return URL");
+  }
+
+  get webhookUrlError(): Locator {
+    return this.page.getByText("Please Enter Valid Webhook URL");
+  }
+
   get merchantCategoryCodeDropdown(): Locator {
     return this.page.getByRole("button", { name: "Select Option" });
   }
@@ -156,6 +164,14 @@ export class PaymentSettings {
 
   get threeDsRequestorAppUrlInput(): Locator {
     return this.page.getByPlaceholder("Enter 3DS Requestor App URL");
+  }
+
+  get threeDsRequestorUrlError(): Locator {
+    return this.page.getByText("Please Enter Valid Threeds URL");
+  }
+
+  get threeDsRequestorAppUrlError(): Locator {
+    return this.page.getByText("Please enter a valid URL or Mobile Deeplink");
   }
 
   // Acquirer Config Settings (MerchantAcquirerDetails — new flow)

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevampedHelper.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevampedHelper.res
@@ -54,12 +54,12 @@ let threeDsRequestoApprUrl = FormRenderer.makeFieldInfo(
   ~customInput=InputFields.textInput(~autoComplete="off", ~customStyle="rounded-xl"),
   ~isRequired=false,
 )
-let authenticationConnectors = connectorList =>
+let authenticationConnectors = connectorOptions =>
   FormRenderer.makeFieldInfo(
     ~label="Authentication Connectors",
     ~name="authentication_connector_details.authentication_connectors",
     ~customInput=InputFields.multiSelectInput(
-      ~options=connectorList->SelectBox.makeOptions,
+      ~options=connectorOptions,
       ~buttonText="Select Field",
       ~showSelectionAsChips=false,
       ~customButtonStyle="!rounded-lg",

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevampedUtils.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsRevampedUtils.res
@@ -103,15 +103,43 @@ let validateEmptyArray = (key, errors, arrayValue) => {
   | _ => ()
   }
 }
+
+type parsedUrl
+
+@new external parseUrl: string => parsedUrl = "URL"
+@get external getProtocol: parsedUrl => string = "protocol"
+@get external getHostname: parsedUrl => string = "hostname"
+@get external getPathname: parsedUrl => string = "pathname"
+
+let isValidHttpUrl = (value, isLiveMode) => {
+  try {
+    let parsedUrl = parseUrl(value)
+    let protocol = parsedUrl->getProtocol
+    let isLocalhost = parsedUrl->getHostname === "localhost"
+
+    protocol === "https:" || (protocol === "http:" && (!isLiveMode || isLocalhost))
+  } catch {
+  | _ => false
+  }
+}
+
+let isValidDeepLink = value => {
+  try {
+    let parsedUrl = parseUrl(value)
+    let pathname = parsedUrl->getPathname
+    let hasDestination = parsedUrl->getHostname !== "" || (pathname !== "" && pathname !== "/")
+
+    hasDestination && RegExp.test(%re("/^[a-zA-Z][a-zA-Z0-9]*:\/\//i"), value)
+  } catch {
+  | _ => false
+  }
+}
+
 let validateCustom = (key, errors, value, isLiveMode) => {
   switch key {
   | WebhookDetails =>
-    let regexUrl = isLiveMode
-      ? RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost")
-      : RegExp.test(%re("/^(http|https):\/\//i"), value)
-
     let webhookErrorDict = errors->getDictfromDict("webhook_details")
-    if !regexUrl {
+    if !isValidHttpUrl(value, isLiveMode) {
       errors->Dict.set("webhook_details", JSON.Encode.null)
       Dict.set(
         webhookErrorDict,
@@ -121,22 +149,15 @@ let validateCustom = (key, errors, value, isLiveMode) => {
       Dict.set(errors, "webhook_details", webhookErrorDict->JSON.Encode.object)
     }
 
-  | ReturnUrl => {
-      let regexUrl = isLiveMode
-        ? RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost")
-        : RegExp.test(%re("/^(http|https):\/\//i"), value)
-      if !regexUrl {
-        Dict.set(errors, "return_url", "Please Enter Valid Return URL"->JSON.Encode.string)
-      }
+  | ReturnUrl =>
+    if !isValidHttpUrl(value, isLiveMode) {
+      Dict.set(errors, "return_url", "Please Enter Valid Return URL"->JSON.Encode.string)
     }
 
   | ThreeDsRequestorUrl => {
-      let regexUrl = isLiveMode
-        ? RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost")
-        : RegExp.test(%re("/^(http|https):\/\//i"), value)
       let authConnectorDetailsErrorDict =
         errors->getDictfromDict("authentication_connector_details")
-      if !regexUrl {
+      if !isValidHttpUrl(value, isLiveMode) {
         errors->Dict.set("authentication_connector_details", JSON.Encode.null)
         Dict.set(
           authConnectorDetailsErrorDict,
@@ -151,11 +172,8 @@ let validateCustom = (key, errors, value, isLiveMode) => {
       }
     }
   | ThreeDsRequestorAppUrl =>
-    let httpUrlValid = isLiveMode
-      ? RegExp.test(%re("/^https:\/\//i"), value) || value->String.includes("localhost")
-      : RegExp.test(%re("/^(http|https):\/\//i"), value)
-
-    let deepLinkValid = RegExp.test(%re("/^[a-zA-Z][a-zA-Z0-9]*:\/\//i"), value)
+    let httpUrlValid = isValidHttpUrl(value, isLiveMode)
+    let deepLinkValid = isValidDeepLink(value)
     if !(httpUrlValid || deepLinkValid) {
       let authConnectorDetailsErrorDict =
         errors->getDictfromDict("authentication_connector_details")

--- a/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsThreeDs.res
+++ b/src/screens/Developer/PaymentSettingsRevamped/PaymentSettingsThreeDs.res
@@ -127,7 +127,10 @@ let make = () => {
         <DesktopRow wrapperClass="pt-4 flex !flex-col gap-4" itemWrapperClass="mx-1">
           <FieldRenderer
             field={threedsConnectorList
-            ->Array.map(item => item.connector_name)
+            ->Array.map((item): SelectBox.dropdownOption => {
+              label: `${item.connector_name} - ${item.connector_label}`,
+              value: item.connector_name,
+            })
             ->authenticationConnectors}
             errorClass
             labelClass={`!${body.lg.semibold} !text-nd_gray-700`}


### PR DESCRIPTION
## What changed

- validate complete webhook, return, 3DS requestor, and 3DS app URLs instead of checking only their prefixes
- preserve the existing live-mode HTTPS requirement and HTTP localhost exception
- show authentication connector names together with their connector labels while keeping the submitted connector value unchanged
- cover malformed URLs and connector labels in the existing Payment Settings Playwright tests

## Why

The revamped Payment Settings forms accepted malformed values such as `https://` because validation only checked the URL scheme. Authentication connector options also displayed only `connector_name`, making accounts with the same connector indistinguishable.

## Impact

Merchants now receive validation errors for malformed URLs, and authentication connector choices are easier to identify without changing the business-profile payload.

## Validation

- `npm run re:build`
- focused URL validation checks against the compiled ReScript output
- `PLAYWRIGHT_BASE_URL=https://example.com playwright test playwright-tests/e2e/7-developers/PaymentSettings.spec.ts --project=chromium --list`

Closes #4654