### PR TITLE
chore: update payment link wasm bundle

### DIFF
--- a/public/hyperswitch/payment_link_wasm/payment_link.d.ts
+++ b/public/hyperswitch/payment_link_wasm/payment_link.d.ts
@@ -16,243 +16,95 @@ export function generate_payment_link_preview(config_json: string): string;
 export function validate_payment_link_config(config_json: string): string;
 export function slugify(s: string): string;
 
-export type InitInput =
-  | RequestInfo
-  | URL
-  | Response
-  | BufferSource
-  | WebAssembly.Module;
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 export interface InitOutput {
   readonly memory: WebAssembly.Memory;
-  readonly generate_payment_link_preview: (
-    a: number,
-    b: number,
-    c: number,
-  ) => void;
-  readonly validate_payment_link_config: (
-    a: number,
-    b: number,
-    c: number,
-  ) => void;
+  readonly generate_payment_link_preview: (a: number, b: number, c: number) => void;
+  readonly validate_payment_link_config: (a: number, b: number, c: number) => void;
   readonly slugify: (a: number, b: number, c: number) => void;
   readonly ffi_superposition_types_rust_future_cancel_f32: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_complete_f32: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_f64: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_i16: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_i32: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_i64: (
-    a: bigint,
-    b: number,
-  ) => bigint;
-  readonly ffi_superposition_types_rust_future_complete_i8: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_rust_buffer: (
-    a: number,
-    b: bigint,
-    c: number,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_complete_u16: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_u8: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_complete_void: (
-    a: bigint,
-    b: number,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_complete_f32: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_f64: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_i16: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_i32: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_i64: (a: bigint, b: number) => bigint;
+  readonly ffi_superposition_types_rust_future_complete_i8: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_rust_buffer: (a: number, b: bigint, c: number) => void;
+  readonly ffi_superposition_types_rust_future_complete_u16: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_u8: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_complete_void: (a: bigint, b: number) => void;
   readonly ffi_superposition_types_rust_future_free_f32: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_f32: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rustbuffer_alloc: (
-    a: number,
-    b: bigint,
-    c: number,
-  ) => void;
-  readonly ffi_superposition_types_rustbuffer_free: (
-    a: number,
-    b: number,
-  ) => void;
-  readonly ffi_superposition_types_rustbuffer_from_bytes: (
-    a: number,
-    b: number,
-    c: number,
-  ) => void;
-  readonly ffi_superposition_types_rustbuffer_reserve: (
-    a: number,
-    b: number,
-    c: bigint,
-    d: number,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_f32: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rustbuffer_alloc: (a: number, b: bigint, c: number) => void;
+  readonly ffi_superposition_types_rustbuffer_free: (a: number, b: number) => void;
+  readonly ffi_superposition_types_rustbuffer_from_bytes: (a: number, b: number, c: number) => void;
+  readonly ffi_superposition_types_rustbuffer_reserve: (a: number, b: number, c: bigint, d: number) => void;
   readonly ffi_superposition_types_uniffi_contract_version: () => number;
-  readonly ffi_superposition_types_rust_future_poll_u16: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_u16: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_cancel_u16: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_i64: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_i64: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_cancel_i64: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_i16: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_pointer: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_pointer: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_cancel_pointer: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_i16: (a: bigint, b: number, c: bigint) => void;
   readonly ffi_superposition_types_rust_future_free_i16: (a: bigint) => void;
   readonly ffi_superposition_types_rust_future_cancel_i16: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_void: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_void: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_cancel_void: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_u8: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_u8: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_cancel_u8: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_i8: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_u32: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_u32: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_complete_u32: (a: bigint, b: number) => number;
+  readonly ffi_superposition_types_rust_future_cancel_u32: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_i8: (a: bigint, b: number, c: bigint) => void;
   readonly ffi_superposition_types_rust_future_free_i8: (a: bigint) => void;
   readonly ffi_superposition_types_rust_future_cancel_i8: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_u64: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_u16: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_u16: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_cancel_u16: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_u64: (a: bigint, b: number, c: bigint) => void;
   readonly ffi_superposition_types_rust_future_free_u64: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_complete_u64: (
-    a: bigint,
-    b: number,
-  ) => bigint;
   readonly ffi_superposition_types_rust_future_cancel_u64: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_rust_buffer: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_rust_buffer: (
-    a: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_cancel_rust_buffer: (
-    a: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_poll_pointer: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_pointer: (
-    a: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_cancel_pointer: (
-    a: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_poll_f64: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_u8: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_u8: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_cancel_u8: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_f64: (a: bigint, b: number, c: bigint) => void;
   readonly ffi_superposition_types_rust_future_free_f64: (a: bigint) => void;
   readonly ffi_superposition_types_rust_future_cancel_f64: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_u32: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
-  readonly ffi_superposition_types_rust_future_free_u32: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_complete_u32: (
-    a: bigint,
-    b: number,
-  ) => number;
-  readonly ffi_superposition_types_rust_future_cancel_u32: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_poll_i32: (
-    a: bigint,
-    b: number,
-    c: bigint,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_i32: (a: bigint, b: number, c: bigint) => void;
   readonly ffi_superposition_types_rust_future_free_i32: (a: bigint) => void;
-  readonly ffi_superposition_types_rust_future_complete_pointer: (
-    a: bigint,
-    b: number,
-  ) => number;
+  readonly ffi_superposition_types_rust_future_complete_pointer: (a: bigint, b: number) => number;
   readonly ffi_superposition_types_rust_future_cancel_i32: (a: bigint) => void;
-  readonly ring_core_0_17_14__bn_mul_mont: (
-    a: number,
-    b: number,
-    c: number,
-    d: number,
-    e: number,
-    f: number,
-  ) => void;
+  readonly ffi_superposition_types_rust_future_poll_rust_buffer: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_rust_buffer: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_cancel_rust_buffer: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_void: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_void: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_cancel_void: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_poll_i64: (a: bigint, b: number, c: bigint) => void;
+  readonly ffi_superposition_types_rust_future_free_i64: (a: bigint) => void;
+  readonly ffi_superposition_types_rust_future_complete_u64: (a: bigint, b: number) => bigint;
+  readonly ffi_superposition_types_rust_future_cancel_i64: (a: bigint) => void;
+  readonly ring_core_0_17_14__bn_mul_mont: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
   readonly __wbindgen_export_0: (a: number) => void;
   readonly __wbindgen_add_to_stack_pointer: (a: number) => number;
   readonly __wbindgen_export_1: (a: number, b: number) => number;
-  readonly __wbindgen_export_2: (
-    a: number,
-    b: number,
-    c: number,
-    d: number,
-  ) => number;
+  readonly __wbindgen_export_2: (a: number, b: number, c: number, d: number) => number;
   readonly __wbindgen_export_3: (a: number, b: number, c: number) => void;
 }
 
 export type SyncInitInput = BufferSource | WebAssembly.Module;
 /**
- * Instantiates the given `module`, which can either be bytes or
- * a precompiled `WebAssembly.Module`.
- *
- * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
- *
- * @returns {InitOutput}
- */
-export function initSync(
-  module: { module: SyncInitInput } | SyncInitInput,
-): InitOutput;
+* Instantiates the given `module`, which can either be bytes or
+* a precompiled `WebAssembly.Module`.
+*
+* @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+*
+* @returns {InitOutput}
+*/
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
 
 /**
- * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
- * for everything else, calls `WebAssembly.instantiate` directly.
- *
- * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
- *
- * @returns {Promise<InitOutput>}
- */
-export default function __wbg_init(
-  module_or_path?:
-    | { module_or_path: InitInput | Promise<InitInput> }
-    | InitInput
-    | Promise<InitInput>,
-): Promise<InitOutput>;
+* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+* for everything else, calls `WebAssembly.instantiate` directly.
+*
+* @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+*
+* @returns {Promise<InitOutput>}
+*/
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/public/hyperswitch/payment_link_wasm/payment_link_bg.wasm.d.ts
+++ b/public/hyperswitch/payment_link_wasm/payment_link_bg.wasm.d.ts
@@ -1,223 +1,69 @@
 /* tslint:disable */
 /* eslint-disable */
 export const memory: WebAssembly.Memory;
-export const generate_payment_link_preview: (
-  a: number,
-  b: number,
-  c: number,
-) => void;
-export const validate_payment_link_config: (
-  a: number,
-  b: number,
-  c: number,
-) => void;
+export const generate_payment_link_preview: (a: number, b: number, c: number) => void;
+export const validate_payment_link_config: (a: number, b: number, c: number) => void;
 export const slugify: (a: number, b: number, c: number) => void;
-export const ffi_superposition_types_rust_future_cancel_f32: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_complete_f32: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_f64: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_i16: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_i32: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_i64: (
-  a: bigint,
-  b: number,
-) => bigint;
-export const ffi_superposition_types_rust_future_complete_i8: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_rust_buffer: (
-  a: number,
-  b: bigint,
-  c: number,
-) => void;
-export const ffi_superposition_types_rust_future_complete_u16: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_u8: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_complete_void: (
-  a: bigint,
-  b: number,
-) => void;
+export const ffi_superposition_types_rust_future_cancel_f32: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_complete_f32: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_f64: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_i16: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_i32: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_i64: (a: bigint, b: number) => bigint;
+export const ffi_superposition_types_rust_future_complete_i8: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_rust_buffer: (a: number, b: bigint, c: number) => void;
+export const ffi_superposition_types_rust_future_complete_u16: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_u8: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_complete_void: (a: bigint, b: number) => void;
 export const ffi_superposition_types_rust_future_free_f32: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_poll_f32: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rustbuffer_alloc: (
-  a: number,
-  b: bigint,
-  c: number,
-) => void;
-export const ffi_superposition_types_rustbuffer_free: (
-  a: number,
-  b: number,
-) => void;
-export const ffi_superposition_types_rustbuffer_from_bytes: (
-  a: number,
-  b: number,
-  c: number,
-) => void;
-export const ffi_superposition_types_rustbuffer_reserve: (
-  a: number,
-  b: number,
-  c: bigint,
-  d: number,
-) => void;
+export const ffi_superposition_types_rust_future_poll_f32: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rustbuffer_alloc: (a: number, b: bigint, c: number) => void;
+export const ffi_superposition_types_rustbuffer_free: (a: number, b: number) => void;
+export const ffi_superposition_types_rustbuffer_from_bytes: (a: number, b: number, c: number) => void;
+export const ffi_superposition_types_rustbuffer_reserve: (a: number, b: number, c: bigint, d: number) => void;
 export const ffi_superposition_types_uniffi_contract_version: () => number;
-export const ffi_superposition_types_rust_future_poll_u16: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_u16: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_u16: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_i64: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_i64: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_i64: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_i16: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
+export const ffi_superposition_types_rust_future_poll_pointer: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_pointer: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_cancel_pointer: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_i16: (a: bigint, b: number, c: bigint) => void;
 export const ffi_superposition_types_rust_future_free_i16: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_i16: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_void: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_void: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_void: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_u8: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_u8: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_u8: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_poll_i8: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
+export const ffi_superposition_types_rust_future_cancel_i16: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_u32: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_u32: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_complete_u32: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_cancel_u32: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_i8: (a: bigint, b: number, c: bigint) => void;
 export const ffi_superposition_types_rust_future_free_i8: (a: bigint) => void;
 export const ffi_superposition_types_rust_future_cancel_i8: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_poll_u64: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
+export const ffi_superposition_types_rust_future_poll_u16: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_u16: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_cancel_u16: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_u64: (a: bigint, b: number, c: bigint) => void;
 export const ffi_superposition_types_rust_future_free_u64: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_complete_u64: (
-  a: bigint,
-  b: number,
-) => bigint;
-export const ffi_superposition_types_rust_future_cancel_u64: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_rust_buffer: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_rust_buffer: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_cancel_rust_buffer: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_pointer: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_pointer: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_cancel_pointer: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_f64: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
+export const ffi_superposition_types_rust_future_cancel_u64: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_u8: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_u8: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_cancel_u8: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_f64: (a: bigint, b: number, c: bigint) => void;
 export const ffi_superposition_types_rust_future_free_f64: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_cancel_f64: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_u32: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_free_u32: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_complete_u32: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_cancel_u32: (
-  a: bigint,
-) => void;
-export const ffi_superposition_types_rust_future_poll_i32: (
-  a: bigint,
-  b: number,
-  c: bigint,
-) => void;
+export const ffi_superposition_types_rust_future_cancel_f64: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_i32: (a: bigint, b: number, c: bigint) => void;
 export const ffi_superposition_types_rust_future_free_i32: (a: bigint) => void;
-export const ffi_superposition_types_rust_future_complete_pointer: (
-  a: bigint,
-  b: number,
-) => number;
-export const ffi_superposition_types_rust_future_cancel_i32: (
-  a: bigint,
-) => void;
-export const ring_core_0_17_14__bn_mul_mont: (
-  a: number,
-  b: number,
-  c: number,
-  d: number,
-  e: number,
-  f: number,
-) => void;
+export const ffi_superposition_types_rust_future_complete_pointer: (a: bigint, b: number) => number;
+export const ffi_superposition_types_rust_future_cancel_i32: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_rust_buffer: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_rust_buffer: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_cancel_rust_buffer: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_void: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_void: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_cancel_void: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_poll_i64: (a: bigint, b: number, c: bigint) => void;
+export const ffi_superposition_types_rust_future_free_i64: (a: bigint) => void;
+export const ffi_superposition_types_rust_future_complete_u64: (a: bigint, b: number) => bigint;
+export const ffi_superposition_types_rust_future_cancel_i64: (a: bigint) => void;
+export const ring_core_0_17_14__bn_mul_mont: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const __wbindgen_export_0: (a: number) => void;
 export const __wbindgen_add_to_stack_pointer: (a: number) => number;
 export const __wbindgen_export_1: (a: number, b: number) => number;
-export const __wbindgen_export_2: (
-  a: number,
-  b: number,
-  c: number,
-  d: number,
-) => number;
+export const __wbindgen_export_2: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_export_3: (a: number, b: number, c: number) => void;


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

Updated the checked-in payment link WASM artifacts under `public/hyperswitch/payment_link_wasm` to align with the latest backend WASM changes.

This includes:

- refreshed `payment_link_bg.wasm`
- regenerated TypeScript declarations for the payment link WASM exports
- updated generated bindings/types for the backend WASM contract

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

The control center needs the payment link WASM bundle to stay in sync with the backend WASM contract so payment link preview/config validation behavior uses the latest backend-generated implementation.

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

- Ran commit hook formatting checks successfully.
- `npm run re:build` was attempted, but ReScript exited because `.bsb.lock` already existed in the local workspace.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [x] Yes
- [ ] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s): N/A

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
