### PR TITLE
fix: increase recon engine file upload size limit to 25MB

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
@@ -35,7 +35,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
       setSelectedFile(_ => None)
       clearFileInput()
     } else if fileSize > maxFileSizeBytes {
-      showToast(~message="File size should not exceed 8 MB", ~toastType=ToastError)
+      showToast(~message="File size should not exceed 25 MB", ~toastType=ToastError)
       setSelectedFile(_ => None)
       clearFileInput()
     } else {
@@ -177,7 +177,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
                 {"Choose a file or drag & drop it here"->React.string}
               </div>
               <div className={`${body.md.medium} text-nd_gray-500`}>
-                {".csv,.ext,.xlsx,.txt only | Max size 8 MB"->React.string}
+                {".csv,.ext,.xlsx,.txt only | Max size 25 MB"->React.string}
               </div>
             </div>
             <div

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesUtils.res
@@ -4,7 +4,7 @@ open ReconEngineUtils
 
 let bytesPerKilobyte = 1000
 let bytesPerMegabyte = bytesPerKilobyte * 1000
-let maxFileSizeBytes = 8 * bytesPerMegabyte
+let maxFileSizeBytes = 25 * bytesPerMegabyte
 
 let formatFileSize = (sizeInBytes: int) => {
   let size = sizeInBytes->Int.toFloat


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Increased the recon engine data source file upload size limit from 8MB to 25MB.

## Motivation and Context

8MB was too restrictive for typical reconciliation files. Fixes #5182.

## How did you test it?

Tested manually by uploading files close to and above the new 25MB limit and confirming the toast/hint text and validation behave correctly.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible