### PR TITLE
feat: add column customization to recon engine tables

### DIFF
--- a/src/Recoils/TableAtoms.res
+++ b/src/Recoils/TableAtoms.res
@@ -44,3 +44,23 @@ let transactionsHierarchicalDefaultCols = Recoil.atom(
   "transactionsHierarchicalDefaultCols",
   HierarchicalTransactionsTableEntity.defaultColumns,
 )
+
+let reconTransformedEntriesDefaultCols = Recoil.atom(
+  "reconTransformedEntriesDefaultCols",
+  ReconEngineExceptionEntity.processingDefaultColumns,
+)
+
+let reconStagingEntriesDefaultCols = Recoil.atom(
+  "reconStagingEntriesDefaultCols",
+  ReconEngineExceptionEntity.processingDefaultColumns,
+)
+
+let reconOverviewTransformedEntriesDefaultCols = Recoil.atom(
+  "reconOverviewTransformedEntriesDefaultCols",
+  ReconEngineExceptionEntity.processingDefaultColumns,
+)
+
+let reconTransformedEntryExceptionsDefaultCols = Recoil.atom(
+  "reconTransformedEntryExceptionsDefaultCols",
+  ReconEngineExceptionEntity.processingDefaultColumns,
+)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewTransformedEntries.res
@@ -150,8 +150,13 @@ let make = (
       <ReconEngineDataTransformedEntriesOverviewCards
         selectedTransformationHistoryId=Some(selectedTransformationHistoryId)
       />
-      <div className="flex-shrink-0"> {topFilterUi} </div>
-      <LoadedTable
+      <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+        <div className="flex-1"> {topFilterUi} </div>
+        <PortalCapture
+          key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+        />
+      </div>
+      <LoadedTableWithCustomColumns
         title
         hideTitle=true
         actualData={processingEntries->Array.map(Nullable.make)}
@@ -161,6 +166,10 @@ let make = (
         offset
         setOffset
         currentFetchCount={processingEntries->Array.length}
+        customColumnMapper=TableAtoms.reconOverviewTransformedEntriesDefaultCols
+        defaultColumns={ReconEngineExceptionEntity.processingMandatoryColumns}
+        showSerialNumberInCustomizeColumns=false
+        sortingBasedOnDisabled=false
         tableheadingClass="h-12"
         tableHeadingTextClass="!font-normal"
         nonFrozenTableParentClass="!rounded-lg"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
@@ -158,8 +158,13 @@ let make = () => {
     <ReconEngineDataTransformedEntriesOverviewCards selectedTransformationHistoryId=None />
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-4">
-        <div className="flex-shrink-0"> {topFilterUi} </div>
-        <LoadedTable
+        <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+          <div className="flex-1"> {topFilterUi} </div>
+          <PortalCapture
+            key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+          />
+        </div>
+        <LoadedTableWithCustomColumns
           title
           hideTitle=true
           actualData={processingEntries->Array.map(Nullable.make)}
@@ -169,6 +174,10 @@ let make = () => {
           offset
           setOffset
           currentFetchCount={processingEntries->Array.length}
+          customColumnMapper=TableAtoms.reconTransformedEntriesDefaultCols
+          defaultColumns={ReconEngineExceptionEntity.processingMandatoryColumns}
+          showSerialNumberInCustomizeColumns=false
+          sortingBasedOnDisabled=false
           tableheadingClass="h-12"
           tableHeadingTextClass="!font-normal"
           nonFrozenTableParentClass="!rounded-lg"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionEntity.res
@@ -15,6 +15,22 @@ type processingColType =
   | Actions
   | ExceptionType
 
+let processingAllColumns = [
+  StagingEntryId,
+  TransformationHistoryId,
+  EntryType,
+  AccountName,
+  Amount,
+  Currency,
+  Status,
+  EffectiveAt,
+  OrderId,
+  Actions,
+  ExceptionType,
+]
+
+let processingMandatoryColumns = [EffectiveAt, Amount, Status]
+
 let processingDefaultColumns = [
   EffectiveAt,
   OrderId,
@@ -127,6 +143,7 @@ let processingTableEntity = EntityType.makeEntity(
   ~uri="",
   ~getObjects=_ => [],
   ~defaultColumns=processingDefaultColumns,
+  ~allColumns=processingAllColumns,
   ~getHeading=getProcessingHeading,
   ~getCell=getProcessingCell,
   ~dataKey="",
@@ -140,6 +157,7 @@ let transformedEntryExceptionTableEntity = (
     ~uri="",
     ~getObjects=_ => [],
     ~defaultColumns=processingDefaultColumns,
+    ~allColumns=processingAllColumns,
     ~getHeading=getProcessingHeading,
     ~getCell=getProcessingCell,
     ~dataKey="",

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
@@ -182,7 +182,12 @@ let make = (~ruleId: string) => {
 
   <div className="flex flex-col gap-4 mt-3">
     <PageLoaderWrapper screenState>
-      <div className="flex-shrink-0"> {topFilterUi} </div>
+      <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+        <div className="flex-1"> {topFilterUi} </div>
+        <PortalCapture
+          key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+        />
+      </div>
       <RenderIf condition={transactions->isEmptyArray}>
         <div className="h-40-vh flex flex-col justify-center items-center gap-2">
           <p className={`${heading.sm.semibold} text-nd_gray-800`}>
@@ -210,7 +215,7 @@ let make = (~ruleId: string) => {
           setOffset
           currentFetchCount={transactions->Array.length}
           customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
-          defaultColumns
+          defaultColumns={HierarchicalTransactionsTableEntity.mandatoryColumns}
           showSerialNumberInCustomizeColumns=false
           sortingBasedOnDisabled=false
           remoteSortEnabled=true
@@ -218,8 +223,6 @@ let make = (~ruleId: string) => {
           showResultsPerPageSelector=false
           tableDataLoading={screenState === PageLoaderWrapper.Loading}
           dataLoading={screenState === PageLoaderWrapper.Loading}
-          customizeColumnButtonIcon="nd-filter-horizontal"
-          hideRightTitleElement=true
           showAutoScroll=true
           customSeparation=[(3, 4)]
           filters={<SearchInput

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptions.res
@@ -143,7 +143,12 @@ let make = () => {
     </div>
     <PageLoaderWrapper screenState>
       <div className="flex flex-col gap-4">
-        <div className="flex-shrink-0"> {topFilterUi} </div>
+        <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+          <div className="flex-1"> {topFilterUi} </div>
+          <PortalCapture
+            key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+          />
+        </div>
         <RenderIf condition={processingEntries->isEmptyArray}>
           <div className="h-40-vh flex flex-col justify-center items-center gap-2">
             <p className={`${heading.sm.semibold} text-nd_gray-800`}>
@@ -155,7 +160,7 @@ let make = () => {
           </div>
         </RenderIf>
         <RenderIf condition={processingEntries->isNonEmptyArray}>
-          <LoadedTable
+          <LoadedTableWithCustomColumns
             title
             hideTitle=true
             actualData={processingEntries->Array.map(Nullable.make)}
@@ -168,6 +173,10 @@ let make = () => {
             offset
             setOffset
             currentFetchCount={processingEntries->Array.length}
+            customColumnMapper=TableAtoms.reconTransformedEntryExceptionsDefaultCols
+            defaultColumns={ReconEngineExceptionEntity.processingMandatoryColumns}
+            showSerialNumberInCustomizeColumns=false
+            sortingBasedOnDisabled=false
             tableheadingClass="h-12"
             tableHeadingTextClass="!font-normal"
             nonFrozenTableParentClass="!rounded-lg"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewTransactions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewDetails/ReconEngineOverviewDetailsComponents/ReconEngineOverviewTransactions.res
@@ -96,7 +96,12 @@ let make = (~ruleDetails: ReconEngineRulesTypes.rulePayload) => {
     </div>
 
   <div className="flex flex-col gap-4">
-    <div className="flex-shrink-0"> {statusFilterUi} </div>
+    <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+      <div className="flex-1"> {statusFilterUi} </div>
+      <PortalCapture
+        key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+      />
+    </div>
     <PageLoaderWrapper screenState customLoader={<Shimmer styleClass="w-full h-96 rounded-xl" />}>
       <LoadedTableWithCustomColumns
         title
@@ -114,7 +119,7 @@ let make = (~ruleDetails: ReconEngineRulesTypes.rulePayload) => {
         setOffset
         currentFetchCount={transactions->Array.length}
         customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
-        defaultColumns
+        defaultColumns={HierarchicalTransactionsTableEntity.mandatoryColumns}
         showSerialNumberInCustomizeColumns=false
         sortingBasedOnDisabled=false
         remoteSortEnabled=true
@@ -122,8 +127,6 @@ let make = (~ruleDetails: ReconEngineRulesTypes.rulePayload) => {
         showResultsPerPageSelector=false
         tableDataLoading={screenState === PageLoaderWrapper.Loading}
         dataLoading={screenState === PageLoaderWrapper.Loading}
-        customizeColumnButtonIcon="nd-filter-horizontal"
-        hideRightTitleElement=true
         showAutoScroll=true
         customSeparation=[(3, 4)]
         filters={<SearchInput

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelineDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelineDetails.res
@@ -267,7 +267,7 @@ let make = (~ingestionHistoryId: string) => {
               <p className={`${body.md.semibold} text-nd_gray-800`}>
                 {"Transformed Entries"->React.string}
               </p>
-              <div className="flex flex-row -ml-1.5">
+              <div className="flex flex-row justify-between items-start gap-3 -ml-1.5">
                 <DynamicFilter
                   title="ReconEnginePipelineDetailsStagingFilters"
                   initialFilters=stagingEntriesFilters
@@ -283,8 +283,13 @@ let make = (~ingestionHistoryId: string) => {
                   refreshFilters=false
                   setOffset
                 />
+                <PortalCapture
+                  key={`${stagingTableTitle}CustomizeColumn`}
+                  name={`${stagingTableTitle}CustomizeColumn`}
+                  customStyle="mt-4"
+                />
               </div>
-              <LoadedTable
+              <LoadedTableWithCustomColumns
                 title=stagingTableTitle
                 hideTitle=true
                 actualData={stagingEntries->Array.map(Nullable.make)}
@@ -294,6 +299,10 @@ let make = (~ingestionHistoryId: string) => {
                 offset
                 setOffset
                 currentFetchCount={stagingEntries->Array.length}
+                customColumnMapper=TableAtoms.reconStagingEntriesDefaultCols
+                defaultColumns={ReconEngineExceptionEntity.processingMandatoryColumns}
+                showSerialNumberInCustomizeColumns=false
+                sortingBasedOnDisabled=false
                 tableheadingClass="h-11"
                 tableHeadingTextClass="!font-normal"
                 nonFrozenTableParentClass="!rounded-none !border-0 !shadow-none"

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
@@ -30,6 +30,8 @@ let defaultColumns: array<hierarchicalColType> = [
   CreditAmount,
 ]
 
+let mandatoryColumns: array<hierarchicalColType> = [Flow, Date, TransactionId, Status]
+
 let allColumns: array<hierarchicalColType> = [
   Flow,
   Date,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsContent.res
@@ -1,5 +1,4 @@
 open ReconEngineTypes
-open HierarchicalTransactionsTableEntity
 
 @react.component
 let make = (
@@ -110,7 +109,12 @@ let make = (
 
   <div className="flex flex-col gap-4 mt-3">
     <PageLoaderWrapper screenState>
-      <div className="flex-shrink-0"> {topFilterUi} </div>
+      <div className="flex flex-row justify-between items-start gap-3 flex-shrink-0">
+        <div className="flex-1"> {topFilterUi} </div>
+        <PortalCapture
+          key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="mt-4"
+        />
+      </div>
       <LoadedTableWithCustomColumns
         title
         hideTitle=true
@@ -127,7 +131,7 @@ let make = (
         setOffset
         currentFetchCount={transactions->Array.length}
         customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
-        defaultColumns
+        defaultColumns={HierarchicalTransactionsTableEntity.mandatoryColumns}
         showPagination=false
         showResultsPerPageSelector=false
         remoteSortEnabled=true
@@ -135,7 +139,6 @@ let make = (
         dataLoading={screenState === PageLoaderWrapper.Loading}
         tableheadingClass="bg-gray-50"
         showAutoScroll=true
-        hideCustomisableColumnButton=true
         customSeparation=[(3, 4)]
         filters={<SearchInput
           inputText=searchText

--- a/src/components/LoadedTableWithCustomColumns/LoadedTableWithCustomColumns.res
+++ b/src/components/LoadedTableWithCustomColumns/LoadedTableWithCustomColumns.res
@@ -34,6 +34,9 @@ let make = (
   ~renderCard=?,
   ~tableLocalFilter=false,
   ~tableheadingClass="",
+  ~tableHeadingTextClass="",
+  ~nonFrozenTableParentClass="",
+  ~loadedTableParentClass="",
   ~tableBorderClass="",
   ~tableDataBorderClass="",
   ~collapseTableRow=false,
@@ -158,6 +161,9 @@ let make = (
     ?setFilterObj
     ?filterIcon
     tableheadingClass
+    tableHeadingTextClass
+    nonFrozenTableParentClass
+    loadedTableParentClass
     tableDataBackgroundClass
     showPagination
     showResultsPerPageSelector


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Enables the customize-columns picker (the same one used by Orders/Payouts in orchestration) across recon engine tables. Users can now choose which columns are visible per table, with selections persisted in localStorage per table title.

Tables enabled:
- Transactions, Exception Transactions, Overview Transactions (already used `LoadedTableWithCustomColumns`, but the button was hidden — the portal target `${title}CustomizeColumn` was never mounted, and `hideCustomisableColumnButton` / `hideRightTitleElement` suppressed it)
- All Transformed Entries, Pipeline Details staging entries, Data Overview transformed entries, Transformed Entry Exceptions (swapped from plain `LoadedTable` to `LoadedTableWithCustomColumns`)

Key changes:
- `LoadedTableWithCustomColumns.res`: forward `tableHeadingTextClass`, `nonFrozenTableParentClass`, `loadedTableParentClass` to `LoadedTable` (used by recon tables, previously dropped by the wrapper)
- `ReconEngineExceptionEntity.res`: add `processingAllColumns` (picker option list) and `processingMandatoryColumns` (`EffectiveAt`, `Amount`, `Status` — locked in the picker); wire `~allColumns` into both processing entities. The picker disables every column present in the `defaultColumns` prop, and recon entities defined `defaultColumns == allColumns`, so passing a small mandatory subset is what makes columns actually toggleable
- `HierarchicalTransactionsTableEntity.res`: add `mandatoryColumns` (`Flow`, `Date`, `TransactionId`, `Status`) for the three transactions tables
- `TableAtoms.res`: four new Recoil atoms for the newly enabled tables; initial visible columns are unchanged from before
- Screens: mount a `PortalCapture` for `${title}CustomizeColumn` beside each filter row (`items-start` + `mt-4` so the button aligns with the date picker, matching the filter's internal 16px top offset), and use the default `customise-columns` icon for consistency with orchestration

## Motivation and Context

Fixes #5288.

Orchestration tables let users tailor visible columns to their workflow; recon engine tables had fixed columns even where the customizable table component was already in use.

## How did you test it?

Compiled with rescript build — clean. Manually verified locally on sandbox: the customize button appears in line with the filter row on each enabled table, the picker opens with mandatory columns locked and the rest toggleable, selections apply to the table, and persist across reloads via localStorage.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


<img width="1622" height="974" alt="Screenshot 2026-07-31 at 4 56 10 AM" src="https://github.com/user-attachments/assets/21eb9710-65ad-44b2-8ce8-380a42d8dc7f" />
