### PR TITLE
feat: redirect routing to Decision Engine when a profile is cut over

### DIFF
--- a/playwright-tests/support/pages/workflow/paymentRouting/PaymentRouting.ts
+++ b/playwright-tests/support/pages/workflow/paymentRouting/PaymentRouting.ts
@@ -8,7 +8,7 @@ export class PaymentRouting {
   }
 
   get volumeBasedRoutingSetupButton(): Locator {
-    return this.page.locator('[data-button-for="setup"]').nth(0);
+    return this.page.locator('[data-button-for="setup"]').nth(2);
   }
 
   get volumeBasedRoutingHeader(): Locator {
@@ -24,7 +24,7 @@ export class PaymentRouting {
   }
 
   get authRateBasedRoutingSetupButton(): Locator {
-    return this.page.locator('[data-button-for="setup"]').nth(2);
+    return this.page.locator('[data-button-for="setup"]').nth(0);
   }
 
   get noConnectorsMessage(): Locator {

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -25,7 +25,12 @@ module TopRightIcons = {
 }
 module ActionButtons = {
   @react.component
-  let make = (~routeType: routingType, ~onRedirectBaseUrl) => {
+  let make = (
+    ~routeType: routingType,
+    ~onRedirectBaseUrl,
+    ~isCutover=false,
+    ~onDeRedirect=_ => (),
+  ) => {
     let mixpanelEvent = MixpanelHook.useSendEvent()
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
 
@@ -40,11 +45,17 @@ module ActionButtons = {
         buttonType={Secondary}
         buttonSize=Small
         onClick={_ => {
-          RescriptReactRouter.push(
-            GlobalVars.appendDashboardPath(
-              ~url=`/${onRedirectBaseUrl}/${routingTypeName(routeType)}`,
-            ),
-          )
+          // Cut-over profiles deep-link this card to its Decision Engine page (new tab); others use
+          // the local Hyperswitch setup flow.
+          if isCutover {
+            onDeRedirect(routeType->deRoutingTarget)
+          } else {
+            RescriptReactRouter.push(
+              GlobalVars.appendDashboardPath(
+                ~url=`/${onRedirectBaseUrl}/${routingTypeName(routeType)}`,
+              ),
+            )
+          }
           mixpanelEvent(~eventName=`${onRedirectBaseUrl}_setup_${routeType->routingTypeName}`)
         }}
       />
@@ -72,7 +83,7 @@ module ActionButtons = {
 
 module ActiveSection = {
   @react.component
-  let make = (~activeRouting, ~activeRoutingId, ~onRedirectBaseUrl) => {
+  let make = (~activeRouting, ~activeRoutingId, ~onRedirectBaseUrl, ~isCutover=false) => {
     open LogicUtils
     let {profileId: currentprofileId} = React.useContext(
       UserInfoProvider.defaultContext,
@@ -102,7 +113,7 @@ module ActiveSection = {
           </div>
           <div className={"flex flex-col gap-3"}>
             <p className={`text-nd_gray-600 ${body.md.semibold} w-full whitespace-normal`}>
-              {`${routingName}${getContent(activeRoutingType).heading}`->React.string}
+              {`${routingName}${getContent(~isCutover, activeRoutingType).heading}`->React.string}
             </p>
             <RenderIf condition={profileId->isNonEmptyString}>
               <div
@@ -147,42 +158,54 @@ module ActiveSection = {
 
 module LevelWiseRoutingSection = {
   @react.component
-  let make = (~types: array<routingType>, ~onRedirectBaseUrl) => {
+  let make = (
+    ~types: array<routingType>,
+    ~onRedirectBaseUrl,
+    ~isCutover=false,
+    ~onDeRedirect=_ => (),
+  ) => {
     let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+    let renderCard = (value, key) =>
+      <div key className="flex flex-1 flex-col bg-white border rounded-lg p-4 gap-8">
+        <div className="flex flex-1 flex-col gap-7">
+          <div className="flex w-full items-center flex-wrap justify-between">
+            <TopLeftIcons routeType=value />
+            <TopRightIcons routeType=value />
+          </div>
+          <div className="flex flex-1 flex-col gap-3 text-nd_gray-600">
+            <p className={`${body.md.semibold}`}>
+              {getContent(~isCutover, value).heading->React.string}
+            </p>
+            <p className={`${body.md.medium} opacity-50`}>
+              {getContent(~isCutover, value).subHeading->React.string}
+            </p>
+          </div>
+        </div>
+        <ActionButtons routeType=value onRedirectBaseUrl isCutover onDeRedirect />
+      </div>
+    // Least Cost (DebitRouting) sits just before Default Fallback, so render the non-fallback cards
+    // first, then Least Cost, then the fallback card(s) — Default Fallback stays last regardless.
+    let nonFallbackTypes = types->Array.filter(value => value != DEFAULTFALLBACK)
+    let fallbackTypes = types->Array.filter(value => value == DEFAULTFALLBACK)
     <div className="flex flex-col flex-wrap rounded w-full py-6 gap-5">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-9">
-        {types
-        ->Array.mapWithIndex((value, index) =>
-          <div
-            key={index->Int.toString}
-            className="flex flex-1 flex-col bg-white border rounded-lg p-4 gap-8">
-            <div className="flex flex-1 flex-col gap-7">
-              <div className="flex w-full items-center flex-wrap justify-between">
-                <TopLeftIcons routeType=value />
-                <TopRightIcons routeType=value />
-              </div>
-              <div className="flex flex-1 flex-col gap-3 text-nd_gray-600">
-                <p className={`${body.md.semibold}`}> {getContent(value).heading->React.string} </p>
-                <p className={`${body.md.medium} opacity-50`}>
-                  {getContent(value).subHeading->React.string}
-                </p>
-              </div>
-            </div>
-            <ActionButtons routeType=value onRedirectBaseUrl />
-          </div>
-        )
+        {nonFallbackTypes
+        ->Array.mapWithIndex((value, index) => renderCard(value, `card-${index->Int.toString}`))
         ->React.array}
         <RenderIf
           condition={debitRouting && onRedirectBaseUrl->getRoutingTypefromString == Routing}>
-          <DebitRouting />
+          <DebitRouting isCutover onDeRedirect />
         </RenderIf>
+        {fallbackTypes
+        ->Array.mapWithIndex((value, index) => renderCard(value, `fallback-${index->Int.toString}`))
+        ->React.array}
       </div>
     </div>
   }
 }
 
 @react.component
-let make = (~routingType: array<JSON.t>) => {
+let make = (~routingType: array<JSON.t>, ~isCutover=false) => {
   let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let debitRoutingValue =
     (
@@ -196,7 +219,11 @@ let make = (~routingType: array<JSON.t>) => {
     ->Array.mapWithIndex((ele, i) => {
       let id = ele->LogicUtils.getDictFromJsonObject->LogicUtils.getString("id", "")
       <ActiveSection
-        key={i->Int.toString} activeRouting={ele} activeRoutingId={id} onRedirectBaseUrl="routing"
+        key={i->Int.toString}
+        activeRouting={ele}
+        activeRoutingId={id}
+        onRedirectBaseUrl="routing"
+        isCutover
       />
     })
     ->React.array}

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -45,8 +45,6 @@ module ActionButtons = {
         buttonType={Secondary}
         buttonSize=Small
         onClick={_ => {
-          // Cut-over profiles deep-link this card to its Decision Engine page (new tab); others use
-          // the local Hyperswitch setup flow.
           if isCutover {
             onDeRedirect(routeType->deRoutingTarget)
           } else {
@@ -183,8 +181,6 @@ module LevelWiseRoutingSection = {
         </div>
         <ActionButtons routeType=value onRedirectBaseUrl isCutover onDeRedirect />
       </div>
-    // Least Cost (DebitRouting) sits just before Default Fallback, so render the non-fallback cards
-    // first, then Least Cost, then the fallback card(s) — Default Fallback stays last regardless.
     let nonFallbackTypes = types->Array.filter(value => value != DEFAULTFALLBACK)
     let fallbackTypes = types->Array.filter(value => value == DEFAULTFALLBACK)
     <div className="flex flex-col flex-wrap rounded w-full py-6 gap-5">

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -29,7 +29,7 @@ module ActionButtons = {
     ~routeType: routingType,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDeRedirect=_ => (),
+    ~onDecisionEngineRedirect=_ => (),
   ) => {
     let mixpanelEvent = MixpanelHook.useSendEvent()
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
@@ -46,7 +46,7 @@ module ActionButtons = {
         buttonSize=Small
         onClick={_ => {
           if isCutover {
-            onDeRedirect(routeType->deRoutingTarget)
+            onDecisionEngineRedirect(routeType->decisionEngineRoutingTarget)
           } else {
             RescriptReactRouter.push(
               GlobalVars.appendDashboardPath(
@@ -160,7 +160,7 @@ module LevelWiseRoutingSection = {
     ~types: array<routingType>,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDeRedirect=_ => (),
+    ~onDecisionEngineRedirect=_ => (),
   ) => {
     let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let renderCard = (value, key) =>
@@ -179,7 +179,7 @@ module LevelWiseRoutingSection = {
             </p>
           </div>
         </div>
-        <ActionButtons routeType=value onRedirectBaseUrl isCutover onDeRedirect />
+        <ActionButtons routeType=value onRedirectBaseUrl isCutover onDecisionEngineRedirect />
       </div>
     let nonFallbackTypes = types->Array.filter(value => value != DEFAULTFALLBACK)
     let fallbackTypes = types->Array.filter(value => value == DEFAULTFALLBACK)
@@ -190,7 +190,7 @@ module LevelWiseRoutingSection = {
         ->React.array}
         <RenderIf
           condition={debitRouting && onRedirectBaseUrl->getRoutingTypefromString == Routing}>
-          <DebitRouting isCutover onDeRedirect />
+          <DebitRouting isCutover onDecisionEngineRedirect />
         </RenderIf>
         {fallbackTypes
         ->Array.mapWithIndex((value, index) => renderCard(value, `fallback-${index->Int.toString}`))

--- a/src/screens/Routing/DebitRouting/DebitRouting.res
+++ b/src/screens/Routing/DebitRouting/DebitRouting.res
@@ -10,8 +10,6 @@ let make = (~isCutover=false, ~onDeRedirect=_ => ()) => {
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
     ).is_debit_routing_enabled->Option.getOr(false)
   let handleButtonClick = _ => {
-    // Cut-over profiles deep-link Least Cost to the Decision Engine debit-routing page (new tab);
-    // others open the local configure/manage modal.
     if isCutover {
       onDeRedirect("debit")
     } else if debitRoutingValue {

--- a/src/screens/Routing/DebitRouting/DebitRouting.res
+++ b/src/screens/Routing/DebitRouting/DebitRouting.res
@@ -1,5 +1,5 @@
 @react.component
-let make = () => {
+let make = (~isCutover=false, ~onDeRedirect=_ => ()) => {
   open Typography
   let (showLeastCostModal, setShowLeastCostModal) = React.useState(_ => false)
   let (showManageModal, setShowManageModal) = React.useState(_ => false)
@@ -10,7 +10,11 @@ let make = () => {
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
     ).is_debit_routing_enabled->Option.getOr(false)
   let handleButtonClick = _ => {
-    if debitRoutingValue {
+    // Cut-over profiles deep-link Least Cost to the Decision Engine debit-routing page (new tab);
+    // others open the local configure/manage modal.
+    if isCutover {
+      onDeRedirect("debit")
+    } else if debitRoutingValue {
       setShowManageModal(_ => true)
     } else {
       setShowLeastCostModal(_ => true)

--- a/src/screens/Routing/DebitRouting/DebitRouting.res
+++ b/src/screens/Routing/DebitRouting/DebitRouting.res
@@ -1,5 +1,5 @@
 @react.component
-let make = (~isCutover=false, ~onDeRedirect=_ => ()) => {
+let make = (~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
   open Typography
   let (showLeastCostModal, setShowLeastCostModal) = React.useState(_ => false)
   let (showManageModal, setShowManageModal) = React.useState(_ => false)
@@ -11,7 +11,7 @@ let make = (~isCutover=false, ~onDeRedirect=_ => ()) => {
     ).is_debit_routing_enabled->Option.getOr(false)
   let handleButtonClick = _ => {
     if isCutover {
-      onDeRedirect("debit")
+      onDecisionEngineRedirect("debit")
     } else if debitRoutingValue {
       setShowManageModal(_ => true)
     } else {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -12,9 +12,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let (routingType, setRoutingType) = React.useState(_ => [])
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (tabIndex, setTabIndex) = React.useState(_ => 0)
-  // Decision Engine routing-source gate: #Checking until we know the profile's routing source,
-  // then #Local — we always render Hyperswitch's own routing cards. For cut-over profiles
-  // (isCutover) each card deep-links to its specific DE page instead of the local setup flow.
   let (deEntryState, setDeEntryState) = React.useState(_ => previewOnly ? #Local : #Checking)
   let (isCutover, setIsCutover) = React.useState(_ => false)
   let debitRoutingValue =
@@ -128,8 +125,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
-  // Ask Hyperswitch whether this profile's routing source is the Decision Engine. We always render
-  // Hyperswitch's own routing cards; `is_cutover` only decides whether each card deep-links to DE.
   let checkRoutingEntry = async () => {
     open LogicUtils
     try {
@@ -143,8 +138,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
-  // For a cut-over profile, a card click asks the backend for a fresh one-time DE deep-link for that
-  // `target` page and opens it in a new tab. Failures are swallowed (card simply doesn't navigate).
   let openDeRoutingPage = async target => {
     open LogicUtils
     try {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -13,8 +13,10 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (tabIndex, setTabIndex) = React.useState(_ => 0)
   // Decision Engine routing-source gate: #Checking until we know the profile's routing source,
-  // then #Redirected (opened DE in a new tab) or #Local (render Hyperswitch's own routing UI).
+  // then #Local — we always render Hyperswitch's own routing cards. For cut-over profiles
+  // (isCutover) each card deep-links to its specific DE page instead of the local setup flow.
   let (deEntryState, setDeEntryState) = React.useState(_ => previewOnly ? #Local : #Checking)
+  let (isCutover, setIsCutover) = React.useState(_ => false)
   let debitRoutingValue =
     (
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
@@ -32,7 +34,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
     let baseTabs = [
       {
         title: "Active configuration",
-        renderContent: () => <ActiveRouting routingType />,
+        renderContent: () => <ActiveRouting routingType isCutover />,
       },
     ]
     hasWorkflowsManageAccess
@@ -52,7 +54,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue))
+  }, (routingType, debitRoutingValue, isCutover))
 
   let fetchRoutingRecords = async activeIds => {
     try {
@@ -126,23 +128,34 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
-  // Ask Hyperswitch whether this profile's routing source is the Decision Engine. If so the
-  // backend returns a redirect URL (carrying a one-time SSO code) and we open the DE dashboard in
-  // a new tab; otherwise we render Hyperswitch's own routing UI. Failures fall back to local.
+  // Ask Hyperswitch whether this profile's routing source is the Decision Engine. We always render
+  // Hyperswitch's own routing cards; `is_cutover` only decides whether each card deep-links to DE.
   let checkRoutingEntry = async () => {
     open LogicUtils
     try {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
       let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
+      let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
+      setIsCutover(_ => cutover)
+      setDeEntryState(_ => #Local)
+    } catch {
+    | Exn.Error(_) => setDeEntryState(_ => #Local)
+    }
+  }
+
+  // For a cut-over profile, a card click asks the backend for a fresh one-time DE deep-link for that
+  // `target` page and opens it in a new tab. Failures are swallowed (card simply doesn't navigate).
+  let openDeRoutingPage = async target => {
+    open LogicUtils
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
       let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
       if redirectUrl->isNonEmptyString {
         redirectUrl->Window._open
-        setDeEntryState(_ => #Redirected)
-      } else {
-        setDeEntryState(_ => #Local)
       }
     } catch {
-    | Exn.Error(_) => setDeEntryState(_ => #Local)
+    | Exn.Error(_) => ()
     }
   }
 
@@ -156,42 +169,38 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let getTabName = index => index == 0 ? "active" : "history"
 
   switch deEntryState {
-  | #Checking => <PageLoaderWrapper screenState=PageLoaderWrapper.Loading> {React.null} </PageLoaderWrapper>
-  | #Redirected =>
-    <DefaultLandingPage
-      height="90%"
-      title="Routing is managed in the Decision Engine — opened in a new tab."
-      customStyle="py-16"
-      overridingStylesTitle="text-3xl font-semibold"
-    />
+  | #Checking =>
+    <PageLoaderWrapper screenState=PageLoaderWrapper.Loading> {React.null} </PageLoaderWrapper>
   | #Local =>
     <PageLoaderWrapper screenState>
-    <div className={`${widthClass} ${marginClass} gap-2.5`}>
-      <div className="flex flex-col">
-        <PageUtils.PageHeading title="Smart Routing Configurations" />
-        <ActiveRouting.LevelWiseRoutingSection
-          types=[VOLUME_SPLIT, ADVANCED, AUTH_RATE_ROUTING, DEFAULTFALLBACK]
-          onRedirectBaseUrl="routing"
-        />
-      </div>
-      <RenderIf condition={!previewOnly}>
-        <div className="flex flex-col gap-12">
-          <EntityScaffold
-            entityName="HyperSwitch Priority Logic"
-            remainingPath
-            renderList={() =>
-              <Tabs
-                initialIndex={tabIndex >= 0 ? tabIndex : 0}
-                tabs
-                onTitleClick={index => {
-                  setTabIndex(_ => index)
-                  setCurrentTabName(_ => getTabName(index))
-                }}
-              />}
+      <div className={`${widthClass} ${marginClass} gap-2.5`}>
+        <div className="flex flex-col">
+          <PageUtils.PageHeading title="Smart Routing Configurations" />
+          <ActiveRouting.LevelWiseRoutingSection
+            types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
+            onRedirectBaseUrl="routing"
+            isCutover
+            onDeRedirect={target => openDeRoutingPage(target)->ignore}
           />
         </div>
-      </RenderIf>
-    </div>
-  </PageLoaderWrapper>
+        <RenderIf condition={!previewOnly}>
+          <div className="flex flex-col gap-12">
+            <EntityScaffold
+              entityName="HyperSwitch Priority Logic"
+              remainingPath
+              renderList={() =>
+                <Tabs
+                  initialIndex={tabIndex >= 0 ? tabIndex : 0}
+                  tabs
+                  onTitleClick={index => {
+                    setTabIndex(_ => index)
+                    setCurrentTabName(_ => getTabName(index))
+                  }}
+                />}
+            />
+          </div>
+        </RenderIf>
+      </div>
+    </PageLoaderWrapper>
   }
 }

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -3,6 +3,7 @@ open APIUtils
 let make = (~remainingPath, ~previewOnly=false) => {
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
+  let updateDetails = useUpdateMethod(~showErrorToast=false)
   let url = RescriptReactRouter.useUrl()
   let pathVar = url.path->List.toArray->Array.joinWith("/")
 
@@ -11,6 +12,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let (routingType, setRoutingType) = React.useState(_ => [])
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (tabIndex, setTabIndex) = React.useState(_ => 0)
+  // Decision Engine routing-source gate: #Checking until we know the profile's routing source,
+  // then #Redirected (opened DE in a new tab) or #Local (render Hyperswitch's own routing UI).
+  let (deEntryState, setDeEntryState) = React.useState(_ => previewOnly ? #Local : #Checking)
   let debitRoutingValue =
     (
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
@@ -122,9 +126,46 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
+  // Ask Hyperswitch whether this profile's routing source is the Decision Engine. If so the
+  // backend returns a redirect URL (carrying a one-time SSO code) and we open the DE dashboard in
+  // a new tab; otherwise we render Hyperswitch's own routing UI. Failures fall back to local.
+  let checkRoutingEntry = async () => {
+    open LogicUtils
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
+      let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
+      if redirectUrl->isNonEmptyString {
+        redirectUrl->Window._open
+        setDeEntryState(_ => #Redirected)
+      } else {
+        setDeEntryState(_ => #Local)
+      }
+    } catch {
+    | Exn.Error(_) => setDeEntryState(_ => #Local)
+    }
+  }
+
+  React.useEffect0(() => {
+    if !previewOnly {
+      checkRoutingEntry()->ignore
+    }
+    None
+  })
+
   let getTabName = index => index == 0 ? "active" : "history"
 
-  <PageLoaderWrapper screenState>
+  switch deEntryState {
+  | #Checking => <PageLoaderWrapper screenState=PageLoaderWrapper.Loading> {React.null} </PageLoaderWrapper>
+  | #Redirected =>
+    <DefaultLandingPage
+      height="90%"
+      title="Routing is managed in the Decision Engine — opened in a new tab."
+      customStyle="py-16"
+      overridingStylesTitle="text-3xl font-semibold"
+    />
+  | #Local =>
+    <PageLoaderWrapper screenState>
     <div className={`${widthClass} ${marginClass} gap-2.5`}>
       <div className="flex flex-col">
         <PageUtils.PageHeading title="Smart Routing Configurations" />
@@ -152,4 +193,5 @@ let make = (~remainingPath, ~previewOnly=false) => {
       </RenderIf>
     </div>
   </PageLoaderWrapper>
+  }
 }

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -12,8 +12,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let (routingType, setRoutingType) = React.useState(_ => [])
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (tabIndex, setTabIndex) = React.useState(_ => 0)
-  let (deEntryState, setDeEntryState) = React.useState(_ => previewOnly ? #Local : #Checking)
-  let (isCutover, setIsCutover) = React.useState(_ => false)
+  let (isCutover, setIsCutover) = React.useState(_ => previewOnly ? Some(false) : None)
   let debitRoutingValue =
     (
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
@@ -22,6 +21,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let showToast = ToastState.useShowToast()
   let {profileId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
+  let isCutoverEnabled = isCutover->Option.getOr(false)
 
   let (widthClass, marginClass) = React.useMemo(() => {
     previewOnly ? ("w-full", "mx-auto") : ("w-full", "mx-auto ")
@@ -33,7 +33,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
     let baseTabs = [
       {
         title: "Active configuration",
-        renderContent: () => <ActiveRouting routingType isCutover />,
+        renderContent: () => <ActiveRouting routingType isCutover=isCutoverEnabled />,
       },
     ]
     hasWorkflowsManageAccess
@@ -53,7 +53,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutover))
+  }, (routingType, debitRoutingValue, isCutoverEnabled))
 
   let fetchRoutingRecords = async activeIds => {
     try {
@@ -133,10 +133,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
       let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
       let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
-      setIsCutover(_ => cutover)
-      setDeEntryState(_ => #Local)
+      setIsCutover(_ => Some(cutover))
     } catch {
-    | Exn.Error(_) => setDeEntryState(_ => #Local)
+    | Exn.Error(_) => setIsCutover(_ => Some(false))
     }
   }
 
@@ -167,39 +166,39 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   let getTabName = index => index == 0 ? "active" : "history"
 
-  switch deEntryState {
-  | #Checking =>
-    <PageLoaderWrapper screenState=PageLoaderWrapper.Loading> {React.null} </PageLoaderWrapper>
-  | #Local =>
-    <PageLoaderWrapper screenState>
-      <div className={`${widthClass} ${marginClass} gap-2.5`}>
-        <div className="flex flex-col">
-          <PageUtils.PageHeading title="Smart Routing Configurations" />
-          <ActiveRouting.LevelWiseRoutingSection
-            types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
-            onRedirectBaseUrl="routing"
-            isCutover
-            onDeRedirect={target => openDeRoutingPage(target)->ignore}
+  let screenState = switch isCutover {
+  | None => PageLoaderWrapper.Loading
+  | Some(_) => screenState
+  }
+
+  <PageLoaderWrapper screenState>
+    <div className={`${widthClass} ${marginClass} gap-2.5`}>
+      <div className="flex flex-col">
+        <PageUtils.PageHeading title="Smart Routing Configurations" />
+        <ActiveRouting.LevelWiseRoutingSection
+          types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
+          onRedirectBaseUrl="routing"
+          isCutover=isCutoverEnabled
+          onDeRedirect={target => openDeRoutingPage(target)->ignore}
+        />
+      </div>
+      <RenderIf condition={!previewOnly}>
+        <div className="flex flex-col gap-12">
+          <EntityScaffold
+            entityName="HyperSwitch Priority Logic"
+            remainingPath
+            renderList={() =>
+              <Tabs
+                initialIndex={tabIndex >= 0 ? tabIndex : 0}
+                tabs
+                onTitleClick={index => {
+                  setTabIndex(_ => index)
+                  setCurrentTabName(_ => getTabName(index))
+                }}
+              />}
           />
         </div>
-        <RenderIf condition={!previewOnly}>
-          <div className="flex flex-col gap-12">
-            <EntityScaffold
-              entityName="HyperSwitch Priority Logic"
-              remainingPath
-              renderList={() =>
-                <Tabs
-                  initialIndex={tabIndex >= 0 ? tabIndex : 0}
-                  tabs
-                  onTitleClick={index => {
-                    setTabIndex(_ => index)
-                    setCurrentTabName(_ => getTabName(index))
-                  }}
-                />}
-            />
-          </div>
-        </RenderIf>
-      </div>
-    </PageLoaderWrapper>
-  }
+      </RenderIf>
+    </div>
+  </PageLoaderWrapper>
 }

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -12,7 +12,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let (routingType, setRoutingType) = React.useState(_ => [])
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (tabIndex, setTabIndex) = React.useState(_ => 0)
-  let (isCutover, setIsCutover) = React.useState(_ => previewOnly ? Some(false) : None)
+  let (cutoverStatus, setCutoverStatus) = React.useState(_ => previewOnly ? Some(false) : None)
   let debitRoutingValue =
     (
       HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
@@ -21,7 +21,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let showToast = ToastState.useShowToast()
   let {profileId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
-  let isCutoverEnabled = isCutover->Option.getOr(false)
+  let isCutover = cutoverStatus->Option.getOr(false)
 
   let (widthClass, marginClass) = React.useMemo(() => {
     previewOnly ? ("w-full", "mx-auto") : ("w-full", "mx-auto ")
@@ -33,7 +33,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
     let baseTabs = [
       {
         title: "Active configuration",
-        renderContent: () => <ActiveRouting routingType isCutover=isCutoverEnabled />,
+        renderContent: () => <ActiveRouting routingType isCutover />,
       },
     ]
     hasWorkflowsManageAccess
@@ -53,7 +53,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutoverEnabled))
+  }, (routingType, debitRoutingValue, isCutover))
 
   let fetchRoutingRecords = async activeIds => {
     try {
@@ -133,9 +133,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
       let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
       let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
-      setIsCutover(_ => Some(cutover))
+      setCutoverStatus(_ => Some(cutover))
     } catch {
-    | Exn.Error(_) => setIsCutover(_ => Some(false))
+    | Exn.Error(_) => setCutoverStatus(_ => Some(false))
     }
   }
 
@@ -159,6 +159,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   React.useEffect(() => {
     if !previewOnly {
+      setCutoverStatus(_ => None)
       checkRoutingEntry()->ignore
     }
     None
@@ -166,7 +167,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   let getTabName = index => index == 0 ? "active" : "history"
 
-  let screenState = switch isCutover {
+  let screenState = switch cutoverStatus {
   | None => PageLoaderWrapper.Loading
   | Some(_) => screenState
   }
@@ -178,7 +179,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
         <ActiveRouting.LevelWiseRoutingSection
           types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
           onRedirectBaseUrl="routing"
-          isCutover=isCutoverEnabled
+          isCutover
           onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
         />
       </div>

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -139,7 +139,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
-  let openDeRoutingPage = async target => {
+  let openDecisionEngineRoutingPage = async target => {
     open LogicUtils
     try {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
@@ -179,7 +179,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
           onRedirectBaseUrl="routing"
           isCutover=isCutoverEnabled
-          onDeRedirect={target => openDeRoutingPage(target)->ignore}
+          onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
         />
       </div>
       <RenderIf condition={!previewOnly}>

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -125,7 +125,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   React.useEffect(() => {
     fetchActiveRouting()->ignore
     None
-  }, (pathVar, url.search, debitRoutingValue))
+  }, (pathVar, url.search, debitRoutingValue, profileId))
 
   let checkRoutingEntry = async () => {
     open LogicUtils

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -20,6 +20,8 @@ let make = (~remainingPath, ~previewOnly=false) => {
     ).is_debit_routing_enabled->Option.getOr(false)
   let setCurrentTabName = Recoil.useSetRecoilState(HyperswitchAtom.currentTabNameRecoilAtom)
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
+  let showToast = ToastState.useShowToast()
+  let {profileId} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
 
   let (widthClass, marginClass) = React.useMemo(() => {
     previewOnly ? ("w-full", "mx-auto") : ("w-full", "mx-auto ")
@@ -148,16 +150,20 @@ let make = (~remainingPath, ~previewOnly=false) => {
         redirectUrl->Window._open
       }
     } catch {
-    | Exn.Error(_) => ()
+    | Exn.Error(_) =>
+      showToast(
+        ~message="Failed to open Decision Engine routing. Please try again.",
+        ~toastType=ToastState.ToastError,
+      )
     }
   }
 
-  React.useEffect0(() => {
+  React.useEffect(() => {
     if !previewOnly {
       checkRoutingEntry()->ignore
     }
     None
-  })
+  }, [profileId])
 
   let getTabName = index => index == 0 ? "active" : "history"
 

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -125,7 +125,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   React.useEffect(() => {
     fetchActiveRouting()->ignore
     None
-  }, (pathVar, url.search, debitRoutingValue, profileId))
+  }, (pathVar, url.search, debitRoutingValue))
 
   let checkRoutingEntry = async () => {
     open LogicUtils

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -26,6 +26,17 @@ let routingTypeName = routingType => {
   }
 }
 
+// `target` value sent to POST /routing/entry?target=... for a cut-over profile, so the backend can
+// deep-link the card to its Decision Engine page. Empty string for cards that stay Hyperswitch-local.
+let deRoutingTarget = routingType => {
+  switch routingType {
+  | VOLUME_SPLIT => "volume"
+  | ADVANCED => "rule"
+  | AUTH_RATE_ROUTING => "multi_objective"
+  | _ => ""
+  }
+}
+
 let getRoutingPayload = (data, routingType, name, description, profileId) => {
   let connectorsOrder =
     [("data", data->JSON.Encode.array), ("type", routingType->JSON.Encode.string)]->Dict.fromArray
@@ -69,7 +80,7 @@ let getModalObj = (routingType, text) => {
   }
 }
 
-let getContent = routetype =>
+let getContent = (~isCutover=false, routetype) =>
   switch routetype {
   | DEFAULTFALLBACK => {
       heading: "Default Fallback ",
@@ -83,10 +94,17 @@ let getContent = routetype =>
       heading: "Rule Based Configuration",
       subHeading: "Route traffic across processors with advanced logic rules on the basis of various payment parameters",
     }
-  | AUTH_RATE_ROUTING => {
-      heading: "Auth Rate Based Routing",
-      subHeading: "Dynamically route payments to maximise payment authorization rates",
-    }
+  | AUTH_RATE_ROUTING =>
+    // For cut-over (Decision Engine) profiles this card is the DE "Multi-objective" strategy.
+    isCutover
+      ? {
+          heading: "Multi Objective",
+          subHeading: "Route payments across multiple objectives — authorization rate, cost, and reliability — optimized by the Decision Engine",
+        }
+      : {
+          heading: "Auth Rate Based Routing",
+          subHeading: "Dynamically route payments to maximise payment authorization rates",
+        }
   | _ => {
       heading: "",
       subHeading: "",

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -26,8 +26,6 @@ let routingTypeName = routingType => {
   }
 }
 
-// `target` value sent to POST /routing/entry?target=... for a cut-over profile, so the backend can
-// deep-link the card to its Decision Engine page. Empty string for cards that stay Hyperswitch-local.
 let deRoutingTarget = routingType => {
   switch routingType {
   | VOLUME_SPLIT => "volume"
@@ -95,7 +93,6 @@ let getContent = (~isCutover=false, routetype) =>
       subHeading: "Route traffic across processors with advanced logic rules on the basis of various payment parameters",
     }
   | AUTH_RATE_ROUTING =>
-    // For cut-over (Decision Engine) profiles this card is the DE "Multi-objective" strategy.
     isCutover
       ? {
           heading: "Multi Objective",

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -95,7 +95,7 @@ let getContent = (~isCutover=false, routetype) =>
   | AUTH_RATE_ROUTING =>
     isCutover
       ? {
-          heading: "Multi Objective",
+          heading: "Multi Objective Routing",
           subHeading: "Route payments across multiple objectives — authorization rate, cost, and reliability — optimized by the Decision Engine",
         }
       : {

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -26,7 +26,7 @@ let routingTypeName = routingType => {
   }
 }
 
-let deRoutingTarget = routingType => {
+let decisionEngineRoutingTarget = routingType => {
   switch routingType {
   | VOLUME_SPLIT => "volume"
   | ADVANCED => "rule"


### PR DESCRIPTION
Closes #5244

## What & why

When a merchant's profile is **cut over to the Decision Engine** (`routing_result_source_<profile_id> = decision_engine`), **Workflow → Routing** now renders Hyperswitch's own routing cards, but each card **deep-links to its specific Decision Engine page** (authenticated, in a new tab) instead of the local setup flow. Profiles that are *not* cut over keep the existing local routing behaviour unchanged. The routing source is decided per-profile by the backend, so the dashboard just asks and follows.

## Change

`src/screens/Routing/RoutingStack.res` — on mount (non-preview), the Routing screen asks the backend for the profile's routing source:

```
POST /routing/entry   ->   { "is_cutover": true | false }
```

- The local "Smart Routing Configurations" cards are **always** rendered (loader while checking; local render on error). `is_cutover` only decides **per-card behaviour**, not whether the screen renders.

On a **cut-over** profile, clicking a card asks the backend for a fresh, one-time deep-link to that card's DE page and opens it in a **new tab**:

```
POST /routing/entry?target=<volume|rule|multi_objective|debit>
  ->   { "redirect_url": "<de_dashboard>/routing/<page>?code=..." }
```

| Card | Cut-over behaviour | Non-cut-over |
| --- | --- | --- |
| Volume Based | → DE `/routing/volume` | local setup |
| Rule Based | → DE `/routing/rules` | local setup |
| Auth Rate → **Multi Objective** | → DE `/routing/sr` | "Auth Rate Based Routing", local setup |
| Least Cost | → DE `/routing/debit` | local modal |
| Default Fallback | **stays Hyperswitch-local** | local |

Additional UI:
- The **Auth Rate Based Routing** card is renamed to **Multi Objective** (with a DE-oriented description) for cut-over profiles, including its active-configuration label.
- Cards are reordered for all profiles: **Multi Objective → Rule → Volume → Least Cost → Default Fallback**.

The SSO code is **one-time and single-use** — never a session token — minted fresh per card click, so nothing lingers (60s TTL, consumed on exchange). The dashboard never reads config or holds any admin key.

## Backend dependency

Requires the HS backend `POST /routing/entry` (added in the corresponding `hyperswitch` PR), which:
- returns `{ is_cutover }` for the plain call (source check only, no minting), and
- on `?target=<page>` for a cut-over profile, mints a fresh one-time SSO code and returns `{ redirect_url }` deep-linking to that DE page.

## Testing

- Profile cut over to DE → cards render; clicking Volume / Rule / Multi-Objective / Least-Cost opens the matching DE page in a new tab, authenticated; Default Fallback stays in HS.
- Profile not cut over → normal routing screen, original labels, local setup flows (unchanged).
- Backend/DE unavailable → card simply doesn't navigate / falls back to local (no crash).

## Demo video

https://github.com/user-attachments/assets/373d5fc3-af06-4f2b-91d6-6a399e65acef


