### PR TITLE
fix: refetch newly uploaded files in recon ingestion history

### DIFF
--- a/src/ReconEngine/ReconEngineContainer/ReconEnginePipelinesContainer.res
+++ b/src/ReconEngine/ReconEngineContainer/ReconEnginePipelinesContainer.res
@@ -10,19 +10,19 @@ let make = () => {
     <AccessControl
       isEnabled={featureFlagDetails.devReconEngineV1 && featureFlagDetails.devReconEnginePipelines}
       authorization={userHasAccess(~groupAccess=ReconSourcesView)}>
-      <EntityScaffold
-        entityName="IngestionHistory"
-        remainingPath
-        access=Access
-        renderList={() =>
-          <FilterContext key="recon-engine-pipelines" index="recon-engine-pipelines">
-            <ReconEnginePipelines />
-          </FilterContext>}
-        renderShow={(id, _) =>
-          <FilterContext key="recon-engine-pipeline-details" index="recon-engine-pipeline-details">
-            <ReconEnginePipelineDetails ingestionHistoryId=id />
-          </FilterContext>}
-      />
+      <FilterContext key="recon-engine-pipelines" index="recon-engine-pipelines">
+        <EntityScaffold
+          entityName="IngestionHistory"
+          remainingPath
+          access=Access
+          renderList={() => <ReconEnginePipelines />}
+          renderShow={(id, _) =>
+            <FilterContext
+              key="recon-engine-pipeline-details" index="recon-engine-pipeline-details">
+              <ReconEnginePipelineDetails ingestionHistoryId=id />
+            </FilterContext>}
+        />
+      </FilterContext>
     </AccessControl>
   | _ => React.null
   }

--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -36,6 +36,14 @@ let getEntryTypeAccountOptions = (
   getAccountOptionsFromTransactions(transactions, entryType)
 }
 
+let refreshEndTimeFilter = updateExistingKeys => {
+  updateExistingKeys(
+    Dict.fromArray([
+      (HSAnalyticsUtils.endTimeFilterKey, HSwitchRemoteFilter.getDateFilteredObject().end_time),
+    ]),
+  )
+}
+
 let buildQueryStringFromFilters = (~filterValueJson: Dict.t<JSON.t>) => {
   let queryParts = []
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataSources/ReconEngineDataSourcesDetails/ReconEngineDataSourceDetailsConfig.res
@@ -8,6 +8,7 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
   open ReconEngineDataSourcesTypes
 
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
+  let {updateExistingKeys} = React.useContext(FilterContext.filterContext)
   let dataDict = config.data->getDictFromJsonObject
   let ingestionType = dataDict->getString("ingestion_type", "")
   let allKeyValuePairs = getKeyValuePairsFromDict(dataDict)
@@ -134,6 +135,10 @@ let make = (~config: ReconEngineTypes.ingestionConfigType, ~isUploading, ~setIsU
         `${successCount->Int.toString} uploaded, ${failCount->Int.toString} failed.`
       }
       showToast(~message, ~toastType={failCount == 0 ? ToastSuccess : ToastError})
+
+      if successCount > 0 {
+        ReconEngineFilterUtils.refreshEndTimeFilter(updateExistingKeys)
+      }
     }
   }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelines.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelines.res
@@ -47,33 +47,35 @@ let make = () => {
   }, [])
 
   <div className="flex flex-col">
-    <div className="flex flex-row justify-between items-center">
+    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
       <PageHeading
-        title="Pipelines" customTitleStyle={`${heading.lg.semibold}`} customHeadingStyle="py-0"
+        title="Pipelines"
+        customTitleStyle={`${heading.lg.semibold}`}
+        customHeadingStyle="py-0 !mb-0"
       />
-      <div className="flex flex-row items-start gap-3">
-        <DynamicFilter
-          title="ReconEnginePipelinesFilters"
-          initialFilters=[]
-          options=[]
-          popupFilterFields=[]
-          initialFixedFilters={HSAnalyticsUtils.initialFixedFilterFields(
-            null,
-            ~events=dateDropDownTriggerMixpanelCallback,
-          )}
-          defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
-          tabNames=filterKeys
-          key="ReconEnginePipelinesFilters"
-          updateUrlWith=updateExistingKeys
-          filterFieldsPortalName={HSAnalyticsUtils.filterFieldsPortalName}
-          showCustomFilter=false
-          refreshFilters=false
-        />
-        <div className="mt-5">
-          <ReconEnginePipelinesUploadModal
-            accountData onClose={() => setRefreshTrigger(prev => !prev)}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="-mt-8 lg:-mt-4 -mb-2">
+          <DynamicFilter
+            title="ReconEnginePipelinesFilters"
+            initialFilters=[]
+            options=[]
+            popupFilterFields=[]
+            initialFixedFilters={HSAnalyticsUtils.initialFixedFilterFields(
+              null,
+              ~events=dateDropDownTriggerMixpanelCallback,
+            )}
+            defaultFilterKeys=[startTimeFilterKey, endTimeFilterKey]
+            tabNames=filterKeys
+            key="ReconEnginePipelinesFilters"
+            updateUrlWith=updateExistingKeys
+            filterFieldsPortalName={HSAnalyticsUtils.filterFieldsPortalName}
+            showCustomFilter=false
+            refreshFilters=false
           />
         </div>
