### PR TITLE
fix: resolve dashboard UI and global search regressions

### DIFF
--- a/src/components/form/PillInput.res
+++ b/src/components/form/PillInput.res
@@ -1,6 +1,12 @@
 @send external focus: Dom.element => unit = "focus"
 @react.component
-let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateCheck=true) => {
+let make = (
+  ~name,
+  ~initialItems: array<string>=[],
+  ~placeholder,
+  ~duplicateCheck=true,
+  ~singleLine=false,
+) => {
   let form = ReactFinalForm.useForm()
   let (items, setItems) = React.useState(_ => initialItems)
   let (inputValue, setInputValue) = React.useState(_ => "")
@@ -8,8 +14,6 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
   let (editingItem, setEditingItem) = React.useState(_ => None)
   let (error, setError) = React.useState(_ => "")
   let (suggestion, setSuggestion) = React.useState(_ => None)
-  let enterKeyCode = 14
-
   let handleInputChange = e => {
     let value = ReactEvent.Form.target(e)["value"]
     setInputValue(_ => value)
@@ -90,8 +94,7 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
 
   let handleKeyDown = e => {
     let key = e->ReactEvent.Keyboard.key
-    let keyCode = e->ReactEvent.Keyboard.keyCode
-    if key === "Enter" || keyCode === enterKeyCode {
+    if key === "Enter" {
       ReactEvent.Keyboard.preventDefault(e)
       switch suggestion {
       | Some(suggestedEmail) => addItem(suggestedEmail)
@@ -102,8 +105,7 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
 
   let handleEditKeydown = (item, ev) => {
     let key = ev->ReactEvent.Keyboard.key
-    let keyCode = ev->ReactEvent.Keyboard.keyCode
-    if key === "Enter" || keyCode === enterKeyCode {
+    if key === "Enter" {
       ReactEvent.Keyboard.preventDefault(ev)
       saveItem(item)
     }
@@ -123,11 +125,58 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
     }
   }
 
-  <div className="w-full cursor-text" onClick={_ => handleContainerClick()}>
-    <div className="w-full flex flex-wrap gap-2 border p-2 text-sm rounded-md">
+  let scrollbarCss = `
+    .pill-input-scrollbar {
+      scrollbar-width: thin;
+      scrollbar-color: #CACFD8 transparent;
+    }
+
+    .pill-input-scrollbar::-webkit-scrollbar {
+      display: block;
+      height: 4px;
+    }
+
+    .pill-input-scrollbar::-webkit-scrollbar-thumb {
+      background-color: #CACFD8;
+      border-radius: 2px;
+    }
+
+    .pill-input-scrollbar::-webkit-scrollbar-track {
+      background-color: transparent;
+    }
+  `
+
+  let containerLayoutClass = singleLine
+    ? "pill-input-scrollbar h-14 flex-nowrap items-center overflow-x-auto overflow-y-hidden"
+    : "flex-wrap"
+  let containerPaddingClass = singleLine ? "px-2 py-1" : "p-2"
+  let pillLayoutClass = singleLine ? "flex-nowrap shrink-0" : "flex-wrap"
+  let inputWrapperClass = singleLine ? "relative flex-1 min-w-40" : "relative"
+  let inputClass = singleLine ? "w-full min-w-40" : "flex-grow"
+  let suggestionDropdown =
+    <RenderIf condition={suggestion->Option.isSome}>
+      <div
+        onClick={_ => handleSuggestionClick()}
+        className="absolute z-10 min-w-80 bg-white border rounded-md shadow-lg mt-1 cursor-pointer top-10 h-16">
+        <div className="bg-gray-200 w-full h-[calc(100%-16px)] my-2 flex items-center px-4">
+          <div className="flex items-center gap-2">
+            <Icon name="user" size=14 className="text-blue-600" />
+            <span className="font-medium"> {React.string(suggestion->Option.getOr(""))} </span>
+          </div>
+        </div>
+      </div>
+    </RenderIf>
+
+  <div className="relative w-full cursor-text" onClick={_ => handleContainerClick()}>
+    <RenderIf condition=singleLine>
+      <style> {scrollbarCss->React.string} </style>
+    </RenderIf>
+    <div
+      className={`w-full flex gap-2 border text-sm rounded-md ${containerLayoutClass} ${containerPaddingClass}`}>
       {items
       ->Array.mapWithIndex((item, i) =>
-        <div key={Int.toString(i)} className="flex flex-wrap gap-1 p-1 border rounded-md">
+        <div
+          key={Int.toString(i)} className={`flex gap-1 p-1 border rounded-md ${pillLayoutClass}`}>
           <RenderIf condition={editingItem == Some(item)}>
             <input
               onClick={event => event->ReactEvent.Mouse.stopPropagation}
@@ -152,7 +201,7 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
         </div>
       )
       ->React.array}
-      <div className="relative">
+      <div className=inputWrapperClass>
         <input
           ref={inputRef->ReactDOM.Ref.domRef}
           type_="text"
@@ -160,23 +209,13 @@ let make = (~name, ~initialItems: array<string>=[], ~placeholder, ~duplicateChec
           placeholder
           onChange=handleInputChange
           onKeyDown=handleKeyDown
-          className="outline-none p-2 flex-grow"
+          className={`outline-none p-2 ${inputClass}`}
           name
         />
-        <RenderIf condition={suggestion->Option.isSome}>
-          <div
-            onClick={_ => handleSuggestionClick()}
-            className="absolute z-10 min-w-80 bg-white border rounded-md shadow-lg mt-1 cursor-pointer top-10 h-16">
-            <div className="bg-gray-200 w-full h-[calc(100%-16px)] my-2 flex items-center px-4">
-              <div className="flex items-center gap-2">
-                <Icon name="user" size=14 className="text-blue-600" />
-                <span className="font-medium"> {React.string(suggestion->Option.getOr(""))} </span>
-              </div>
-            </div>
-          </div>
-        </RenderIf>
+        <RenderIf condition={!singleLine}> {suggestionDropdown} </RenderIf>
       </div>
     </div>
+    <RenderIf condition=singleLine> {suggestionDropdown} </RenderIf>
     <RenderIf condition={!(error->LogicUtils.isEmptyString)}>
       <div className="flex gap-1 mt-2">
         <Icon name="exclamation-circle" size=12 className="text-red-600" />

--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
@@ -220,8 +220,7 @@ let make = () => {
   }
 
   let onClipboardSuggestionClicked = (suggestion: clipboardSuggestion) => {
-    let filterKey = (suggestion.idType :> string)->camelToSnake
-    setLocalSearchText(_ => `${filterKey}:${suggestion.id}`)
+    setLocalSearchText(_ => suggestion.id)
     setFilterText("")
     setClipboardSuggestion(_ => None)
     revertFocus(~inputRef)

--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
@@ -241,12 +241,10 @@ module ClipboardSuggestion = {
   let make = (~clipboardSuggestion, ~onClipboardSuggestionClicked) => {
     switch clipboardSuggestion {
     | Some(suggestion: clipboardSuggestion) =>
-      let label = (suggestion.idType :> string)->camelToSnake
-      let displayValue = `${label} ${filterSeparator} ${suggestion.id}`
       let filter: categoryOption = {
         categoryType: Payment_id,
         options: [suggestion.id],
-        placeholder: `${label}:${suggestion.id}`,
+        placeholder: suggestion.id,
       }
 
       <Div
@@ -260,7 +258,7 @@ module ClipboardSuggestion = {
         <div>
           <FilterOption
             onClick={_ => onClipboardSuggestionClicked(suggestion)}
-            value=displayValue
+            value={suggestion.id}
             placeholder={Some("Click to search")}
             filter
             viewType=FiltersSugsestions

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
@@ -15,8 +15,8 @@ type disputesObject = {
   connector_dispute_id: string,
   connector_reason: string,
   connector_reason_code: int,
-  challenge_required_by: int,
-  connector_created_at: int,
+  challenge_required_by: float,
+  connector_created_at: float,
   connector_updated_at: int,
   created_at: float,
   modified_at: float,
@@ -111,8 +111,8 @@ let tableItemToObjMapper: Dict.t<JSON.t> => disputesObject = dict => {
     connector_dispute_id: dict->getString(ConnectorDisputeId->colMapper, "NA"),
     connector_reason: dict->getString(ConnectorReason->colMapper, "NA"),
     connector_reason_code: dict->getInt(ConnectorReasonCode->colMapper, 0),
-    challenge_required_by: dict->getInt(ChallengeRequiredBy->colMapper, 0),
-    connector_created_at: dict->getInt(ConnectorCreatedAt->colMapper, 0),
+    challenge_required_by: dict->getFloat(ChallengeRequiredBy->colMapper, 0.0),
+    connector_created_at: dict->getFloat(ConnectorCreatedAt->colMapper, 0.0),
     connector_updated_at: dict->getInt(ConnectorUpdatedAt->colMapper, 0),
     created_at: dict->getFloat(CreatedAt->colMapper, 0.0),
     modified_at: dict->getFloat(ModifiedAt->colMapper, 0.0),
@@ -229,8 +229,8 @@ let getCell = (disputeObj: disputesObject, colType): Table.cell => {
   | ConnectorDisputeId => Text(disputeObj.connector_dispute_id)
   | ConnectorReason => Text(disputeObj.connector_reason)
   | ConnectorReasonCode => Text(disputeObj.connector_reason_code->Int.toString)
-  | ChallengeRequiredBy => Text(disputeObj.challenge_required_by->Int.toString)
-  | ConnectorCreatedAt => Text(disputeObj.connector_created_at->Int.toString)
+  | ChallengeRequiredBy => Date(disputeObj.challenge_required_by->DateTimeUtils.unixToISOString)
+  | ConnectorCreatedAt => Date(disputeObj.connector_created_at->DateTimeUtils.unixToISOString)
   | ConnectorUpdatedAt => Text(disputeObj.connector_updated_at->Int.toString)
   | CreatedAt => Date(disputeObj.created_at->DateTimeUtils.unixToISOString)
   | ModifiedAt => Date(disputeObj.modified_at->DateTimeUtils.unixToISOString)

--- a/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
+++ b/src/screens/Analytics/GlobalSearchResults/GlobalSearchTables/Disputes/DisputeTableEntity.res
@@ -1,6 +1,7 @@
 let domain = "disputes"
 
 open LogicUtils
+open DateTimeUtils
 type disputesObject = {
   dispute_id: string,
   dispute_amount: float,
@@ -229,11 +230,11 @@ let getCell = (disputeObj: disputesObject, colType): Table.cell => {
   | ConnectorDisputeId => Text(disputeObj.connector_dispute_id)
   | ConnectorReason => Text(disputeObj.connector_reason)
   | ConnectorReasonCode => Text(disputeObj.connector_reason_code->Int.toString)
-  | ChallengeRequiredBy => Date(disputeObj.challenge_required_by->DateTimeUtils.unixToISOString)
-  | ConnectorCreatedAt => Date(disputeObj.connector_created_at->DateTimeUtils.unixToISOString)
+  | ChallengeRequiredBy => Date(disputeObj.challenge_required_by->unixToISOString)
+  | ConnectorCreatedAt => Date(disputeObj.connector_created_at->unixToISOString)
   | ConnectorUpdatedAt => Text(disputeObj.connector_updated_at->Int.toString)
-  | CreatedAt => Date(disputeObj.created_at->DateTimeUtils.unixToISOString)
-  | ModifiedAt => Date(disputeObj.modified_at->DateTimeUtils.unixToISOString)
+  | CreatedAt => Date(disputeObj.created_at->unixToISOString)
+  | ModifiedAt => Date(disputeObj.modified_at->unixToISOString)
   | Connector => Text(disputeObj.connector)
   | Evidence => Text(disputeObj.evidence)
   | ProfileId => Text(disputeObj.profile_id)

--- a/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/GooglePay/GooglePayIntegration.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorMetaData/GooglePay/GooglePayIntegration.res
@@ -1,6 +1,5 @@
 @react.component
 let make = (~connector, ~closeAccordionFn, ~update, ~onCloseClickCustomFun) => {
-  open Typography
   let featureFlag = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   <div className="flex flex-col gap-6 p-6 ">
@@ -12,7 +11,6 @@ let make = (~connector, ~closeAccordionFn, ~update, ~onCloseClickCustomFun) => {
           <GooglePayFlow connector closeAccordionFn update onCloseClickCustomFun />
         </RenderIf>
         <RenderIf condition={featureFlag.googlePayDirectFlow}>
-          <p className={body.md.semibold}> {"Choose Configuration Method"->React.string} </p>
           <GPayFlow connector closeAccordionFn update onCloseClickCustomFun />
         </RenderIf>
       </>

--- a/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
+++ b/src/screens/UserManagement/UserRevamp/NewUserInvitationForm.res
@@ -173,18 +173,18 @@ let make = () => {
 
   <div className="flex flex-col h-full">
     <div
-      className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 xl:gap-6 items-end p-6 !pb-10 border-b">
+      className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-6 xl:gap-6 items-start p-6 !pb-10 border-b">
       <div className="col-span-1 sm:col-span-2 lg:col-span-5 w-full">
         <FormRenderer.FieldRenderer
           field=inviteEmail labelClass="!text-black !text-base !-ml-[0.5px]"
         />
       </div>
-      <div className="col-span-1 sm:col-span-1 lg:col-span-1 w-full p-1">
+      <div className="col-span-1 sm:col-span-1 lg:col-span-1 w-full p-1 sm:pt-11">
         <FormRenderer.SubmitButton
           text={"Send Invite"}
           loadingText="Loading..."
           buttonSize={Small}
-          customSubmitButtonStyle="w-full !h-12"
+          customSubmitButtonStyle="!h-12"
         />
       </div>
     </div>

--- a/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
+++ b/src/screens/UserManagement/UserRevamp/UserManagementHelper.res
@@ -244,7 +244,9 @@ let inviteEmail = FormRenderer.makeFieldInfo(
   ~name="email_list",
   ~customInput=(~input, ~placeholder as _) => {
     let showPlaceHolder = input.value->LogicUtils.getArrayFromJson([])->Array.length === 0
-    <PillInput name="email_list" placeholder={showPlaceHolder ? "Eg: abc.sa@wise.com" : ""} />
+    <PillInput
+      name="email_list" placeholder={showPlaceHolder ? "Eg: abc.sa@wise.com" : ""} singleLine=true
+    />
   },
   ~isRequired=true,
 )


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Keep invitation email pills on a fixed-height, horizontally scrollable row so pressing Enter does not expand the field or shift the Send Invite button.
- Keep the Send Invite button aligned with the email input and use the standard small-button width consistently across disabled and enabled states.
- Remove the duplicate Cybersource Google Pay "Choose Configuration Method" heading while preserving the shared flow heading.
- Format `Connector Created At` and `Challenge Required By` timestamps in global-search dispute results through the shared date cell.
- Display and search clipboard-detected payment/refund IDs as raw copied values without adding `payment_id:` or `refund_id:` prefixes.

## Motivation and Context

These changes resolve multiple user-facing dashboard regressions involving unstable invitation-form layout, duplicate connector configuration content, unreadable raw timestamps, and unexpected clipboard-search filters.

Closes #5305

## How did you test it?

- Ran `npm run re:build` successfully.
- Ran the repository ReScript formatting check through the commit hook successfully.
- Reviewed the staged production diff and verified that no Playwright files are included.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
