### PR TITLE
refactor: add optional variant, size and fitContent props to Tabs wrapper

### DIFF
--- a/src/components/Tabs.res
+++ b/src/components/Tabs.res
@@ -6,7 +6,15 @@ type tab = {
 }
 
 @react.component
-let make = (~tabs, ~initialIndex=?, ~onTitleClick=?, ~disabledTab=[]) => {
+let make = (
+  ~tabs,
+  ~initialIndex=?,
+  ~onTitleClick=?,
+  ~disabledTab=[],
+  ~variant=TabsBinding.Underline,
+  ~size=TabsBinding.Lg,
+  ~fitContent=?,
+) => {
   let initialIndex = initialIndex->Option.getOr(0)
   let (selectedValue, setSelectedValue) = React.useState(() => initialIndex->Int.toString)
 
@@ -41,11 +49,7 @@ let make = (~tabs, ~initialIndex=?, ~onTitleClick=?, ~disabledTab=[]) => {
 
   <ErrorBoundary>
     <TabsBinding
-      value={selectedValue}
-      onValueChange={handleValueChange}
-      variant=TabsBinding.Underline
-      size=TabsBinding.Lg
-      items
+      value={selectedValue} onValueChange={handleValueChange} variant size ?fitContent items
     />
   </ErrorBoundary>
 }

--- a/src/components/Tabs.resi
+++ b/src/components/Tabs.resi
@@ -10,4 +10,7 @@ let make: (
   ~initialIndex: int=?,
   ~onTitleClick: int => unit=?,
   ~disabledTab: array<string>=?,
+  ~variant: TabsBinding.tabsVariant=?,
+  ~size: TabsBinding.tabsSize=?,
+  ~fitContent: bool=?,
 ) => React.element


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The shared `Tabs` wrapper (`src/components/Tabs.res`) hard-codes `variant=Underline` and `size=Lg` when it renders the underlying `TabsBinding`. Any screen that needs a different tab style therefore cannot use the wrapper and has to drop down to the low-level `TabsBinding` directly, re-implementing the selection and state plumbing the wrapper already provides.

This PR adds optional `variant`, `size` and `fitContent` props to the wrapper and forwards them to `TabsBinding`. The props default to the current values (`variant=Underline`, `size=Lg`), so every existing caller keeps its exact behaviour and no call site needs to change. Callers that need a different look (for example a boxed control toggle) can now pass `variant=Boxed size=Md fitContent=true` through the wrapper instead of using `TabsBinding` directly.

## Motivation and Context

Raised as a standalone change so it can be reviewed and merged independently, per review feedback on https://github.com/juspay/hyperswitch-control-center/pull/5106. The Normal/Advanced payments-list source toggle in that PR needs the boxed tab style, which the wrapper could not express without this change.

Closes #5176

## Dependencies

- Follow-up consumer PR: https://github.com/juspay/hyperswitch-control-center/pull/5106

## How did you test it?

Verified the wrapper compiles and that existing `<Tabs>` callers (ReconEngine screens and others) continue to build unchanged, since the new props default to the previously hard-coded values.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes
