### PR TITLE
chore(ci): rename ready-for-review label to required-checks-passed

### DIFF
--- a/.github/workflows/pr-required-checks-passed-label.yml
+++ b/.github/workflows/pr-required-checks-passed-label.yml
@@ -1,4 +1,4 @@
-name: PR Ready for Review Label
+name: PR Required CI Checks Passed Label
 
 on:
   workflow_run:
@@ -26,12 +26,12 @@ on:
       - converted_to_draft
 
 concurrency:
-  group: pr-ready-label-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_sha }}
+  group: pr-required-ci-checks-label-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
-  pr_ready_label_evaluation:
-    name: Evaluate required checks and toggle label
+  pr_ci_checks_label_evaluation:
+    name: Evaluate required CI checks and toggle label
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -78,7 +78,7 @@ jobs:
           )
 
           repo="${{ github.event.repository.full_name }}"
-          label="R-ready-for-review"
+          label="CI-required-checks-passed"
 
           pr_json="$(gh api "repos/${repo}/pulls/${PR_NUMBER}")"
           pr_state="$(jq -r '.state' <<<"$pr_json")"


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Renames the automated PR label from R-ready-for-review to CI-required-checks-passed.

  The associated workflow has also been renamed from pr-ready-for-review-label.yml to pr-required-checks-passed-label.yml, along with its workflow name, job name,  and concurrency group.

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

The previous R-ready-for-review label combined two different signals:

  - Whether the required CI checks passed.
  - Whether the developer considers the PR ready for review.

  Passing CI checks does not necessarily mean the author has finished working on the PR. The new label clearly represents only the automated CI state.

  A PR can be considered ready for review when both labels are present:

  - CI-required-checks-passed — automatically managed by CI.
  - S-waiting-on-review — manually added by the developer.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

1. Run workflow validation:

     actionlint .github/workflows/pr-required-checks-passed-label.yml

  2. Open or update a non-draft PR and wait for all configured required checks to pass.
  3. Verify that CI-required-checks-passed is automatically added.
  4. Push a commit that causes a required check to become pending or fail.
  5. Verify that CI-required-checks-passed is removed.
  6. Convert the PR to a draft and verify that the label is removed.
  7. Mark the PR ready for review again and verify that the label is restored after all required checks pass.
  
## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [ ] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [ ] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