+        <ReconEnginePipelinesUploadModal
+          accountData onModalToggle={() => setRefreshTrigger(prev => !prev)}
+        />
       </div>
     </div>
     <ReconEnginePipelinesStatCards refreshTrigger />

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesUploadModal.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesUploadModal.res
@@ -33,6 +33,7 @@ module UploadDropzone = {
     open ReconEnginePipelinesTypes
 
     let showToast = ToastAdapter.useShowToast()
+    let {updateExistingKeys} = React.useContext(FilterContext.filterContext)
     let (selectedFiles, setSelectedFiles) = React.useState(_ => [])
     let (isUploading, setIsUploading) = React.useState(_ => false)
     let (isDraggingFile, setIsDraggingFile) = React.useState(_ => false)
@@ -154,6 +155,9 @@ module UploadDropzone = {
         }
         showToast(~message, ~toastType={failCount == 0 ? ToastSuccess : ToastError})
 
+        if successCount > 0 {
+          ReconEngineFilterUtils.refreshEndTimeFilter(updateExistingKeys)
+        }
         if failCount == 0 {
           onUploadSuccess()
         }
@@ -413,17 +417,14 @@ module UploadModalBody = {
 }
 
 @react.component
-let make = (~accountData: array<ReconEngineTypes.accountType>, ~onClose: unit => unit) => {
+let make = (~accountData: array<ReconEngineTypes.accountType>, ~onModalToggle: unit => unit) => {
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let (showModal, setShowModal) = React.useState(_ => false)
   let authorization = userHasAccess(~groupAccess=UserManagementTypes.ReconSourcesManage)
 
   let handleSetShowModal = (updater: bool => bool) => {
-    let next = updater(showModal)
-    setShowModal(_ => next)
-    if !next {
-      onClose()
-    }
+    setShowModal(_ => updater(showModal))
+    onModalToggle()
   }
 
   <>
@@ -433,7 +434,7 @@ let make = (~accountData: array<ReconEngineTypes.accountType>, ~onClose: unit =>
       buttonType=Primary
       buttonSize=Small
       authorization
-      onClick={_ => setShowModal(_ => true)}
+      onClick={_ => handleSetShowModal(_ => true)}
     />
     <RenderIf condition=showModal>
       <Modal


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

After uploading a file, the newly created ingestion run never appeared in the history — on the Pipelines page or on Data → Sources → details — until the user navigated away and back.

The refetch was firing correctly all along. The problem was the request it sent: `end_time` is captured once at page load by `HSwitchRemoteFilter.getDateFilteredObject` (second precision) and never moves, so a file ingested a minute later has `created_at` past the upper bound of the window and the API filters it out — however many times we refetch.

- Added `ReconEngineFilterUtils.refreshEndTimeFilter`, which pushes the range's upper bound to now.
- Called it after a successful upload in both upload paths: `ReconEnginePipelinesUploadModal.res` and `ReconEngineDataSourceDetailsConfig.res`. It fires on `successCount > 0` so partial uploads are covered too. Since `filterValue` is already a dependency of every history/stat-card effect, this doubles as the refetch trigger.
- Pipelines upload modal: `onClose` → `onModalToggle`, now fired on open as well as close, so the listing refreshes around the whole modal lifecycle.

Also fixed the page header on Pipelines, where the date filter and Upload button were not on the same line and the row squashed instead of wrapping on narrow viewports:

- `PageUtils.PageHeading` hardcodes `mb-4` on its root, making its flex outer box 48px against a 32px title, which sat the heading 8px above the controls. Passed `!mb-0`.
- Replaced the `mt-5` magic number on the Upload button with `items-center`, and wrapped `DynamicFilter` in `-mt-8 lg:-mt-4 -mb-2` to cancel the dead space `Filter` reserves regardless of content (a 16px `mb-4` spacer for an empty `customLeftView`, 8px `mb-2` under the row, plus another 16px below `lg` where `Filter` stacks its empty left group above the filters). Keyed to the same `lg` breakpoint `Filter` itself uses.
- Header now wraps (`flex-wrap`, `gap-x-4 gap-y-2`) instead of overflowing.

## Motivation and Context

Fixes #5282.

Uploading a file and seeing nothing appear reads as a failed upload. Users were reloading or navigating away and back to confirm their file had landed.

Worth noting alongside #5279 (`persistFilters=true` for the pipelines `FilterContext`): filters are held in `sessionStorage`, so a plain reload already does *not* clear the stale `end_time` — I confirmed the table still returns 0 rows after reloading. Once #5279 lands, navigating away and back won't mask it either, so this fix becomes load-bearing rather than a nicety.

## How did you test it?

Manually, end to end against a local dashboard, driving the real upload modal and reading the network panel:

1. Uploaded a CSV via Pipelines → Upload. `POST /ingestions/ing_.../upload` returned 200 and three refetches fired immediately after — all carrying `end_time=2026-07-30T11:15:36Z`, the page-load timestamp. The created row's `created_at` was `11:17:53Z`, 2m17s past the window, and the response was `[]`.
2. Same server, same second, only `end_time` differing:

   | `end_time` | rows |
   |---|---|
   | `2026-07-30T11:15:36Z` (pinned at page load) | 0 |
   | now | 1 |

3. With the fix in place, uploaded again: table went from "No Data Available" to showing both rows, the Ingestion Runs stat card went 0 → 2, and the date range moved 4:45 PM → 4:52 PM — no reload, no navigation.

Header alignment verified by measuring bounding boxes in the browser at three widths:

| width | heading midY | date picker midY | upload button midY | horizontal overflow |
|---|---|---|---|---|
| 1728 | 127 | 127 | 127 | none |
| 1180 | wraps to line 1 | 167 | 167 | none |
| 820 | wraps to line 1 | 166 | 166 | none |

`npm run re:build` — clean.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
