### PR TITLE
fix: use accurate platform analytics banner copy for org filter

### DIFF
--- a/src/screens/Analytics/HSAnalyticsUtils.res
+++ b/src/screens/Analytics/HSAnalyticsUtils.res
@@ -184,12 +184,18 @@ module PlatformAggregatedDataBanner = {
   @react.component
   let make = () => {
     let {isCurrentMerchantPlatform} = OMPSwitchHooks.useOMPType()
+    let {getResolvedUserInfo} = React.useContext(UserInfoProvider.defaultContext)
+    let {analyticsEntity} = getResolvedUserInfo()
+    let description = switch analyticsEntity {
+    | #Organization => "You are viewing aggregated data from all merchant accounts under your organization, including both platform-connected and standard merchants."
+    | _ => "You are viewing aggregated data from all merchant accounts connected to your platform account."
+    }
     <RenderIf condition={isCurrentMerchantPlatform}>
       <div className="my-3 w-full">
         <AlertV2Binding
           alertType=Primary
           slot={{slot: <Icon name="nd-toast-info" size=20 className="text-nd_primary_blue-450" />}}
-          description="You are viewing aggregated data from all merchant accounts connected to your platform account."
+          description
         />
       </div>
     </RenderIf>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The Platform Analytics banner always showed the platform-specific copy ("...connected to your platform account"), even when the **Org** filter was selected. Under Org, analytics aggregate data from both platform-connected and standard merchants, so the platform-only wording was misleading.

`PlatformAggregatedDataBanner` now switches the description based on the selected `analyticsEntity`:
- **Organization**: "You are viewing aggregated data from all merchant accounts under your organization, including both platform-connected and standard merchants."
- **Merchant/Profile** (platform merchant view): unchanged existing copy.

## Motivation and Context

Fixes #5177

## How did you test it?

Verified via `npx rescript build` that the change compiles and the compiled JS produces both copy variants keyed off `analyticsEntity`.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible