### PR TITLE
test: support Playwright E2E and visual tests on remote environments

### DIFF
--- a/playwright-tests/e2e/2-homepage/homepage.spec.ts
+++ b/playwright-tests/e2e/2-homepage/homepage.spec.ts
@@ -12,6 +12,7 @@ import {
   createDummyConnectorAPI,
   createBusinessProfileAPI,
   createMerchantAPI,
+  switchMerchantAPI,
   createStripeGooglePayConnectorAPI,
 } from "../../support/commands";
 import UsersPage from "../../support/pages/settings/UsersPage";
@@ -905,11 +906,18 @@ test.describe("Organization Chart Tree", () => {
       context.request,
     );
     const newMerchantId = newMerchant.merchant_id;
+    const newMerchantToken = await switchMerchantAPI(
+      token,
+      newMerchantId,
+      context.request,
+    );
 
     await createBusinessProfileAPI(
       newMerchantId,
       "new-test-profile",
       context.request,
+      undefined,
+      newMerchantToken,
     );
 
     await orgChart.visit();
@@ -1026,11 +1034,18 @@ test.describe("Organization Chart Tree", () => {
       context.request,
     );
     const newMerchantId = newMerchant.merchant_id;
+    const newMerchantToken = await switchMerchantAPI(
+      token,
+      newMerchantId,
+      context.request,
+    );
 
     await createBusinessProfileAPI(
       newMerchantId,
       "new-test-profile",
       context.request,
+      undefined,
+      newMerchantToken,
     );
 
     await orgChart.visit();

--- a/playwright-tests/e2e/3-operations/customers.spec.ts
+++ b/playwright-tests/e2e/3-operations/customers.spec.ts
@@ -152,8 +152,19 @@ test.describe("Customers page", () => {
     const merchantId = await homePage.merchantID.nth(0).textContent();
     if (!merchantId) return;
 
-    await createDummyConnectorAPI(merchantId, "stripe_test_1", context.request);
-    await createPaymentAPI(merchantId, context.request);
+    await createDummyConnectorAPI(
+      merchantId,
+      "stripe_test_1",
+      context.request,
+      page,
+    );
+    await createPaymentAPI(
+      merchantId,
+      context.request,
+      undefined,
+      undefined,
+      page,
+    );
 
     await homePage.operations.click();
     await homePage.customers.click();
@@ -203,8 +214,19 @@ test.describe("Customers page", () => {
     const merchantId = await homePage.merchantID.nth(0).textContent();
     if (!merchantId) return;
 
-    await createDummyConnectorAPI(merchantId, "stripe_test_1", context.request);
-    await createPaymentAPI(merchantId, context.request);
+    await createDummyConnectorAPI(
+      merchantId,
+      "stripe_test_1",
+      context.request,
+      page,
+    );
+    await createPaymentAPI(
+      merchantId,
+      context.request,
+      undefined,
+      undefined,
+      page,
+    );
 
     await homePage.operations.click();
     await homePage.customers.click();
@@ -260,9 +282,25 @@ test.describe("Customers page", () => {
     const merchantId = await homePage.merchantID.nth(0).textContent();
     if (!merchantId) return;
 
-    await createDummyConnectorAPI(merchantId, "stripe_test_1", context.request);
-    await createPaymentAPI(merchantId, context.request);
-    await createCustomerAPI(merchantId, "test_customer2", context.request);
+    await createDummyConnectorAPI(
+      merchantId,
+      "stripe_test_1",
+      context.request,
+      page,
+    );
+    await createPaymentAPI(
+      merchantId,
+      context.request,
+      undefined,
+      undefined,
+      page,
+    );
+    await createCustomerAPI(
+      merchantId,
+      "test_customer2",
+      context.request,
+      page,
+    );
 
     await homePage.operations.click();
     await homePage.customers.click();
@@ -293,7 +331,12 @@ test.describe("Customers page", () => {
     const merchantId = await homePage.merchantID.nth(0).textContent();
     if (!merchantId) return;
 
-    await createCustomerAPI(merchantId, "test_customer2", context.request);
+    await createCustomerAPI(
+      merchantId,
+      "test_customer2",
+      context.request,
+      page,
+    );
 
     await homePage.operations.click();
     await homePage.customers.click();
@@ -329,7 +372,12 @@ test.describe("Customers page", () => {
     const merchantId = await homePage.merchantID.nth(0).textContent();
     if (!merchantId) return;
 
-    await createCustomerAPI(merchantId, "test_customer2", context.request);
+    await createCustomerAPI(
+      merchantId,
+      "test_customer2",
+      context.request,
+      page,
+    );
 
     await homePage.operations.click();
     await homePage.customers.click();
@@ -465,7 +513,7 @@ test.describe("Customers page", () => {
     );
 
     for (const customerId of customerIds) {
-      await createCustomerAPI(merchantId, customerId, context.request);
+      await createCustomerAPI(merchantId, customerId, context.request, page);
     }
 
     await homePage.operations.click();

--- a/playwright-tests/e2e/3-operations/disputeOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/disputeOperations.spec.ts
@@ -356,6 +356,18 @@ test.describe("Disputes List page", () => {
       const homePage = new HomePage(page);
       const paymentOperations = new PaymentOperations(page);
 
+      await page.route("**/dashboard/config/feature?domain=", async (route) => {
+        const response = await route.fetch();
+        const json = await response.json();
+        json.features = {
+          ...json.features,
+          generate_report: false,
+          email: false,
+        };
+        await route.fulfill({ response, json });
+      });
+      await page.reload();
+
       await mockDisputesList(page, [sampleDispute()]);
       await goToDisputes(page, homePage);
 
@@ -591,6 +603,17 @@ test.describe("Dispute detail page", () => {
         connector: "checkout",
         dispute_status: "dispute_opened",
       });
+
+      await page.route("**/dashboard/config/feature?domain=", async (route) => {
+        const response = await route.fetch();
+        const json = await response.json();
+        json.features = {
+          ...json.features,
+          dispute_evidence_upload: false,
+        };
+        await route.fulfill({ response, json });
+      });
+      await page.reload();
 
       // Flag defaults to false in local config — no mock needed.
       await openDisputeDetail(page, homePage, disputesOperations, dispute);

--- a/playwright-tests/e2e/3-operations/paymentOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/paymentOperations.spec.ts
@@ -23,6 +23,19 @@ test.describe("Payment Operations", () => {
     email = generateUniqueEmail();
     await signupUser(email, PLAYWRIGHT_PASSWORD);
     await loginUI(page, email, PLAYWRIGHT_PASSWORD);
+
+    await page.route("**/dashboard/config/feature?domain=", async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      json.features = {
+        ...json.features,
+        dev_opensearch: false,
+        dev_clickhouse_aggregate: false,
+        dev_sort_enabled: true,
+      };
+      await route.fulfill({ response, json });
+    });
+    await page.reload();
   });
 
   test.describe("Verify Components of Payment Operations", () => {
@@ -89,8 +102,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        const paymentData = await createPaymentAPI(merchantId, context.request);
+        const paymentData = await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
 
         await homePage.operations.click();
         await homePage.paymentOperations.click();
@@ -162,7 +182,7 @@ test.describe("Payment Operations", () => {
         await expect(paymentOperations.orderCell(1, 8)).toContainText(
           paymentData.payment_method_type,
         );
-        await expect(paymentOperations.orderCell(1, 9)).toContainText("N/A");
+        await expect(paymentOperations.orderCell(1, 9)).toContainText(/^(Visa|N\/A)$/);
         await expect(paymentOperations.orderCell(1, 10)).toContainText(
           paymentData.connector_transaction_id,
         );
@@ -246,8 +266,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -325,8 +352,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -359,8 +393,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -426,8 +467,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -469,6 +517,7 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
         const amounts = [10000, 20000, 30000];
         for (const amount of amounts) {
@@ -476,20 +525,13 @@ test.describe("Payment Operations", () => {
             merchantId,
             context.request,
             amount,
+            undefined,
+            page,
           );
           payments.push({ payment_id: payment.payment_id, amount });
           await page.waitForTimeout(1000);
         }
       }
-
-      await page.route(/\/config\/feature/, async (route) => {
-        const response = await route.fetch();
-        const json = await response.json();
-        json.features = { ...json.features, dev_sort_enabled: true };
-        await route.fulfill({ response, json });
-      });
-      await page.reload();
-      await page.waitForLoadState("networkidle");
 
       await homePage.operations.click();
       await homePage.paymentOperations.click();
@@ -668,9 +710,16 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
         for (let i = 0; i < 21; i++) {
-          await createPaymentAPI(merchantId, context.request).catch(() => { });
+          await createPaymentAPI(
+            merchantId,
+            context.request,
+            undefined,
+            undefined,
+            page,
+          ).catch(() => { });
         }
       }
 
@@ -709,9 +758,22 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -757,8 +819,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -838,6 +907,7 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
       }
 
@@ -877,6 +947,7 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
       }
 
@@ -932,8 +1003,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1185,8 +1263,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1225,8 +1310,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await page.route("**/dashboard/config/feature?domain=", async (route) => {
@@ -1266,8 +1358,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1289,8 +1388,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await page.route("**/dashboard/config/feature?domain=", async (route) => {
@@ -1327,8 +1433,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await page.route("**/dashboard/config/feature?domain=", async (route) => {
@@ -1374,8 +1487,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await page.route("**/dashboard/config/feature?domain=", async (route) => {
@@ -1425,8 +1545,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        const paymentData = await createPaymentAPI(merchantId, context.request);
+        const paymentData = await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
 
         await homePage.operations.click();
         await homePage.paymentOperations.click();
@@ -1461,8 +1588,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1663,8 +1797,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1810,8 +1951,9 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request, 12345, false);
+        await createPaymentAPI(merchantId, context.request, 12345, false, page);
       }
 
       await homePage.operations.click();
@@ -1835,8 +1977,9 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request, 12345, false);
+        await createPaymentAPI(merchantId, context.request, 12345, false, page);
       }
 
       await homePage.operations.click();
@@ -1864,8 +2007,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();
@@ -1906,8 +2056,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -1966,8 +2123,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -1994,8 +2158,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -2022,8 +2193,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -2056,8 +2234,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -2090,8 +2275,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await openRefundModal(page, homePage, paymentOperations);
@@ -2117,8 +2309,9 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request, 12345, false);
+        await createPaymentAPI(merchantId, context.request, 12345, false, page);
       }
 
       await homePage.operations.click();
@@ -2142,10 +2335,12 @@ test.describe("Payment Operations", () => {
       merchantId: string,
       request: Parameters<typeof createDummyConnectorAPI>[2],
     ) => {
-      await createDummyConnectorAPI(merchantId, "stripe_test_1", request);
+      await createDummyConnectorAPI(merchantId, "stripe_test_1", request, page);
       const payment = await createRequiresCapturePaymentAPI(
         merchantId,
         request,
+        undefined,
+        page,
       );
       await mockPaymentRequiresCapture(page, payment.payment_id);
       return payment;
@@ -2205,8 +2400,15 @@ test.describe("Payment Operations", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
-        await createPaymentAPI(merchantId, context.request);
+        await createPaymentAPI(
+          merchantId,
+          context.request,
+          undefined,
+          undefined,
+          page,
+        );
       }
 
       await homePage.operations.click();

--- a/playwright-tests/e2e/3-operations/payoutsOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/payoutsOperations.spec.ts
@@ -14,6 +14,7 @@ const PLAYWRIGHT_PASSWORD = process.env.PLAYWRIGHT_PASSWORD || "Playwright00#";
 let email: string;
 
 const setupPayout = async (
+  page: Page,
   homePage: HomePage,
   request: Parameters<typeof createPayoutConnectorAPI>[2],
 ) => {
@@ -21,8 +22,12 @@ const setupPayout = async (
   if (!merchantId) {
     throw new Error("Merchant ID not found");
   }
-  await createPayoutConnectorAPI(merchantId, "adyen_test_1", request);
-  const payout = (await createPayoutAPI(merchantId, request)) as unknown as {
+  await createPayoutConnectorAPI(merchantId, "adyen_test_1", request, page);
+  const payout = (await createPayoutAPI(
+    merchantId,
+    request,
+    page,
+  )) as unknown as {
     payout_id: string;
     amount: number;
     currency: string;
@@ -74,7 +79,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        const { payout } = await setupPayout(homePage, context.request);
+        const { payout } = await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -95,7 +100,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        const { payout } = await setupPayout(homePage, context.request);
+        const { payout } = await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -120,7 +125,7 @@ test.describe("Payouts Operations", () => {
         context,
       }) => {
         const homePage = new HomePage(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -147,7 +152,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -213,7 +218,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
         await payoutOperations.columnButton.click();
@@ -271,7 +276,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -362,7 +367,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -384,7 +389,7 @@ test.describe("Payouts Operations", () => {
       test("should apply a Status filter", async ({ page, context }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -405,7 +410,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -424,7 +429,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -577,7 +582,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
         await mockTwoPayoutList(page);
 
         await goToPayouts(page, homePage);
@@ -626,7 +631,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await page.route(
           "**/dashboard/config/feature?domain=",
@@ -663,7 +668,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
 
@@ -679,7 +684,7 @@ test.describe("Payouts Operations", () => {
     }) => {
       const homePage = new HomePage(page);
       const payoutOperations = new PayoutOperations(page);
-      const { payout } = await setupPayout(homePage, context.request);
+      const { payout } = await setupPayout(page, homePage, context.request);
 
       await goToPayouts(page, homePage);
       await payoutOperations.payoutCell(1, 1).click();
@@ -832,7 +837,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         // audit_trail defaults to true locally; force it on explicitly so the
         // test does not depend on env state.
@@ -859,7 +864,7 @@ test.describe("Payouts Operations", () => {
       }) => {
         const homePage = new HomePage(page);
         const payoutOperations = new PayoutOperations(page);
-        await setupPayout(homePage, context.request);
+        await setupPayout(page, homePage, context.request);
 
         await page.route(
           "**/dashboard/config/feature?domain=",

--- a/playwright-tests/e2e/3-operations/refundOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/refundOperations.spec.ts
@@ -17,6 +17,7 @@ const refundColumnSize = 12;
 let email: string;
 
 const setupRefund = async (
+  page: Page,
   homePage: HomePage,
   request: Parameters<typeof createDummyConnectorAPI>[2],
 ) => {
@@ -24,9 +25,22 @@ const setupRefund = async (
   if (!merchantId) {
     throw new Error("Merchant ID not found");
   }
-  await createDummyConnectorAPI(merchantId, "stripe_test_1", request);
-  const payment = await createPaymentAPI(merchantId, request);
-  const refund = await createRefundAPI(merchantId, payment.payment_id, request);
+  await createDummyConnectorAPI(merchantId, "stripe_test_1", request, page);
+  const payment = await createPaymentAPI(
+    merchantId,
+    request,
+    undefined,
+    undefined,
+    page,
+  );
+  const refund = await createRefundAPI(
+    merchantId,
+    payment.payment_id,
+    request,
+    undefined,
+    undefined,
+    page,
+  );
   return { merchantId, payment, refund };
 };
 
@@ -55,7 +69,7 @@ test.describe("Refunds Operations", () => {
       const homePage = new HomePage(page);
 
       const refundOperations = new RefundOperations(page);
-      await setupRefund(homePage, context.request);
+      await setupRefund(page, homePage, context.request);
 
       await goToRefunds(page, homePage);
 
@@ -115,6 +129,7 @@ test.describe("Refunds Operations", () => {
 
         const refundOperations = new RefundOperations(page);
         const { payment, refund } = await setupRefund(
+          page,
           homePage,
           context.request,
         );
@@ -145,7 +160,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -164,7 +179,7 @@ test.describe("Refunds Operations", () => {
         context,
       }) => {
         const homePage = new HomePage(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -192,7 +207,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -244,7 +259,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const paymentOperations = new PaymentOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -267,7 +282,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -289,7 +304,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -335,7 +350,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        const { refund } = await setupRefund(homePage, context.request);
+        const { refund } = await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -358,7 +373,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await page.route(/\/config\/feature/, async (route) => {
           const response = await route.fetch();
@@ -389,7 +404,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
 
@@ -406,7 +421,11 @@ test.describe("Refunds Operations", () => {
       const homePage = new HomePage(page);
 
       const refundOperations = new RefundOperations(page);
-      const { payment, refund } = await setupRefund(homePage, context.request);
+      const { payment, refund } = await setupRefund(
+        page,
+        homePage,
+        context.request,
+      );
 
       await goToRefunds(page, homePage);
       await refundOperations.refundCell(1, 1).click();
@@ -465,7 +484,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        const { refund } = await setupRefund(homePage, context.request);
+        const { refund } = await setupRefund(page, homePage, context.request);
 
         await page.route(`**/refunds/${refund.refund_id}`, async (route) => {
           const response = await route.fetch();
@@ -487,7 +506,7 @@ test.describe("Refunds Operations", () => {
         const homePage = new HomePage(page);
 
         const refundOperations = new RefundOperations(page);
-        await setupRefund(homePage, context.request);
+        await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
         await refundOperations.refundCell(1, 1).click();
@@ -506,7 +525,7 @@ test.describe("Refunds Operations", () => {
       const homePage = new HomePage(page);
 
       const refundOperations = new RefundOperations(page);
-      const { refund } = await setupRefund(homePage, context.request);
+      const { refund } = await setupRefund(page, homePage, context.request);
 
       await page.route(`**/refunds/${refund.refund_id}`, async (route) => {
         const response = await route.fetch();

--- a/playwright-tests/e2e/4-connectors/frmConnector.spec.ts
+++ b/playwright-tests/e2e/4-connectors/frmConnector.spec.ts
@@ -59,6 +59,7 @@ test.describe("Live FRM Connectors", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
   });

--- a/playwright-tests/e2e/4-connectors/payinConnector.spec.ts
+++ b/playwright-tests/e2e/4-connectors/payinConnector.spec.ts
@@ -295,6 +295,7 @@ test.describe("Payin Connector tests", () => {
       merchantId,
       "secondary_profile",
       context.request,
+      page,
     );
 
     // Pin the default connector to the active profile explicitly. Relying on

--- a/playwright-tests/e2e/4-connectors/payinConnector.spec.ts
+++ b/playwright-tests/e2e/4-connectors/payinConnector.spec.ts
@@ -15,6 +15,8 @@ import {
   createAPIKey,
   createStripeConnectorAPIwithAPIKey,
   getDefaultProfileId,
+  getJwtFromLocalStorage,
+  switchProfileAPI,
   generateCerts,
 } from "../../support/commands";
 import { connectorConfig } from "../../support/fixtures/payinConnectorConfig";
@@ -78,7 +80,13 @@ async function setupConfiguredStripeConnector(
   label: string = "stripe_configured",
 ): Promise<string> {
   const { merchantId } = await ompLineage(page);
-  await createStripeConnectorAPI(merchantId, label, context.request);
+  await createStripeConnectorAPI(
+    merchantId,
+    label,
+    context.request,
+    undefined,
+    page,
+  );
   await page.reload();
   await page.waitForLoadState("networkidle");
   return label;
@@ -199,7 +207,13 @@ test.describe("Payin Connector tests", () => {
   }) => {
     const stripeLabel = "stripe_default";
     const { merchantId } = await ompLineage(page);
-    await createStripeConnectorAPI(merchantId, stripeLabel, context.request);
+    await createStripeConnectorAPI(
+      merchantId,
+      stripeLabel,
+      context.request,
+      undefined,
+      page,
+    );
     await gotoConnectorList(page);
 
     const connectorRow = page.locator("tr", { hasText: stripeLabel }).first();
@@ -229,7 +243,13 @@ test.describe("Payin Connector tests", () => {
   }) => {
     const stripeLabel = "stripe_default";
     const { merchantId } = await ompLineage(page);
-    await createStripeConnectorAPI(merchantId, stripeLabel, context.request);
+    await createStripeConnectorAPI(
+      merchantId,
+      stripeLabel,
+      context.request,
+      undefined,
+      page,
+    );
     await gotoConnectorList(page);
 
     const connectorRow = page.locator("tr", { hasText: stripeLabel }).first();
@@ -297,6 +317,12 @@ test.describe("Payin Connector tests", () => {
       context.request,
       page,
     );
+    const defaultProfileToken = await getJwtFromLocalStorage(page);
+    const secondaryProfileToken = await switchProfileAPI(
+      defaultProfileToken,
+      secondaryProfileId,
+      context.request,
+    );
 
     // Pin the default connector to the active profile explicitly. Relying on
     // getDefaultProfileId() (profiles[0]) is unsafe once a second profile
@@ -307,12 +333,15 @@ test.describe("Payin Connector tests", () => {
       defaultLabel,
       context.request,
       defaultProfileId,
+      page,
     );
     await createStripeConnectorAPI(
       merchantId,
       secondaryLabel,
       context.request,
       secondaryProfileId,
+      page,
+      secondaryProfileToken,
     );
 
     await gotoConnectorList(page);
@@ -819,8 +848,12 @@ test.describe("Payin Connector tests", () => {
   }) => {
     test.setTimeout(CONNECTOR_SETUP_TIMEOUT);
     const { merchantId } = await ompLineage(page);
-    const apiKey = await createAPIKey(merchantId, "", context.request);
-    const profileId = await getDefaultProfileId(merchantId, context.request);
+    const apiKey = await createAPIKey(merchantId, "", context.request, page);
+    const profileId = await getDefaultProfileId(
+      merchantId,
+      context.request,
+      page,
+    );
 
     const labels = Array.from(
       { length: 21 },
@@ -833,6 +866,7 @@ test.describe("Payin Connector tests", () => {
         apiKey,
         context.request,
         profileId,
+        page,
       );
       await page.waitForTimeout(200);
     }
@@ -856,7 +890,7 @@ test.describe("Payin Connector tests", () => {
     await page.getByText(createdLabel).first().click();
 
     await expect(page.getByText("Integration statusACTIVE")).toBeVisible();
-    await expect(page.getByText("Webhook Endpointhttp://")).toBeVisible();
+    await expect(page.getByText("Webhook Endpointhttp")).toBeVisible();
     await expect(page.getByText("Profiledefault -")).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Secret Key" }),
@@ -1243,13 +1277,13 @@ test.describe("All Payin Connectors", () => {
       await expect(
         page.getByTestId(
           connector.fields.overrides["Enter Connector label"] ||
-            connector.label,
+          connector.label,
         ),
       ).toBeVisible();
       await page
         .getByTestId(
           connector.fields.overrides["Enter Connector label"] ||
-            connector.label,
+          connector.label,
         )
         .click();
     });

--- a/playwright-tests/e2e/4-connectors/pmAuthProcessor.spec.ts
+++ b/playwright-tests/e2e/4-connectors/pmAuthProcessor.spec.ts
@@ -21,7 +21,7 @@ async function signupAndLogin(page: Page, context: BrowserContext) {
   await loginUI(page, email, PLAYWRIGHT_PASSWORD);
   const merchantId = await homePage.merchantID.nth(0).textContent();
   if (merchantId) {
-    await createDummyConnectorAPI(merchantId, "stripe_test_1", context.request);
+    await createDummyConnectorAPI(merchantId, "stripe_test_1", context.request, page);
   }
 }
 
@@ -71,6 +71,7 @@ test.describe("Live PM Auth Processors", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page
       );
     }
   });

--- a/playwright-tests/e2e/6-workflow/PaymentRouting.spec.ts
+++ b/playwright-tests/e2e/6-workflow/PaymentRouting.spec.ts
@@ -51,6 +51,7 @@ test.describe("Volume based routing", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -109,6 +110,7 @@ test.describe("Volume based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -156,6 +158,7 @@ test.describe("Volume based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -201,6 +204,7 @@ test.describe("Volume based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -231,6 +235,7 @@ test.describe("Volume based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -269,6 +274,7 @@ test.describe("Rule based routing", () => {
         merchantId,
         "stripe_operator_test",
         context.request,
+        page,
       );
     }
     await homePage.workflow.click();
@@ -412,6 +418,7 @@ test.describe("Payment default fallback", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -439,16 +446,19 @@ test.describe("Payment default fallback", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
       await createDummyConnectorAPI(
         merchantId,
         "stripe_test_2",
         context.request,
+        page,
       );
       await createDummyConnectorAPI(
         merchantId,
         "stripe_test_3",
         context.request,
+        page,
       );
     }
 
@@ -524,6 +534,7 @@ test.describe("Routing list - Configuration History", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -561,6 +572,7 @@ test.describe("Routing list - Configuration History", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -670,6 +682,7 @@ test.describe("Routing list - Configuration History", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -798,6 +811,7 @@ test.describe("Routing list - Configuration History", () => {
         merchantId,
         "stripe_test_volume_b",
         context.request,
+        page,
       );
     }
 
@@ -853,6 +867,7 @@ test.describe("Routing list - Configuration History", () => {
         merchantId,
         "stripe_routing_edit",
         context.request,
+        page,
       );
     }
 
@@ -929,16 +944,19 @@ test.describe("Advanced rule connector selection modes", () => {
         merchantId,
         "stripe_rule_test_a",
         context.request,
+        page,
       );
       await createDummyConnectorAPI(
         merchantId,
         "stripe_rule_test_b",
         context.request,
+        page,
       );
       await createDummyConnectorAPI(
         merchantId,
         "stripe_rule_test_c",
         context.request,
+        page,
       );
     }
 
@@ -1270,6 +1288,7 @@ test.describe("Auth rate based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -1303,6 +1322,7 @@ test.describe("Auth rate based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 
@@ -1343,6 +1363,7 @@ test.describe("Auth rate based routing", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
     }
 

--- a/playwright-tests/e2e/6-workflow/PayoutRouting.spec.ts
+++ b/playwright-tests/e2e/6-workflow/PayoutRouting.spec.ts
@@ -59,6 +59,7 @@ test.describe("Volume based payout routing", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -109,6 +110,7 @@ test.describe("Volume based payout routing", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -153,6 +155,7 @@ test.describe("Volume based payout routing", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -198,6 +201,7 @@ test.describe("Volume based payout routing", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -228,6 +232,7 @@ test.describe("Volume based payout routing", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -266,6 +271,7 @@ test.describe("Rule based payout routing", () => {
         merchantId,
         "adyen_payout_operator_test",
         context.request,
+        page,
       );
     }
     await homePage.workflow.click();
@@ -406,6 +412,7 @@ test.describe("Payout default fallback", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -435,16 +442,19 @@ test.describe("Payout default fallback", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
       await createPayoutConnectorAPI(
         merchantId,
         "adyen_payout_2",
         context.request,
+        page,
       );
       await createPayoutConnectorAPI(
         merchantId,
         "adyen_payout_3",
         context.request,
+        page,
       );
     }
 
@@ -519,6 +529,7 @@ test.describe("Payout Routing list - Configuration History", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -556,6 +567,7 @@ test.describe("Payout Routing list - Configuration History", () => {
         merchantId,
         connectorLabel,
         context.request,
+        page,
       );
     }
 
@@ -630,6 +642,7 @@ test.describe("Payout Routing list - Configuration History", () => {
         merchantId,
         "adyen_payout_1",
         context.request,
+        page,
       );
     }
 
@@ -771,6 +784,7 @@ test.describe("Payout Routing list - Configuration History", () => {
         merchantId,
         "adyen_payout_volume_b",
         context.request,
+        page,
       );
     }
 
@@ -826,6 +840,7 @@ test.describe("Payout Routing list - Configuration History", () => {
         merchantId,
         "adyen_payout_routing_edit",
         context.request,
+        page,
       );
     }
 
@@ -902,16 +917,19 @@ test.describe("Advanced payout rule connector selection modes", () => {
         merchantId,
         "adyen_payout_rule_a",
         context.request,
+        page,
       );
       await createPayoutConnectorAPI(
         merchantId,
         "adyen_payout_rule_b",
         context.request,
+        page,
       );
       await createPayoutConnectorAPI(
         merchantId,
         "adyen_payout_rule_c",
         context.request,
+        page,
       );
     }
 

--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -371,6 +371,7 @@ test.describe("Payment Settings", () => {
           merchantId,
           connectorLabel,
           context.request,
+          page,
         );
       }
 
@@ -470,6 +471,7 @@ test.describe("Payment Settings", () => {
           merchantId,
           "threeds_tab_connector",
           context.request,
+          page,
         );
       }
       await page.reload();
@@ -954,6 +956,7 @@ test.describe("Payment Settings", () => {
 
       await homePage.developer.click();
       await homePage.paymentSettings.click();
+      await expect(paymentSettings.pageHeader).toBeVisible();
       await paymentSettings.paymentLinkTab.click();
     });
 

--- a/playwright-tests/e2e/8-settings/pmtConfiguration.spec.ts
+++ b/playwright-tests/e2e/8-settings/pmtConfiguration.spec.ts
@@ -50,7 +50,12 @@ async function loginWithConnectorAndVisit(
   if (!merchantId) {
     throw new Error("Could not read merchant ID after login");
   }
-  await createDummyConnectorAPI(merchantId, "stripe_test_pmt", apiContext);
+  await createDummyConnectorAPI(
+    merchantId,
+    "stripe_test_pmt",
+    apiContext,
+    page,
+  );
 
   const configurePMTPage = new ConfigurePMTPage(page);
   await configurePMTPage.visit();

--- a/playwright-tests/support/commands.ts
+++ b/playwright-tests/support/commands.ts
@@ -383,17 +383,53 @@ export async function switchMerchantAPI(
   return switchedToken;
 }
 
+export async function switchProfileAPI(
+  token: string,
+  profileId: string,
+  context?: APIRequestContext,
+): Promise<string> {
+  const ctx = context ?? (await request.newContext());
+  const response = await ctx.post(`${API_URL}/user/switch/profile`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    data: {
+      profile_id: profileId,
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`switchProfileAPI failed (${response.status()}): ${body}`);
+  }
+
+  const body = await response.json();
+  const switchedToken = body.token as string | undefined;
+  if (!switchedToken) {
+    throw new Error(
+      "switchProfileAPI failed: response did not include a token",
+    );
+  }
+
+  return switchedToken;
+}
+
 export async function createStripeConnectorAPI(
   merchantId: string,
   connectorLabel: string,
   context?: APIRequestContext,
   profileId?: string,
+  page?: Page,
+  token = "",
 ): Promise<void> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const authorizationToken = token || jwt;
+  const apiKey = await createAPIKey(merchantId, token, ctx, page);
 
   const resolvedProfileId =
-    profileId ?? (await getDefaultProfileId(merchantId, ctx));
+    profileId ?? (await getDefaultProfileId(merchantId, ctx, page));
 
   const data: Record<string, unknown> = {
     connector_type: "payment_processor",
@@ -430,6 +466,9 @@ export async function createStripeConnectorAPI(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": apiKey,
+        ...(authorizationToken
+          ? { Authorization: `Bearer ${authorizationToken}` }
+          : {}),
       },
       data,
     },
@@ -449,10 +488,12 @@ export async function createStripeConnectorAPIwithAPIKey(
   apiKey: string,
   context?: APIRequestContext,
   profileId?: string,
+  page?: Page,
 ): Promise<void> {
   const ctx = context ?? (await request.newContext());
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
   const resolvedProfileId =
-    profileId ?? (await getDefaultProfileId(merchantId, ctx));
+    profileId ?? (await getDefaultProfileId(merchantId, ctx, page));
 
   const data: Record<string, unknown> = {
     connector_type: "payment_processor",
@@ -489,6 +530,7 @@ export async function createStripeConnectorAPIwithAPIKey(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": apiKey,
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
       },
       data,
     },

--- a/playwright-tests/support/commands.ts
+++ b/playwright-tests/support/commands.ts
@@ -674,9 +674,11 @@ export async function createAuthenticationConnectorAPI(
   merchantId: string,
   connectorLabel: string,
   context?: APIRequestContext,
+  page?: Page,
 ): Promise<void> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(
     `${API_URL}/account/${merchantId}/connectors`,
@@ -685,6 +687,7 @@ export async function createAuthenticationConnectorAPI(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": apiKey,
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
       },
       data: {
         connector_type: "authentication_processor",

--- a/playwright-tests/support/commands.ts
+++ b/playwright-tests/support/commands.ts
@@ -815,6 +815,7 @@ export async function createRequiresCapturePaymentAPI(
   merchantId: string,
   context?: APIRequestContext,
   amount: number = 12345,
+  page?: Page,
 ): Promise<{
   payment_id: string;
   profile_id: string;
@@ -826,13 +827,15 @@ export async function createRequiresCapturePaymentAPI(
   payment_method_type: string;
 }> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(`${API_URL}/payments`, {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
       "api-key": apiKey,
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
     data: {
       amount,
@@ -925,6 +928,7 @@ export async function createRefundAPI(
   context?: APIRequestContext,
   amount: number = 5000,
   reason: string = "Test refund",
+  page?: Page,
 ): Promise<{
   refund_id: string;
   payment_id: string;
@@ -938,13 +942,15 @@ export async function createRefundAPI(
   profile_id: string;
 }> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(`${API_URL}/refunds`, {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
       "api-key": apiKey,
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
     data: {
       payment_id: paymentId,
@@ -965,9 +971,11 @@ export async function createPayoutConnectorAPI(
   merchantId: string,
   connectorLabel: string,
   context?: APIRequestContext,
+  page?: Page,
 ): Promise<void> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(
     `${API_URL}/account/${merchantId}/connectors`,
@@ -976,6 +984,7 @@ export async function createPayoutConnectorAPI(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": apiKey,
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
       },
       data: {
         connector_type: "payout_processor",
@@ -1026,6 +1035,7 @@ export async function createPayoutConnectorAPI(
 export async function createPayoutAPI(
   merchantId: string,
   context?: APIRequestContext,
+  page?: Page,
 ): Promise<{
   payment_id: string;
   profile_id: string;
@@ -1040,13 +1050,15 @@ export async function createPayoutAPI(
   metadata: Record<string, string>;
 }> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(`${API_URL}/payouts/create`, {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
       "api-key": apiKey,
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
     data: {
       amount: 12345,

--- a/playwright-tests/support/commands.ts
+++ b/playwright-tests/support/commands.ts
@@ -672,15 +672,18 @@ export async function createCustomerAPI(
   merchantId: string,
   customerId: string,
   context?: APIRequestContext,
+  page?: Page,
 ): Promise<{ customer_id: string }> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(`${API_URL}/customers`, {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
       "api-key": apiKey,
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
     data: {
       customer_id: customerId,
@@ -705,6 +708,7 @@ export async function createPaymentAPI(
   context?: APIRequestContext,
   amount: number = 12345,
   confirm: boolean = true,
+  page?: Page,
 ): Promise<{
   payment_id: string;
   profile_id: string;
@@ -719,13 +723,15 @@ export async function createPaymentAPI(
   metadata: Record<string, string>;
 }> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const apiKey = await createAPIKey(merchantId, "", ctx, page);
 
   const response = await ctx.post(`${API_URL}/payments`, {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
       "api-key": apiKey,
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
     data: {
       amount,

--- a/playwright-tests/support/commands.ts
+++ b/playwright-tests/support/commands.ts
@@ -108,7 +108,9 @@ export async function createAPIKey(
 ): Promise<string> {
   const ctx = context ?? (await request.newContext());
   const jwt = page ? await getJwtFromLocalStorage(page) : "";
-  console.log(jwt);
+  // Prefer an explicitly supplied token because callers may have obtained a
+  // JWT scoped to a merchant other than the one currently active in the UI.
+  const authorizationToken = token || jwt;
   // CI backends occasionally take >30s on the first request when the worker
   // pool is cold. One retry with a fresh context recovers from transient
   // socket hangs without masking persistent failures.
@@ -118,7 +120,9 @@ export async function createAPIKey(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": ADMIN_API_KEY,
-        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+        ...(authorizationToken
+          ? { Authorization: `Bearer ${authorizationToken}` }
+          : {}),
       },
       data: {
         name: "API Key 1",
@@ -233,9 +237,13 @@ export async function createBusinessProfileAPI(
   merchantId: string,
   profileName: string,
   context?: APIRequestContext,
+  page?: Page,
+  token = "",
 ): Promise<string> {
   const ctx = context ?? (await request.newContext());
-  const apiKey = await createAPIKey(merchantId, "", ctx);
+  const jwt = page ? await getJwtFromLocalStorage(page) : "";
+  const authorizationToken = token || jwt;
+  const apiKey = await createAPIKey(merchantId, token, ctx, page);
 
   const response = await ctx.post(
     `${API_URL}/account/${merchantId}/business_profile`,
@@ -244,6 +252,9 @@ export async function createBusinessProfileAPI(
         "Content-Type": "application/json",
         Accept: "application/json",
         "api-key": apiKey,
+        ...(authorizationToken
+          ? { Authorization: `Bearer ${authorizationToken}` }
+          : {}),
       },
       data: {
         profile_name: profileName,
@@ -338,6 +349,38 @@ export async function createMerchantAPI(
   }
 
   throw new Error("createMerchantAPI: exhausted retries");
+}
+
+export async function switchMerchantAPI(
+  token: string,
+  merchantId: string,
+  context?: APIRequestContext,
+): Promise<string> {
+  const ctx = context ?? (await request.newContext());
+  const response = await ctx.post(`${API_URL}/user/switch/merchant`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    data: {
+      merchant_id: merchantId,
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`switchMerchantAPI failed (${response.status()}): ${body}`);
+  }
+
+  const body = await response.json();
+  const switchedToken = body.token as string | undefined;
+  if (!switchedToken) {
+    throw new Error(
+      "switchMerchantAPI failed: response did not include a token",
+    );
+  }
+
+  return switchedToken;
 }
 
 export async function createStripeConnectorAPI(

--- a/playwright-tests/support/pages/developers/PaymentSettings.ts
+++ b/playwright-tests/support/pages/developers/PaymentSettings.ts
@@ -47,7 +47,7 @@ export class PaymentSettings {
   }
 
   get paymentLinkTab(): Locator {
-    return this.page.locator("text=Payment Link");
+    return this.page.getByText("Payment Link", { exact: true });
   }
 
   get vaultTab(): Locator {

--- a/playwright-tests/support/pages/homepage/HomePage.ts
+++ b/playwright-tests/support/pages/homepage/HomePage.ts
@@ -182,7 +182,7 @@ export class HomePage {
   }
 
   get routing(): Locator {
-    return this.page.locator('[data-testid="routing"]');
+    return this.page.getByTestId('workflow').getByRole('link', { name: 'Routing', exact: true });
   }
 
   get surchargeRouting(): Locator {

--- a/playwright-tests/visual-testing/3-operations.spec.ts
+++ b/playwright-tests/visual-testing/3-operations.spec.ts
@@ -50,6 +50,18 @@ test.describe("Visual Testing - Payment Operations", () => {
   }) => {
     await mockV2MerchantList(page);
 
+    await page.route("**/dashboard/config/feature?domain=", async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      json.features = {
+        ...json.features,
+        dev_opensearch: false,
+        dev_clickhouse_aggregate: false,
+      };
+      await route.fulfill({ response, json });
+    });
+    await page.reload();
+
     const homePage = new HomePage(page);
     const paymentOperations = new PaymentOperations(page);
 
@@ -65,8 +77,15 @@ test.describe("Visual Testing - Payment Operations", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
-      const paymentData = await createPaymentAPI(merchantId, context.request);
+      const paymentData = await createPaymentAPI(
+        merchantId,
+        context.request,
+        undefined,
+        undefined,
+        page,
+      );
     }
 
     await homePage.operations.click();
@@ -181,6 +200,18 @@ test.describe("Visual Testing - Payment Operations", () => {
   }) => {
     await mockV2MerchantList(page);
 
+    await page.route("**/dashboard/config/feature?domain=", async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      json.features = {
+        ...json.features,
+        dev_opensearch: false,
+        dev_clickhouse_aggregate: false,
+      };
+      await route.fulfill({ response, json });
+    });
+    await page.reload();
+
     const homePage = new HomePage(page);
     const paymentOperations = new PaymentOperations(page);
 
@@ -196,8 +227,15 @@ test.describe("Visual Testing - Payment Operations", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
-      await createPaymentAPI(merchantId, context.request);
+      await createPaymentAPI(
+        merchantId,
+        context.request,
+        undefined,
+        undefined,
+        page,
+      );
     }
 
     await homePage.operations.click();
@@ -247,6 +285,18 @@ test.describe("Visual Testing - Refund Operations", () => {
   }) => {
     await mockV2MerchantList(page);
 
+    await page.route("**/dashboard/config/feature?domain=", async (route) => {
+      const response = await route.fetch();
+      const json = await response.json();
+      json.features = {
+        ...json.features,
+        dev_opensearch: false,
+        dev_clickhouse_aggregate: false,
+      };
+      await route.fulfill({ response, json });
+    });
+    await page.reload();
+
     const homePage = new HomePage(page);
     const refundOperations = new RefundOperations(page);
 
@@ -260,8 +310,15 @@ test.describe("Visual Testing - Refund Operations", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
-      await createPaymentAPI(merchantId, context.request);
+      await createPaymentAPI(
+        merchantId,
+        context.request,
+        undefined,
+        undefined,
+        page,
+      );
     }
 
     await homePage.operations.click();
@@ -340,8 +397,9 @@ test.describe("Visual Testing - Payout Operations", () => {
         merchantId,
         "adyen_test_1",
         context.request,
+        page,
       );
-      await createPayoutAPI(merchantId, context.request);
+      await createPayoutAPI(merchantId, context.request, page);
     }
 
     await homePage.operations.click();
@@ -517,8 +575,15 @@ test.describe("Visual Testing - Customers", () => {
         merchantId,
         "stripe_test_1",
         context.request,
+        page,
       );
-      await createPaymentAPI(merchantId, context.request);
+      await createPaymentAPI(
+        merchantId,
+        context.request,
+        undefined,
+        undefined,
+        page,
+      );
     }
 
     await homePage.operations.click();

--- a/playwright-tests/visual-testing/4-connectors.spec.ts
+++ b/playwright-tests/visual-testing/4-connectors.spec.ts
@@ -442,6 +442,7 @@ test.describe("Visual Testing - Connectors", () => {
           merchantId,
           "stripe_test_1",
           context.request,
+          page,
         );
       }
 

--- a/playwright-tests/visual-testing/6-workflow.spec.ts
+++ b/playwright-tests/visual-testing/6-workflow.spec.ts
@@ -50,7 +50,7 @@ const seedConnector = async (
   if (!merchantId) {
     throw new Error("Routing visual test: could not read merchant id");
   }
-  await createDummyConnectorAPI(merchantId, label, context.request);
+  await createDummyConnectorAPI(merchantId, label, context.request, page);
 };
 
 // Drives the volume-based UI flow to create and activate one routing
@@ -102,7 +102,7 @@ const seedPayoutConnector = async (
   if (!merchantId) {
     throw new Error("Payout routing visual test: could not read merchant id");
   }
-  await createPayoutConnectorAPI(merchantId, label, context.request);
+  await createPayoutConnectorAPI(merchantId, label, context.request, page);
 };
 
 const createActivePayoutVolumeConfig = async (

--- a/playwright-tests/visual-testing/7-developers.spec.ts
+++ b/playwright-tests/visual-testing/7-developers.spec.ts
@@ -57,7 +57,7 @@ test.describe("Visual Testing - Developers", () => {
 
       const merchantId = await homePage.merchantID.nth(0).textContent();
       if (merchantId) {
-        await createAPIKey(merchantId, "", context.request);
+        await createAPIKey(merchantId, "", context.request, page);
       }
 
       await homePage.developer.click();

--- a/playwright-tests/visual-testing/8-settings.spec.ts
+++ b/playwright-tests/visual-testing/8-settings.spec.ts
@@ -78,6 +78,7 @@ test.describe("Visual Testing - Settings", () => {
         merchantId,
         "stripe_test_pmt",
         context.request,
+        page,
       );
 
       await homePage.settings.click();


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

This PR updates the Playwright E2E and visual test suites so they can run reliably against remote Hyperswitch environments.

  Key changes include:

  - Attach the authenticated user's JWT to test setup API requests when required by remote environments.
  - Add helpers for switching merchant and profile contexts and using the correctly scoped token.
  - Update API-based test-data setup for payments, refunds, payouts, customers, connectors, business profiles, and API keys.
  - Make feature-flag-dependent tests deterministic by explicitly mocking the required flag values.
  - Update selectors and assertions that differ between local and remote deployments.
  - Apply the remote-compatible setup across:
    - Homepage and organization tests
    - Payment, refund, payout, dispute, and customer operations
    - Connector tests
    - Payment and payout routing
    - Developer and payment settings
    - Visual regression tests

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

The existing Playwright helpers primarily relied on API-key authentication and the merchant/profile context available in the local test
  environment. Remote environments enforce additional authorization and token scoping, causing test-data setup requests to fail or create
  resources under the wrong merchant or profile.

  Remote deployments can also have different feature-flag configurations, which makes UI assertions environment-dependent and leads to
  inconsistent test results.

  These changes propagate the active browser JWT to setup requests, explicitly switch merchant or profile context where necessary, and control
  relevant feature flags within tests. This makes the suites more deterministic and allows the same tests to run against both local and remote
  environments.


## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
