### PR TITLE
fix: clarify included/excluded fields in clone connector modal

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalHelper.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalHelper.res
@@ -61,31 +61,49 @@ module CloneScopeSummary = {
   @react.component
   let make = () => {
     <div className="flex flex-col gap-3">
-      <p className={`${body.sm.semibold} text-nd_gray-400 tracking-wide`}>
-        {"INCLUDED IN THE CLONE"->React.string}
-      </p>
-      <div className="flex flex-wrap gap-2">
-        {["Credentials", "Webhook", "Payment methods", "Label"]
-        ->Array.map(item =>
-          <TagBinding
-            key=item
-            text=item
-            variant=Subtle
-            color=Success
-            shape=Squarical
-            size=Xs
-            leftSlot={<Icon name="nd-check" size=12 className="text-nd_green-600" />}
-          />
-        )
-        ->React.array}
+      <div className="flex flex-col gap-2">
+        <p className={`${body.sm.semibold} text-nd_gray-400 tracking-wide`}>
+          {"INCLUDED IN THE CLONE"->React.string}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {["Credentials", "Webhook", "Payment methods"]
+          ->Array.map(item =>
+            <TagBinding
+              key=item
+              text=item
+              variant=Subtle
+              color=Success
+              shape=Squarical
+              size=Xs
+              leftSlot={<Icon name="nd-check" size=12 className="text-nd_green-600" />}
+            />
+          )
+          ->React.array}
+        </div>
       </div>
-      <p className={`${body.sm.regular} text-nd_gray-500`}>
-        {"Not copied: "->React.string}
-        <span className={`${body.sm.semibold} text-nd_gray-600`}>
-          {"wallet, FRM & external auth"->React.string}
-        </span>
-        {". Review after cloning"->React.string}
-      </p>
+      <div className="flex flex-col gap-2">
+        <p className={`${body.sm.semibold} text-nd_gray-400 tracking-wide`}>
+          {"NOT INCLUDED"->React.string}
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {["Wallets", "Bank debits"]
+          ->Array.map(item =>
+            <TagBinding
+              key=item
+              text=item
+              variant=Subtle
+              color=Neutral
+              shape=Squarical
+              size=Xs
+              leftSlot={<Icon name="nd-cross" size=12 className="text-nd_gray-500" />}
+            />
+          )
+          ->React.array}
+        </div>
+        <p className={`${body.sm.regular} text-nd_gray-500`}>
+          {"These payment methods aren't copied. Enable them manually if needed."->React.string}
+        </p>
+      </div>
     </div>
   }
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Cleans up the copy in the Clone connector modal's scope summary:

- Removed the "Label" tag from "Included in the clone" — the label is a new value the admin types in, not something copied from the source, so listing it as "included" was misleading.
- Replaced the single cramped line ("Not copied: wallet, FRM & external auth. Review after cloning") with a "Not included" tag row that mirrors the "Included" section's style, calling out the two payment methods that aren't copied: **Wallets** and **Bank debits**, with a short caption to enable them manually if needed.

## Motivation and Context

Fixes issue #5221 - the previous copy was confusing: it mixed backend config field names (FRM, external auth) that don't mean anything to a merchant with payment-method terminology, and crammed the exclusion note into a single dense sentence instead of a scannable format matching the rest of the modal.

## How did you test it?

- `npm run re:build` - verified ReScript compilation passes
- Visually reviewed the modal with the updated tag rows

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

<img width="732" height="731" alt="Screenshot 2026-07-22 at 3 08 39 PM" src="https://github.com/user-attachments/assets/a5e2e361-eb64-4303-8015-5086ae5ce107" />
