### PR TITLE
fix: sort role permissions by sidebar order

### DIFF
--- a/playwright-tests/e2e/8-settings/users.spec.ts
+++ b/playwright-tests/e2e/8-settings/users.spec.ts
@@ -19,6 +19,42 @@ const PLAYWRIGHT_PASSWORD = process.env.PLAYWRIGHT_PASSWORD || "Playwright00#";
 const MAIL_URL = process.env.PLAYWRIGHT_MAIL_URL || "http://localhost:8025";
 const email = "playwright@test.com";
 
+const permissionGroupsInSidebarOrder = [
+  "Operations",
+  "Connectors",
+  "Analytics",
+  "Workflows",
+  "ReconOps",
+  "ReconReports",
+  "ReconTransactions",
+  "ReconExceptions",
+  "ReconRules",
+  "ReconSources",
+  "Account",
+  "MerchantDetails",
+  "Theme",
+  "Users",
+];
+
+const sortPermissionGroupsBySidebarOrder = (groups: string[]) =>
+  [...groups].sort((firstGroup, secondGroup) => {
+    const firstIndex = permissionGroupsInSidebarOrder.findIndex(
+      (group) => group.toLowerCase() === firstGroup.toLowerCase(),
+    );
+    const secondIndex = permissionGroupsInSidebarOrder.findIndex(
+      (group) => group.toLowerCase() === secondGroup.toLowerCase(),
+    );
+
+    if (firstIndex === -1 && secondIndex === -1) {
+      return firstGroup.localeCompare(secondGroup, undefined, {
+        sensitivity: "base",
+      });
+    }
+    if (firstIndex === -1) return 1;
+    if (secondIndex === -1) return -1;
+    return firstIndex - secondIndex;
+  });
+
 async function setupAndNavigate(
   page: Page,
   context: BrowserContext,
@@ -387,6 +423,11 @@ test.describe("Users - Invite Users", () => {
         )?.trim();
         if (text) renderedGroups.push(text);
       }
+
+      expect(
+        renderedGroups,
+        `${role}: permission groups should follow the dashboard sidebar order`,
+      ).toEqual(sortPermissionGroupsBySidebarOrder(renderedGroups));
 
       // Every accessible group from the API must be rendered and NOT greyed.
       for (const groupName of expectedAccessible) {

--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -48,15 +48,21 @@ module RoleAccessOverview = {
       roleInfo,
       detailedUserAccess,
     )
+    let modulesInSidebarOrder =
+      Array.concat(
+        modulesWithAccess,
+        moduleWithoutAccess,
+      )->UserUtils.sortPermissionModulesBySidebarOrder
+    let accessibleModuleNames = modulesWithAccess->Array.map(module_ => module_.parentGroup)
+
     <div className="flex flex-col gap-8">
-      {modulesWithAccess
+      {modulesInSidebarOrder
       ->Array.mapWithIndex((elem, index) => {
-        <ModuleAccessRenderer elem index />
-      })
-      ->React.array}
-      {moduleWithoutAccess
-      ->Array.mapWithIndex((elem, index) => {
-        <ModuleAccessRenderer elem index customCss="text-grey-200" />
+        <ModuleAccessRenderer
+          elem
+          index
+          customCss={accessibleModuleNames->Array.includes(elem.parentGroup) ? "" : "text-grey-200"}
+        />
       })
       ->React.array}
     </div>

--- a/src/screens/UserManagement/UserRevamp/UserUtils.res
+++ b/src/screens/UserManagement/UserRevamp/UserUtils.res
@@ -91,6 +91,49 @@ let itemToObjMapperForDetailedRoleInfo: Dict.t<
   }
 }
 
+// Mirrors the dashboard sidebar: core orchestration, recon, developers, then settings.
+// Keep legacy recon groups in the same position as the current recon permission groups.
+let permissionGroupsInSidebarOrder = [
+  "Operations",
+  "Connectors",
+  "Analytics",
+  "Workflows",
+  "ReconOps",
+  "ReconReports",
+  "ReconTransactions",
+  "ReconExceptions",
+  "ReconRules",
+  "ReconSources",
+  "Account",
+  "MerchantDetails",
+  "Theme",
+  "Users",
+]
+
+let sortPermissionModulesBySidebarOrder = (
+  modules: array<UserManagementTypes.detailedUserModuleType>,
+) =>
+  modules->Array.toSorted((firstModule, secondModule) => {
+    let getSidebarIndex = moduleName =>
+      permissionGroupsInSidebarOrder->Array.findIndex(groupName =>
+        groupName->String.toLowerCase === moduleName->String.toLowerCase
+      )
+
+    let firstIndex = firstModule.parentGroup->getSidebarIndex
+    let secondIndex = secondModule.parentGroup->getSidebarIndex
+
+    switch (firstIndex, secondIndex) {
+    | (-1, -1) =>
+      String.compare(
+        firstModule.parentGroup->String.toLowerCase,
+        secondModule.parentGroup->String.toLowerCase,
+      )
+    | (-1, _) => 1.
+    | (_, -1) => -1.
+    | (_, _) => Float.fromInt(firstIndex - secondIndex)
+    }
+  })
+
 let modulesWithUserAccess = (
   roleInfo: array<UserManagementTypes.userModuleType>,
   userAccessGroup: array<UserManagementTypes.detailedUserModuleType>,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Add a deterministic permission-group order that follows the dashboard sidebar: Operations, Connectors, Analytics, Workflows, Recon, Developers, and Settings.
- Support both the legacy Recon permission groups and the current Recon Engine groups.
- Sort the complete role permission list before rendering, while preserving the greyed-out styling for groups the selected role cannot access.
- Place unknown future permission groups alphabetically after the known sidebar groups.
- Extend the existing user invitation Playwright coverage to assert the rendered permission order for every available role and entity scope.

## Motivation and Context

The invite-user page rendered permission groups in the order returned by the role-info API, then split them into accessible and inaccessible sections. This made the ordering backend-dependent and inconsistent with the dashboard navigation.

Fixes #2154

## How did you test it?

- Ran `npm run re:build` successfully across all 3,940 ReScript modules.
- Ran Prettier validation for `playwright-tests/e2e/8-settings/users.spec.ts`.
- Ran Playwright test discovery for the users spec; all 21 tests were parsed and listed successfully.
- Added an ordering assertion to the existing permission-groups test for merchant, profile, and organization roles.
- Ran `git diff --check`.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible