### PR TITLE
fix: handle advanced payment list pagination edge cases

### DIFF
--- a/src/components/Table.res
+++ b/src/components/Table.res
@@ -145,12 +145,12 @@ module TableRow = {
         }
       })
       ->Option.isSome
-    let bgColor = coloredRow
+    let bgColor = isVisited
+      ? "bg-nd_gray-50"
+      : coloredRow
       ? selectedRowColor
       : highlightSelectedRow && selectedIndex == actualIndex
       ? "bg-nd_gray-150"
-      : isVisited
-      ? "bg-nd_gray-50"
       : "bg-white dark:bg-jp-gray-lightgray_background"
     let fontSize = "text-fs-14"
     let fontWeight = "font-medium"

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -456,112 +456,101 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-let openSearchCsvColumns: array<openSearchCsvColumn> = [
-  CsvPaymentId,
-  CsvStatus,
-  CsvAmount,
-  CsvCurrency,
-  CsvConnector,
-  CsvPaymentMethod,
-  CsvPaymentMethodType,
-  CsvProfileId,
-  CsvMerchantId,
-  CsvCustomerId,
-  CsvActiveAttemptId,
-  CsvMerchantConnectorId,
-  CsvCardLast4,
-  CsvCardNetwork,
-  CsvCardIssuer,
-  CsvRefundsStatus,
-  CsvRefundsCount,
-  CsvDisputeStatus,
-  CsvDisputeCount,
-  CsvRoutingApproach,
-  CsvUnifiedCode,
-  CsvUnifiedMessage,
-  CsvCreated,
-  CsvModified,
+let openSearchCsvColumns = [
+  "payment_id",
+  "attempt_id",
+  "status",
+  "amount",
+  "currency",
+  "connector",
+  "connector_transaction_id",
+  "amount_to_capture",
+  "customer_id",
+  "created_at",
+  "order_details",
+  "error_message",
+  "capture_method",
+  "authentication_type",
+  "mandate_id",
+  "payment_method",
+  "payment_method_type",
+  "metadata",
+  "setup_future_usage",
+  "statement_descriptor_name",
+  "description",
+  "off_session",
+  "business_country",
+  "business_label",
+  "business_sub_label",
+  "allowed_payment_method_types",
+  "payment_method_data",
+  "card_network",
+  "fingerprint_id",
+  "modified_at",
+  "error_code",
+  "payment_method_id",
+  "card_holder_name",
+  "merchant_order_reference_id",
+  "profile_id",
 ]
 
-let getOpenSearchCsvKey = column =>
-  switch column {
-  | CsvPaymentId => "payment_id"
-  | CsvStatus => "status"
-  | CsvAmount => "amount"
-  | CsvCurrency => "currency"
-  | CsvConnector => "connector"
-  | CsvPaymentMethod => "payment_method"
-  | CsvPaymentMethodType => "payment_method_type"
-  | CsvProfileId => "profile_id"
-  | CsvMerchantId => "merchant_id"
-  | CsvCustomerId => "customer_id"
-  | CsvActiveAttemptId => "active_attempt_id"
-  | CsvMerchantConnectorId => "merchant_connector_id"
-  | CsvCardLast4 => "card_last_4"
-  | CsvCardNetwork => "card_network"
-  | CsvCardIssuer => "card_issuer"
-  | CsvRefundsStatus => "refunds_status"
-  | CsvRefundsCount => "refunds_count"
-  | CsvDisputeStatus => "dispute_status"
-  | CsvDisputeCount => "dispute_count"
-  | CsvRoutingApproach => "routing_approach"
-  | CsvUnifiedCode => "unified_code"
-  | CsvUnifiedMessage => "unified_message"
-  | CsvCreated => "created"
-  | CsvModified => "modified"
-  }
+let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, key) => {
+  let amountToString = amount =>
+    CurrencyUtils.convertCurrencyFromLowestDenomination(
+      ~amount,
+      ~currency=dict->getString("currency", ""),
+    )->Float.toString
+  let jsonToString = key =>
+    dict->getString(
+      key,
+      dict->getMappedValueFromDict(key, "", json => json->JSON.stringifyAny->Option.getOr("")),
+    )
 
-let getOpenSearchCsvHeader = column =>
-  switch column {
-  | CsvPaymentId => "Payment ID"
-  | CsvStatus => "Payment Status"
-  | CsvAmount => "Amount"
-  | CsvCurrency => "Currency"
-  | CsvConnector => "Connector"
-  | CsvPaymentMethod => "Payment Method"
-  | CsvPaymentMethodType => "Payment Method Type"
-  | CsvProfileId => "Profile ID"
-  | CsvMerchantId => "Merchant ID"
-  | CsvCustomerId => "Customer ID"
-  | CsvActiveAttemptId => "Active Attempt ID"
-  | CsvMerchantConnectorId => "Merchant Connector ID"
-  | CsvCardLast4 => "Card Last 4"
-  | CsvCardNetwork => "Card Network"
-  | CsvCardIssuer => "Card Issuer"
-  | CsvRefundsStatus => "Refund Status"
-  | CsvRefundsCount => "Refund Count"
-  | CsvDisputeStatus => "Dispute Status"
-  | CsvDisputeCount => "Dispute Count"
-  | CsvRoutingApproach => "Routing Approach"
-  | CsvUnifiedCode => "Unified Code"
-  | CsvUnifiedMessage => "Unified Message"
-  | CsvCreated => "Created"
-  | CsvModified => "Modified"
+  let value = switch key {
+  | "attempt_id" => dict->getString("attempt_id", dict->getString("active_attempt_id", ""))
+  | "amount" => dict->getOptionFloat("amount")->Option.mapOr("", amountToString)
+  | "connector_transaction_id" =>
+    dict->getString("connector_transaction_id", dict->getString("connector_payment_id", ""))
+  | "amount_to_capture" =>
+    switch dict->getOptionFloat("amount_to_capture") {
+    | Some(amount) => amount->amountToString
+    | None => dict->getOptionFloat("amount_capturable")->Option.mapOr("", amountToString)
+    }
+  | "order_details" => jsonToString("order_details")
+  | "error_message" =>
+    dict->getString("error_message", dict->getStringFromNestedDict("error", "error_message", ""))
+  | "statement_descriptor_name" =>
+    dict->getString("statement_descriptor_name", dict->getString("statement_descriptor", ""))
+  | "off_session" => dict->getString("off_session", dict->getString("customer_present", ""))
+  | "allowed_payment_method_types" => jsonToString("allowed_payment_method_types")
+  | "payment_method_data" => jsonToString("payment_method_data")
+  | "metadata" => jsonToString("metadata")
+  | "card_network" =>
+    dict->getString(
+      "card_network",
+      dict->getDictFromNestedDict("payment_method_data", "card")->getString("card_network", ""),
+    )
+  | "error_code" =>
+    dict->getString("error_code", dict->getStringFromNestedDict("error", "error_code", ""))
+  | "card_holder_name" =>
+    dict->getString(
+      "card_holder_name",
+      dict
+      ->getDictFromNestedDict("payment_method_data", "card")
+      ->getString("card_holder_name", ""),
+    )
+  | "merchant_order_reference_id" =>
+    dict->getString("merchant_order_reference_id", dict->getString("merchant_reference_id", ""))
+  | key => dict->getString(key, "")
   }
+  value->JSON.Encode.string
+}
 
-let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, column) =>
-  switch column {
-  | CsvAmount => dict->getFloat("amount", 0.0)->Float.toString->JSON.Encode.string
-  | CsvRefundsCount => dict->getInt("refunds_count", 0)->Int.toString->JSON.Encode.string
-  | CsvDisputeCount => dict->getInt("dispute_count", 0)->Int.toString->JSON.Encode.string
-  | CsvMerchantConnectorId =>
-    dict
-    ->getString("merchant_connector_id", dict->getString("connector_id", ""))
-    ->JSON.Encode.string
-  | CsvCreated => dict->getString("created_at", "")->JSON.Encode.string
-  | CsvModified => dict->getString("modified_at", "")->JSON.Encode.string
-  | column => dict->getString(column->getOpenSearchCsvKey, "")->JSON.Encode.string
-  }
-
-let csvHeaders =
-  openSearchCsvColumns->Array.map(column => (
-    column->getOpenSearchCsvKey,
-    column->getOpenSearchCsvHeader,
-  ))
+let csvHeaders = openSearchCsvColumns->Array.map(key => (key, key))
 
 let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
   openSearchCsvColumns
-  ->Array.map(column => (column->getOpenSearchCsvKey, getOpenSearchCsvValue(dict, column)))
+  ->Array.map(key => (key, getOpenSearchCsvValue(dict, key)))
   ->getJsonFromArrayOfJson
 
 let getHeading = (~devSortEnabled, colType: colType) => {
@@ -669,7 +658,7 @@ let useGetStatus = (order: order) => {
 }
 
 let formatActivityCount = (count, label) => {
-  `${count->Int.toString} ${pluralize(~count, ~singular=label)}`
+  `${count->Int.toString} ${label}${count > 1 ? "S" : ""}`
 }
 
 let getActivityTags = (order: order) => {
@@ -698,7 +687,7 @@ let getActivitiesCell = (order: order): Table.cell => {
   CustomCell(
     <>
       <RenderIf condition={activityTags->isEmptyArray}>
-        <div className="w-32 whitespace-nowrap text-nd_gray-400"> {"-"->React.string} </div>
+        <div className="whitespace-nowrap"> {"-"->React.string} </div>
       </RenderIf>
       <RenderIf condition={activityTags->isNonEmptyArray}>
         <ToolTip
@@ -1047,8 +1036,22 @@ let getCell = (order: order, colType: colType, merchantId, orgId): Table.cell =>
       />,
       "",
     )
-  | AmountCapturable => Currency(order.amount_capturable /. conversionFactor, order.currency)
-  | AmountReceived => Currency(order.amount_captured /. conversionFactor, order.currency)
+  | AmountCapturable =>
+    CustomCell(
+      <CurrencyCell
+        amount={(order.amount_capturable /. conversionFactor)->Float.toString}
+        currency={order.currency}
+      />,
+      "",
+    )
+  | AmountReceived =>
+    CustomCell(
+      <CurrencyCell
+        amount={(order.amount_captured /. conversionFactor)->Float.toString}
+        currency={order.currency}
+      />,
+      "",
+    )
   | ClientSecret => Text(order.client_secret)
   | Created => Date(order.created_at)
   | Modified => Date(order.modified_at)
@@ -1139,14 +1142,16 @@ let getCell = (order: order, colType: colType, merchantId, orgId): Table.cell =>
     | None => Text("N/A")
     }
   | MerchantConnectorId =>
-    CustomCell(
-      <CopyTextCustomComp
-        customTextCss="w-44 truncate whitespace-nowrap"
-        displayValue=Some(order.connector_id)
-        showTooltip=true
-      />,
-      "",
-    )
+    order.connector_id->isNonEmptyString
+      ? CustomCell(
+          <CopyTextCustomComp
+            customTextCss="w-44 truncate whitespace-nowrap"
+            displayValue=Some(order.connector_id)
+            showTooltip=true
+          />,
+          order.connector_id,
+        )
+      : Text("NA")
   | ActiveAttemptId =>
     CustomCell(
       <CopyTextCustomComp
@@ -1157,15 +1162,19 @@ let getCell = (order: order, colType: colType, merchantId, orgId): Table.cell =>
       order.active_attempt_id->Option.getOr(""),
     )
   | CardLast4 => EllipsisText(order.card_last_4->Option.getOr(""), "w-20")
-  | CardIssuer =>
-    CustomCell(
-      <CopyTextCustomComp
-        customTextCss="w-36 truncate whitespace-nowrap"
-        displayValue=Some(order.card_issuer->Option.getOr(""))
-        showTooltip=true
-      />,
-      "",
-    )
+  | CardIssuer => {
+      let cardIssuer = order.card_issuer->Option.getOr("")
+      cardIssuer->isNonEmptyString
+        ? CustomCell(
+            <CopyTextCustomComp
+              customTextCss="w-36 truncate whitespace-nowrap"
+              displayValue=Some(cardIssuer)
+              showTooltip=true
+            />,
+            cardIssuer,
+          )
+        : Text("NA")
+    }
   | RefundsStatus =>
     EllipsisText(order.refunds_status->Option.getOr("")->formatAdvancedDisplayValue, "w-28")
   | RefundsCount => EllipsisText(order.refunds_count->Option.getOr(0)->Int.toString, "w-20")

--- a/src/screens/Transaction/Order/OrderEntity.res
+++ b/src/screens/Transaction/Order/OrderEntity.res
@@ -456,45 +456,84 @@ let openSearchBaseColumns: array<colType> = [
 
 let openSearchAllColumns = openSearchBaseColumns->Array.concat(openSearchNewColumns)
 
-let openSearchCsvColumns = [
-  "payment_id",
-  "attempt_id",
-  "status",
-  "amount",
-  "currency",
-  "connector",
-  "connector_transaction_id",
-  "amount_to_capture",
-  "customer_id",
-  "created_at",
-  "order_details",
-  "error_message",
-  "capture_method",
-  "authentication_type",
-  "mandate_id",
-  "payment_method",
-  "payment_method_type",
-  "metadata",
-  "setup_future_usage",
-  "statement_descriptor_name",
-  "description",
-  "off_session",
-  "business_country",
-  "business_label",
-  "business_sub_label",
-  "allowed_payment_method_types",
-  "payment_method_data",
-  "card_network",
-  "fingerprint_id",
-  "modified_at",
-  "error_code",
-  "payment_method_id",
-  "card_holder_name",
-  "merchant_order_reference_id",
-  "profile_id",
+let openSearchCsvColumns: array<openSearchCsvColumn> = [
+  CsvPaymentId,
+  CsvAttemptId,
+  CsvStatus,
+  CsvAmount,
+  CsvCurrency,
+  CsvConnector,
+  CsvConnectorTransactionId,
+  CsvAmountToCapture,
+  CsvCustomerId,
+  CsvCreatedAt,
+  CsvOrderDetails,
+  CsvErrorMessage,
+  CsvCaptureMethod,
+  CsvAuthenticationType,
+  CsvMandateId,
+  CsvPaymentMethod,
+  CsvPaymentMethodType,
+  CsvMetadata,
+  CsvSetupFutureUsage,
+  CsvStatementDescriptorName,
+  CsvDescription,
+  CsvOffSession,
+  CsvBusinessCountry,
+  CsvBusinessLabel,
+  CsvBusinessSubLabel,
+  CsvAllowedPaymentMethodTypes,
+  CsvPaymentMethodData,
+  CsvCardNetwork,
+  CsvFingerprintId,
+  CsvModifiedAt,
+  CsvErrorCode,
+  CsvPaymentMethodId,
+  CsvCardHolderName,
+  CsvMerchantOrderReferenceId,
+  CsvProfileId,
 ]
 
-let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, key) => {
+let getOpenSearchCsvKey = column =>
+  switch column {
+  | CsvPaymentId => "payment_id"
+  | CsvAttemptId => "attempt_id"
+  | CsvStatus => "status"
+  | CsvAmount => "amount"
+  | CsvCurrency => "currency"
+  | CsvConnector => "connector"
+  | CsvConnectorTransactionId => "connector_transaction_id"
+  | CsvAmountToCapture => "amount_to_capture"
+  | CsvCustomerId => "customer_id"
+  | CsvCreatedAt => "created_at"
+  | CsvOrderDetails => "order_details"
+  | CsvErrorMessage => "error_message"
+  | CsvCaptureMethod => "capture_method"
+  | CsvAuthenticationType => "authentication_type"
+  | CsvMandateId => "mandate_id"
+  | CsvPaymentMethod => "payment_method"
+  | CsvPaymentMethodType => "payment_method_type"
+  | CsvMetadata => "metadata"
+  | CsvSetupFutureUsage => "setup_future_usage"
+  | CsvStatementDescriptorName => "statement_descriptor_name"
+  | CsvDescription => "description"
+  | CsvOffSession => "off_session"
+  | CsvBusinessCountry => "business_country"
+  | CsvBusinessLabel => "business_label"
+  | CsvBusinessSubLabel => "business_sub_label"
+  | CsvAllowedPaymentMethodTypes => "allowed_payment_method_types"
+  | CsvPaymentMethodData => "payment_method_data"
+  | CsvCardNetwork => "card_network"
+  | CsvFingerprintId => "fingerprint_id"
+  | CsvModifiedAt => "modified_at"
+  | CsvErrorCode => "error_code"
+  | CsvPaymentMethodId => "payment_method_id"
+  | CsvCardHolderName => "card_holder_name"
+  | CsvMerchantOrderReferenceId => "merchant_order_reference_id"
+  | CsvProfileId => "profile_id"
+  }
+
+let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, column) => {
   let amountToString = amount =>
     CurrencyUtils.convertCurrencyFromLowestDenomination(
       ~amount,
@@ -506,51 +545,57 @@ let getOpenSearchCsvValue = (dict: Dict.t<JSON.t>, key) => {
       dict->getMappedValueFromDict(key, "", json => json->JSON.stringifyAny->Option.getOr("")),
     )
 
-  let value = switch key {
-  | "attempt_id" => dict->getString("attempt_id", dict->getString("active_attempt_id", ""))
-  | "amount" => dict->getOptionFloat("amount")->Option.mapOr("", amountToString)
-  | "connector_transaction_id" =>
+  let value = switch column {
+  | CsvAttemptId => dict->getString("attempt_id", dict->getString("active_attempt_id", ""))
+  | CsvAmount => dict->getOptionFloat("amount")->Option.mapOr("", amountToString)
+  | CsvConnectorTransactionId =>
     dict->getString("connector_transaction_id", dict->getString("connector_payment_id", ""))
-  | "amount_to_capture" =>
+  | CsvAmountToCapture =>
     switch dict->getOptionFloat("amount_to_capture") {
     | Some(amount) => amount->amountToString
     | None => dict->getOptionFloat("amount_capturable")->Option.mapOr("", amountToString)
     }
-  | "order_details" => jsonToString("order_details")
-  | "error_message" =>
+  | CsvOrderDetails => jsonToString("order_details")
+  | CsvErrorMessage =>
     dict->getString("error_message", dict->getStringFromNestedDict("error", "error_message", ""))
-  | "statement_descriptor_name" =>
+  | CsvStatementDescriptorName =>
     dict->getString("statement_descriptor_name", dict->getString("statement_descriptor", ""))
-  | "off_session" => dict->getString("off_session", dict->getString("customer_present", ""))
-  | "allowed_payment_method_types" => jsonToString("allowed_payment_method_types")
-  | "payment_method_data" => jsonToString("payment_method_data")
-  | "metadata" => jsonToString("metadata")
-  | "card_network" =>
+  | CsvOffSession => dict->getString("off_session", dict->getString("customer_present", ""))
+  | CsvAllowedPaymentMethodTypes => jsonToString("allowed_payment_method_types")
+  | CsvPaymentMethodData => jsonToString("payment_method_data")
+  | CsvMetadata => jsonToString("metadata")
+  | CsvCardNetwork =>
     dict->getString(
       "card_network",
       dict->getDictFromNestedDict("payment_method_data", "card")->getString("card_network", ""),
     )
-  | "error_code" =>
+  | CsvErrorCode =>
     dict->getString("error_code", dict->getStringFromNestedDict("error", "error_code", ""))
-  | "card_holder_name" =>
+  | CsvCardHolderName =>
     dict->getString(
       "card_holder_name",
       dict
       ->getDictFromNestedDict("payment_method_data", "card")
       ->getString("card_holder_name", ""),
     )
-  | "merchant_order_reference_id" =>
+  | CsvMerchantOrderReferenceId =>
     dict->getString("merchant_order_reference_id", dict->getString("merchant_reference_id", ""))
-  | key => dict->getString(key, "")
+  | column => dict->getString(column->getOpenSearchCsvKey, "")
   }
   value->JSON.Encode.string
 }
 
-let csvHeaders = openSearchCsvColumns->Array.map(key => (key, key))
+let csvHeaders = openSearchCsvColumns->Array.map(column => {
+  let key = column->getOpenSearchCsvKey
+  (key, key)
+})
 
 let mapOrderDictToCsvRow = (dict: Dict.t<JSON.t>) =>
   openSearchCsvColumns
-  ->Array.map(key => (key, getOpenSearchCsvValue(dict, key)))
+  ->Array.map(column => {
+    let key = column->getOpenSearchCsvKey
+    (key, getOpenSearchCsvValue(dict, column))
+  })
   ->getJsonFromArrayOfJson
 
 let getHeading = (~devSortEnabled, colType: colType) => {

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -234,32 +234,6 @@ type paymentListSource =
   | @as("Normal") Normal
   | @as("Advanced") Advanced
 
-type openSearchCsvColumn =
-  | CsvPaymentId
-  | CsvStatus
-  | CsvAmount
-  | CsvCurrency
-  | CsvConnector
-  | CsvPaymentMethod
-  | CsvPaymentMethodType
-  | CsvProfileId
-  | CsvMerchantId
-  | CsvCustomerId
-  | CsvActiveAttemptId
-  | CsvMerchantConnectorId
-  | CsvCardLast4
-  | CsvCardNetwork
-  | CsvCardIssuer
-  | CsvRefundsStatus
-  | CsvRefundsCount
-  | CsvDisputeStatus
-  | CsvDisputeCount
-  | CsvRoutingApproach
-  | CsvUnifiedCode
-  | CsvUnifiedMessage
-  | CsvCreated
-  | CsvModified
-
 type openSearchRefundStatus = [#partial_refunded | #full_refunded]
 
 type openSearchDisputeStatus = [

--- a/src/screens/Transaction/Order/OrderTypes.res
+++ b/src/screens/Transaction/Order/OrderTypes.res
@@ -177,6 +177,43 @@ type otherDetailsColType =
   | RequestExtendedAuth
   | HyperswitchErrorDescription
 
+type openSearchCsvColumn =
+  | CsvPaymentId
+  | CsvAttemptId
+  | CsvStatus
+  | CsvAmount
+  | CsvCurrency
+  | CsvConnector
+  | CsvConnectorTransactionId
+  | CsvAmountToCapture
+  | CsvCustomerId
+  | CsvCreatedAt
+  | CsvOrderDetails
+  | CsvErrorMessage
+  | CsvCaptureMethod
+  | CsvAuthenticationType
+  | CsvMandateId
+  | CsvPaymentMethod
+  | CsvPaymentMethodType
+  | CsvMetadata
+  | CsvSetupFutureUsage
+  | CsvStatementDescriptorName
+  | CsvDescription
+  | CsvOffSession
+  | CsvBusinessCountry
+  | CsvBusinessLabel
+  | CsvBusinessSubLabel
+  | CsvAllowedPaymentMethodTypes
+  | CsvPaymentMethodData
+  | CsvCardNetwork
+  | CsvFingerprintId
+  | CsvModifiedAt
+  | CsvErrorCode
+  | CsvPaymentMethodId
+  | CsvCardHolderName
+  | CsvMerchantOrderReferenceId
+  | CsvProfileId
+
 type optionObj = {
   urlKey: string,
   label: string,

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -630,12 +630,10 @@ let setData = (
   setScreenState,
   previewOnly,
 ) => {
-  let arr = Array.make(~length=offset, Dict.make()->PaymentInterfaceUtils.mapDictToPaymentPayload)
-  if total <= offset {
+  if offset > 0 && total <= offset {
     setOffset(_ => 0)
-  }
-
-  if total > 0 {
+  } else if total > 0 {
+    let arr = Array.make(~length=offset, Dict.make()->PaymentInterfaceUtils.mapDictToPaymentPayload)
     let orderData =
       arr
       ->Array.concat(data)
@@ -651,6 +649,11 @@ let setData = (
     setScreenState(_ => PageLoaderWrapper.Custom)
   }
 }
+
+let getSelectedPaymentRows = selectedRows =>
+  selectedRows->Array.filter(row =>
+    row->getDictFromJsonObject->getString("payment_id", "")->isNonEmptyString
+  )
 
 let isNonEmptyValue = value => {
   value->Option.getOr(Dict.make())->Dict.toArray->Array.length > 0

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -650,11 +650,6 @@ let setData = (
   }
 }
 
-let getSelectedPaymentRows = selectedRows =>
-  selectedRows->Array.filter(row =>
-    row->getDictFromJsonObject->getString("payment_id", "")->isNonEmptyString
-  )
-
 let isNonEmptyValue = value => {
   value->Option.getOr(Dict.make())->Dict.toArray->Array.length > 0
 }

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -66,8 +66,7 @@ let make = (~previewOnly=false) => {
     sortKey: "",
     sortType: ASC,
   }
-  let pageDetailDict = Recoil.useRecoilValueFromAtom(LoadedTable.table_pageDetails)
-  let setPageDetails = Recoil.useSetRecoilState(LoadedTable.table_pageDetails)
+  let (pageDetailDict, setPageDetails) = Recoil.useRecoilState(LoadedTable.table_pageDetails)
   let pageDetail = pageDetailDict->getValueFromDict(tableTitle, defaultValue)
   let resultsPerPage = pageDetail.resultsPerPage
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
@@ -78,9 +77,9 @@ let make = (~previewOnly=false) => {
   let setSearchTextAndResetOffset = updateSearchText => {
     setPageDetails(prev => {
       let currentPageDetail = prev->getValueFromDict(tableTitle, defaultValue)
-      let newDict = prev->Dict.toArray->Dict.fromArray
-      newDict->Dict.set(tableTitle, {...currentPageDetail, offset: 0})
-      newDict
+      let updatedPageDetails = prev->Dict.toArray->Dict.fromArray
+      updatedPageDetails->Dict.set(tableTitle, {...currentPageDetail, offset: 0})
+      updatedPageDetails
     })
     setOffset(_ => 0)
     setSearchText(updateSearchText)

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -67,6 +67,7 @@ let make = (~previewOnly=false) => {
     sortType: ASC,
   }
   let pageDetailDict = Recoil.useRecoilValueFromAtom(LoadedTable.table_pageDetails)
+  let setPageDetails = Recoil.useSetRecoilState(LoadedTable.table_pageDetails)
   let pageDetail = pageDetailDict->getValueFromDict(tableTitle, defaultValue)
   let resultsPerPage = pageDetail.resultsPerPage
   let (offset, setOffset) = React.useState(_ => pageDetail.offset)
@@ -74,6 +75,16 @@ let make = (~previewOnly=false) => {
     FilterContext.filterContext,
   )
   let startTime = filterValueJson->getString(startTimeFilterKey(version), "")
+  let setSearchTextAndResetOffset = updateSearchText => {
+    setPageDetails(prev => {
+      let currentPageDetail = prev->getValueFromDict(tableTitle, defaultValue)
+      let newDict = prev->Dict.toArray->Dict.fromArray
+      newDict->Dict.set(tableTitle, {...currentPageDetail, offset: 0})
+      newDict
+    })
+    setOffset(_ => 0)
+    setSearchText(updateSearchText)
+  }
 
   let handleExtendDateButtonClick = _ => {
     let startDateObj = startTime->DayJs.getDayJsForString
@@ -249,7 +260,7 @@ let make = (~previewOnly=false) => {
       : "Search by payment ID"
     let searchBar =
       <SearchBarFilter
-        placeholder=searchPlaceholder setSearchVal=setSearchText searchVal=searchText
+        placeholder=searchPlaceholder setSearchVal=setSearchTextAndResetOffset searchVal=searchText
       />
     let searchBarWithInfo =
       <div className="flex items-center gap-2">

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -305,7 +305,10 @@ let make = (~previewOnly=false) => {
     />
   }, (searchText, version, isAdvancedSource, devSavedViews))
 
-  let selectedPaymentRows = selectedRows->getSelectedPaymentRows
+  let selectedPaymentRows =
+    selectedRows->Array.filter(row =>
+      row->getDictFromJsonObject->getString("payment_id", "")->isNonEmptyString
+    )
 
   let downloadData = () => {
     let currentDate = Date.make()->Date.toISOString->dateFormat("YYYY-MM-DD")

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -305,11 +305,13 @@ let make = (~previewOnly=false) => {
     />
   }, (searchText, version, isAdvancedSource, devSavedViews))
 
+  let selectedPaymentRows = selectedRows->getSelectedPaymentRows
+
   let downloadData = () => {
     let currentDate = Date.make()->Date.toISOString->dateFormat("YYYY-MM-DD")
     DownloadUtils.downloadTableAsCsv(
       ~csvHeaders,
-      ~rawData=selectedRows,
+      ~rawData=selectedPaymentRows,
       ~tableItemToObjMapper=dict => dict,
       ~itemToCSVMapping=mapOrderDictToCsvRow,
       ~fileName=`payments_${currentDate}.csv`,
@@ -317,7 +319,7 @@ let make = (~previewOnly=false) => {
     )
   }
 
-  let hasSelectedRows = selectedRows->isNonEmptyArray
+  let hasSelectedRows = selectedPaymentRows->isNonEmptyArray
   let canExportSelectedRows = isAdvancedSource && hasSelectedRows
   let exportButtonState: Button.buttonState = canExportSelectedRows ? Normal : Disabled
   let exportTooltipText = !isAdvancedSource
@@ -375,7 +377,7 @@ let make = (~previewOnly=false) => {
               rightIcon={CustomIcon(
                 <span
                   className={`inline-flex h-5 w-5 items-center justify-center rounded-full bg-white bg-opacity-20 ${body.md.medium} ${selectedRowsCountClass}`}>
-                  {selectedRows->Array.length->Int.toString->React.string}
+                  {selectedPaymentRows->Array.length->Int.toString->React.string}
                 </span>,
               )}
               onClick={_ => canExportSelectedRows ? downloadData() : ()}

--- a/src/screens/Transaction/SavedViews/SavedViewsComponent.res
+++ b/src/screens/Transaction/SavedViews/SavedViewsComponent.res
@@ -30,7 +30,7 @@ let make = (
     setSavedViews(_ => [])
     fetchSavedViews()->ignore
     None
-  }, [])
+  }, (entity, version))
 
   React.useEffect(() => {
     if !isInternalUpdate {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes advanced payments list pagination, selected export, and CSV rendering issues.

- Resets the payments table pagination cache before applying a new search term so advanced search starts from `offset: 0` instead of reusing a stale page-2 offset.
- Preserves the user-selected `resultsPerPage` while clearing only the cached offset for the active payments table.
- Keeps the response-time offset reset as a fallback for filters/date range/profile changes that shrink the result set.
- Filters selected export rows to include only real payment rows with a non-empty `payment_id`, avoiding placeholder rows from remote pagination padding.
- Aligns advanced payments CSV export headers and order with the generated payments report columns.
- Adds export value fallbacks for fields that can arrive under alternate API keys, including attempt ID, connector transaction ID, amount to capture, error fields, card fields, statement descriptor, off-session, and merchant reference fields.
- Serializes JSON-like export fields consistently for order details, allowed payment methods, payment method data, and metadata.
- Uses consistent amount cell rendering for amount received and amount capturable columns.
- Shows `NA` instead of an empty copy control for empty Merchant Connector ID and Card Issuer cells.
- Fixes related activity tag rendering so empty values keep table layout stable and plural labels render as `REFUNDS` instead of `REFUNDs`.
- Keeps the recently visited row highlight visible when a visited payment is selected through the table checkbox.
- Refreshes saved views when the active payments entity or API version changes.

## Motivation and Context

Issue context: https://github.com/juspay/hyperswitch-cloud/issues/22476#issuecomment-5178207952

When a merchant searched from page 2 or later in the advanced payments list, the table reused the cached `LoadedTable.table_pageDetails` offset. For narrowed searches such as `22`, `abcd`, or `venu.b@juspay.in`, the first request could be sent with `offset: 20` even though the search results fit on page 1. This caused repeated/cancelled list requests as the UI recovered back to `offset: 0`.

The fix resets pagination before the search request is built, instead of relying only on the response-time fallback that resets offset after an invalid page response. The existing fallback remains useful for non-search cases where the result count changes unexpectedly.

The PR also makes selected-row CSV export consistent with generated report output and avoids blank/null UI states caused by advanced list response shape differences.

Fixes juspay/hyperswitch-cloud#22476

## How did you test it?

- Ran `npm run re:format`
- Ran `git diff --check`
- Ran `npm run re:build`
- Verified with local console/API payload logs that searching from page 2 sends `offset: 0` for the search request
- Compared advanced payments export headers/order against the generated payments report CSV

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): Uses the existing Advanced payments list gating.

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
