### PR TITLE
fix: update clone connector modal for wallets support

### DIFF
--- a/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalHelper.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorPreview/CloneConnectorModalHelper.res
@@ -86,7 +86,7 @@ module CloneScopeSummary = {
           {"NOT INCLUDED"->React.string}
         </p>
         <div className="flex flex-wrap gap-2">
-          {["Wallets", "Bank debits"]
+          {["Bank debits"]
           ->Array.map(item =>
             <TagBinding
               key=item
@@ -101,7 +101,7 @@ module CloneScopeSummary = {
           ->React.array}
         </div>
         <p className={`${body.sm.regular} text-nd_gray-500`}>
-          {"These payment methods aren't copied. Enable them manually if needed."->React.string}
+          {"Bank debits require manual setup — they aren't included when cloning a connector."->React.string}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The Clone Connector modal's "NOT INCLUDED" section listed both "Wallets" and "Bank debits" as payment methods that aren't copied when cloning a connector. Wallets are now cloned along with credentials, webhook, and payment methods, so the modal's copy was out of date.

- Removed "Wallets" from the "NOT INCLUDED" list — only "Bank debits" remains.
- Tightened the disclaimer text to: "Bank debits require manual setup — they aren't included when cloning a connector."

## Motivation and Context

A recent backend change ensures wallets are now included when cloning a connector, but the frontend modal (`CloneConnectorModalHelper.res`) still listed wallets as excluded, which was misleading to users.

## How did you test it?

- Ran `npm run re:build` — 0 errors, 0 warnings.
- Verified the change visually against the existing Clone Connector modal screenshot/flow.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [x] Yes
- [ ] No

Backend PR URL: (wallets-included-in-clone backend change)

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
