### PR TITLE
fix: raise minimum password length to 12 characters

### DIFF
--- a/playwright-tests/e2e/1-auth/auth.spec.ts
+++ b/playwright-tests/e2e/1-auth/auth.spec.ts
@@ -524,7 +524,7 @@ test.describe("Forgot password", () => {
     { tag: "@mail" },
     async ({ page, context }) => {
       const email = generateUniqueEmail();
-      const newPassword = "Test@123";
+      const newPassword = "Test@1234567";
 
       const signinPage = new SignInPage(page);
       const resetPasswordPage = new ResetPasswordPage(page);
@@ -572,12 +572,12 @@ test.describe("Forgot password", () => {
       const weakPasswords = [
         {
           password: "Weak1!",
-          expectedError: "Password must be at least 8 characters long.",
+          expectedError: "Password must be at least 12 characters long.",
         },
         { password: "password123!", expectedError: /uppercase/ },
         { password: "PASSWORD123!", expectedError: /lowercase/ },
-        { password: "Password!@#", expectedError: /numeric/ },
-        { password: "Password123", expectedError: /special/ },
+        { password: "Password!@#>", expectedError: /numeric/ },
+        { password: "Password1234", expectedError: /special/ },
       ];
 
       await signupUser(email, PLAYWRIGHT_PASSWORD);

--- a/src/components/form/PasswordStrengthInputAsChips.res
+++ b/src/components/form/PasswordStrengthInputAsChips.res
@@ -3,10 +3,10 @@ type passwordCheck = {
   lowercase: bool,
   uppercase: bool,
   specialChar: bool,
-  minEightChars: bool,
+  minChars: bool,
 }
 
-type chipType = Number | Lowercase | Uppercase | SpecialChar | MinEightChars
+type chipType = Number | Lowercase | Uppercase | SpecialChar | MinChars
 
 module PasswordChip = {
   @react.component
@@ -19,7 +19,7 @@ module PasswordChip = {
     | Lowercase => (passwordChecks.lowercase, "Lowercase Letters")
     | Uppercase => (passwordChecks.uppercase, "Uppercase Letters")
     | SpecialChar => (passwordChecks.specialChar, "Special Characters")
-    | MinEightChars => (passwordChecks.minEightChars, "8 Characters")
+    | MinChars => (passwordChecks.minChars, "12 Characters")
     }
 
     let textClass = isCheckPassed ? "text-green-700 font-medium" : "font-base dark:text-gray-100"
@@ -50,7 +50,7 @@ let make = (
     lowercase: false,
     uppercase: false,
     specialChar: false,
-    minEightChars: false,
+    minChars: false,
   }
   let (passwordChecks, setPasswordChecks) = React.useState(_ => initialPasswordState)
   let (showValidation, setShowValidation) = React.useState(_ => false)
@@ -65,10 +65,10 @@ let make = (
   )
 
   let validateFunc = strVal => {
-    if strVal->String.length >= 8 {
+    if strVal->String.length >= 12 {
       setPasswordChecks(prev => {
         ...prev,
-        minEightChars: true,
+        minChars: true,
       })
     }
     if RegExp.test(%re("/^(?=.*[A-Z])/"), strVal) {
@@ -114,7 +114,7 @@ let make = (
     },
   }
 
-  let passwordChips = [MinEightChars, Lowercase, Number, SpecialChar, Uppercase]
+  let passwordChips = [MinChars, Lowercase, Number, SpecialChar, Uppercase]
 
   <>
     <TextInputAdapter

--- a/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuthUtils.res
@@ -2,11 +2,11 @@ open CommonAuthTypes
 let passwordKeyValidation = (value, key, keyVal, errors) => {
   let mustHave: array<string> = []
   if value->LogicUtils.isNonEmptyString && key === keyVal {
-    if value->String.length < 8 {
+    if value->String.length < 12 {
       Dict.set(
         errors,
         key,
-        "Your password is not strong enough. Password must be at least 8 characters long."->JSON.Encode.string,
+        "Your password is not strong enough. Password must be at least 12 characters long."->JSON.Encode.string,
       )
     } else {
       if !RegExp.test(%re("/^(?=.*[A-Z])/"), value) {


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Raises the client-side minimum password length from 8 to 12 characters to meet the PCI DSS minimum password length requirement.

- `src/entryPoints/AuthModule/Common/CommonAuthUtils.res`: `passwordKeyValidation` now requires ≥12 characters (updated error message). This single function backs login, reset-password, invite-member, change-password, and 2FA-recovery validation.
- `src/components/form/PasswordStrengthInputAsChips.res`: the password-strength checklist chip now checks/displays "12 Characters" instead of "8 Characters" (renamed `minEightChars`/`MinEightChars` → `minChars`/`MinChars` to match).

This is a frontend-only change, matching the backend change in juspay/hyperswitch#13540.

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables

## Motivation and Context

PCI DSS requires a 12-character minimum password length; the current 8-character minimum falls short of compliance. The backend was already updated in juspay/hyperswitch#13540, which noted the frontend should be updated separately to match and avoid a client/server validation mismatch.

Closes #5313

## How did you test it?

- [x] Verified `rescript build` compiles cleanly
- [ ] Verify signup/change-password/reset-password reject passwords shorter than 12 characters in the browser

## Checklist
<!-- Put an `x` in the boxes that apply -->

- [x] I formatted the code
- [x] I reviewed the submitted code
- [ ] I added unit tests for my changes where possible