### PR TITLE
fix: show all attempts on individual payout page

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -548,7 +548,11 @@ let useGetURL = () => {
         switch methodType {
         | Get =>
           switch id {
-          | Some(payout_id) => `payouts/${payout_id}`
+          | Some(payout_id) =>
+            switch queryParameters {
+            | Some(queryParams) => `payouts/${payout_id}?${queryParams}`
+            | None => `payouts/${payout_id}`
+            }
           | None =>
             switch transactionEntity {
             | #Merchant => `payouts/list?limit=100`

--- a/src/screens/Payouts/ShowPayout.res
+++ b/src/screens/Payouts/ShowPayout.res
@@ -255,7 +255,7 @@ module MorePayoutDetails = {
 let make = (~id, ~profileId, ~merchantId, ~orgId) => {
   open APIUtils
   let getURL = useGetURL()
-  let fetchDetails = useUpdateMethod()
+  let fetchDetails = useGetMethod()
   let {version} = React.useContext(UserInfoProvider.defaultContext).getCommonSessionDetails()
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
@@ -265,24 +265,20 @@ let make = (~id, ~profileId, ~merchantId, ~orgId) => {
   let fetchPayoutsData = async () => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-      //TODO: Needs to be replaced with get API
-      let payoutsUrl = getURL(~entityName=V1(PAYOUTS), ~methodType=Post)
-      let filterData =
-        [
-          ("payout_id", id->JSON.Encode.string),
-          ("limit", 1->JSON.Encode.int),
-        ]->LogicUtils.getJsonFromArrayOfJson
+      let payoutsUrl = getURL(
+        ~entityName=V1(PAYOUTS),
+        ~methodType=Get,
+        ~id=Some(id),
+        ~queryParameters=Some("expand_attempts=true"),
+      )
       let _ = await internalSwitch(
         ~expectedOrgId=orgId,
         ~expectedMerchantId=merchantId,
         ~expectedProfileId=profileId,
       )
-      let response = await fetchDetails(payoutsUrl, filterData, Post)
+      let response = await fetchDetails(payoutsUrl)
       let payoutData =
         response
-        ->getDictFromJsonObject
-        ->getArrayFromDict("data", [])
-        ->getValueFromArray(0, JSON.Encode.null)
         ->getDictFromJsonObject
         ->PayoutsEntity.itemToObjMapper
       setPayoutsData(_ => payoutData)


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The individual Payout detail page (`ShowPayout.res`) showed only a single payout attempt because it fetched the payout via the list API (`POST payouts/list`, `limit=1`) and read the first row of the `data` array.

This PR:
- Fetches the payout via `GET payouts/{payout_id}?expand_attempts=true` using `useGetMethod()` and maps the response object directly.
- Honors `queryParameters` in the `PAYOUTS` GET case of `APIUtils.res`, matching the existing `ORDERS` case, so `expand_attempts` can be appended.

This mirrors how the Payments detail page (`ShowOrder.res`) loads and renders all attempts.

## Motivation and Context

Closes #5273

## How did you test it?

Ran `npm run re:build` — compiles clean (3155/3155). The "Payout Attempts" table now renders every attempt returned by the expanded retrieve response.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code