### PR TITLE
feat: add wallet-specific payment method blocking

### DIFF
--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -177,6 +177,8 @@ test.describe("Payment Settings", () => {
       await paymentSettings.dropdownValueByText("Credit").click();
       await page.keyboard.press("Escape");
 
+      await expect(paymentSettings.dropdownValueByText("Credit")).not.toBeVisible();
+
       await paymentSettings
         .paymentMethodBlockingCardTypesDropdown("Google Pay")
         .click();

--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -79,11 +79,12 @@ test.describe("Payment Settings", () => {
       await homePage.surchargeConnectors.click();
       await expect(page).toHaveURL(/.*dashboard\/surcharge-processor/);
 
-      await expect(
-        surchargeProcessor.connectNowOrConnectButton,
-      ).toBeVisible();
+      await expect(surchargeProcessor.connectNowOrConnectButton).toBeVisible();
       await surchargeProcessor.connectNowOrConnectButton.click();
-      await page.locator('[name*="api_key"]').first().fill("interpayments_test_api_key");
+      await page
+        .locator('[name*="api_key"]')
+        .first()
+        .fill("interpayments_test_api_key");
       await surchargeProcessor.connectAndProceedButton.click();
       await surchargeProcessor.doneButton.click();
 
@@ -137,6 +138,10 @@ test.describe("Payment Settings", () => {
       await expect(paymentSettings.merchantCategoryCodeDropdown).toBeVisible();
       await expect(paymentSettings.clickToPayToggle).toBeVisible();
       await expect(paymentSettings.paymentMethodBlocking).toBeVisible();
+      await expect(paymentSettings.applePayPaymentMethodBlocking).toBeVisible();
+      await expect(
+        paymentSettings.googlePayPaymentMethodBlocking,
+      ).toBeVisible();
       await expect(paymentSettings.returnUrlInput).toBeVisible();
       await expect(paymentSettings.webhookUrlInput).toBeVisible();
       await expect(paymentSettings.updateButton).toBeVisible();
@@ -154,6 +159,48 @@ test.describe("Payment Settings", () => {
       await expect(paymentSettings.webhookUrlInput).toHaveValue(
         "https://example.com/webhook",
       );
+    });
+
+    test("should submit nested wallet payment method blocking payload", async ({
+      page,
+    }) => {
+      const paymentSettings = new PaymentSettings(page);
+
+      await expect(paymentSettings.applePayPaymentMethodBlocking).toBeVisible();
+      await expect(
+        paymentSettings.googlePayPaymentMethodBlocking,
+      ).toBeVisible();
+
+      await paymentSettings
+        .paymentMethodBlockingCardTypesDropdown("Apple Pay")
+        .click();
+      await paymentSettings.dropdownValueByText("Credit").click();
+      await page.keyboard.press("Escape");
+
+      await paymentSettings
+        .paymentMethodBlockingCardTypesDropdown("Google Pay")
+        .click();
+      await paymentSettings.dropdownValueByText("Debit").click();
+      await page.keyboard.press("Escape");
+
+      const updateRequestPromise = page.waitForRequest(
+        (request) =>
+          request.method() === "POST" &&
+          request.url().includes("/business_profile/"),
+      );
+
+      await paymentSettings.clickUpdate();
+
+      const updateRequest = await updateRequestPromise;
+      const payload = updateRequest.postDataJSON();
+      const walletBlocking = payload.payment_method_blocking.wallet;
+
+      expect(walletBlocking.card_types).toBeUndefined();
+      expect(walletBlocking.apple_pay.card_types).toEqual(["credit"]);
+      expect(walletBlocking.google_pay.card_types).toEqual(["debit"]);
+      await expect(paymentSettings.detailsUpdatedToast).toBeVisible({
+        timeout: 10000,
+      });
     });
 
     test("should save toggle, form, and dropdown values when Update is clicked", async ({
@@ -495,7 +542,7 @@ test.describe("Payment Settings", () => {
       const requestorAppUrl = "https://example.com/3ds-requestor-app";
 
       await paymentSettings.selectFieldDropdown().click();
-      await page.getByRole('option', { name: 'juspaythreedsserver' }).click();
+      await page.getByRole("option", { name: "juspaythreedsserver" }).click();
       await page.keyboard.press("Escape");
 
       await paymentSettings.threeDsRequestorUrlInput.fill(requestorUrl);
@@ -522,9 +569,11 @@ test.describe("Payment Settings", () => {
       );
 
       // Verify the connector is the selected option in the multi-select
-      await page.getByRole('button', { name: 'Select Field1' }).click();
+      await page.getByRole("button", { name: "Select Field1" }).click();
       await expect(
-        page.getByRole('option', { name: 'juspaythreedsserver' }).getByRole('checkbox')
+        page
+          .getByRole("option", { name: "juspaythreedsserver" })
+          .getByRole("checkbox"),
       ).toHaveAttribute("data-state", "checked");
     });
   });

--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -446,7 +446,7 @@ test.describe("Payment Settings", () => {
 
       await expect(paymentSettings.clickToPayConnectorDropdown).toBeVisible();
       await paymentSettings.clickToPayConnectorDropdown.click();
-      await page.getByRole('menuitem', { name: 'juspaythreedsserver_default' }).click();
+      await page.getByRole('menuitem', { name: connectorLabel }).click();
 
       await paymentSettings.clickUpdate();
       await expect(paymentSettings.detailsUpdatedToast).toBeVisible({

--- a/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
+++ b/playwright-tests/e2e/7-developers/PaymentSettings.spec.ts
@@ -446,7 +446,7 @@ test.describe("Payment Settings", () => {
 
       await expect(paymentSettings.clickToPayConnectorDropdown).toBeVisible();
       await paymentSettings.clickToPayConnectorDropdown.click();
-      await paymentSettings.dropdownValueByText(connectorLabel).click();
+      await page.getByRole('menuitem', { name: 'juspaythreedsserver_default' }).click();
 
       await paymentSettings.clickUpdate();
       await expect(paymentSettings.detailsUpdatedToast).toBeVisible({

--- a/playwright-tests/support/pages/developers/PaymentSettings.ts
+++ b/playwright-tests/support/pages/developers/PaymentSettings.ts
@@ -107,6 +107,26 @@ export class PaymentSettings {
     return this.page.getByText("Payment Method Blocking");
   }
 
+  get applePayPaymentMethodBlocking(): Locator {
+    return this.page.getByText("Apple Pay", { exact: true });
+  }
+
+  get googlePayPaymentMethodBlocking(): Locator {
+    return this.page.getByText("Google Pay", { exact: true });
+  }
+
+  paymentMethodBlockingCardTypesDropdown(label: string): Locator {
+    return this.page
+      .locator("div", {
+        has: this.page.getByText(label, { exact: true }),
+      })
+      .filter({
+        has: this.page.getByRole("button", { name: "Select Card Types" }),
+      })
+      .last()
+      .getByRole("button", { name: "Select Card Types" });
+  }
+
   get maxAutoRetriesInput(): Locator {
     return this.page.getByPlaceholder("Enter number of max auto retries");
   }
@@ -135,12 +155,11 @@ export class PaymentSettings {
   }
 
   dropdownValue(value: string): Locator {
-    return this.page.getByRole('menuitem', { name: value });
+    return this.page.getByRole("menuitem", { name: value });
   }
 
   dropdownValueByText(text: string): Locator {
-    return this.page
-      .getByRole('menuitem', { name: text });
+    return this.page.getByRole("menuitem", { name: text });
   }
 
   selectFieldDropdown(): Locator {
@@ -235,23 +254,23 @@ export class PaymentSettings {
   }
 
   acquirerMerchantNameInput(modal: Locator): Locator {
-    return this.page.getByRole('textbox', { name: 'e.g. Demo Merchant' });
+    return this.page.getByRole("textbox", { name: "e.g. Demo Merchant" });
   }
 
   acquirerMerchantIdInput(modal: Locator): Locator {
-    return this.page.getByRole('textbox', { name: 'e.g. 00004500000' });
+    return this.page.getByRole("textbox", { name: "e.g. 00004500000" });
   }
 
   acquirerBinInput(modal: Locator): Locator {
-    return this.page.getByRole('spinbutton', { name: 'e.g.' }).first();
+    return this.page.getByRole("spinbutton", { name: "e.g." }).first();
   }
 
   acquirerIcaInput(modal: Locator): Locator {
-    return this.page.getByRole('spinbutton', { name: 'e.g.' }).nth(1);
+    return this.page.getByRole("spinbutton", { name: "e.g." }).nth(1);
   }
 
   acquirerFraudRateInput(modal: Locator): Locator {
-    return this.page.getByRole('spinbutton', { name: 'e.g. 25' });
+    return this.page.getByRole("spinbutton", { name: "e.g. 25" });
   }
 
   acquirerNetworkDropdownInModal(modal: Locator): Locator {
@@ -281,7 +300,9 @@ export class PaymentSettings {
 
   // Validation errors
   get acquirerBinError(): Locator {
-    return this.page.locator('[data-form-error="Acquirer BIN must be between 4 and 20 digits"]');
+    return this.page.locator(
+      '[data-form-error="Acquirer BIN must be between 4 and 20 digits"]',
+    );
   }
 
   get fraudRateError(): Locator {
@@ -424,8 +445,9 @@ export class PaymentSettings {
 
   async selectFirstMerchantCategoryCode(): Promise<string> {
     await this.merchantCategoryCodeDropdown.click();
-    const firstOption = this.page
-      .getByRole('menuitem', { name: 'Wine producers' })
+    const firstOption = this.page.getByRole("menuitem", {
+      name: "Wine producers",
+    });
     const optionText = (await firstOption.getAttribute("data-value")) ?? "";
     await firstOption.click();
     return optionText;

--- a/playwright-tests/support/pages/developers/PaymentSettings.ts
+++ b/playwright-tests/support/pages/developers/PaymentSettings.ts
@@ -159,7 +159,7 @@ export class PaymentSettings {
   }
 
   dropdownValueByText(text: string): Locator {
-    return this.page.getByRole("menuitem", { name: text });
+    return this.page.getByRole('option', { name: text });
   }
 
   selectFieldDropdown(): Locator {

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
@@ -79,9 +79,14 @@ type surchargeConnectorDetails = {surcharge_connector_id: string}
 
 type paymentMethodBlockingEntry = {card_types: option<array<string>>}
 
+type paymentMethodBlockingWallet = {
+  apple_pay: option<paymentMethodBlockingEntry>,
+  google_pay: option<paymentMethodBlockingEntry>,
+}
+
 type paymentMethodBlocking = {
   card: option<paymentMethodBlockingEntry>,
-  wallet: option<paymentMethodBlockingEntry>,
+  wallet: option<paymentMethodBlockingWallet>,
 }
 
 type commonProfileEntity = {

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -196,12 +196,36 @@ let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEnt
   card_types: entryDict->getOptionStrArrayFromDict("card_types"),
 }
 
+let paymentMethodBlockingWalletEntryMapper = (walletDict, key, legacyEntry) => {
+  let entryDict = walletDict->getDictfromDict(key)
+  if entryDict->isEmptyDict {
+    legacyEntry
+  } else {
+    Some(entryDict->paymentMethodBlockingEntryMapper)
+  }
+}
+
+let paymentMethodBlockingWalletMapper: Dict.t<
+  JSON.t,
+> => paymentMethodBlockingWallet = walletDict => {
+  let legacyEntry =
+    walletDict
+    ->getOptionStrArrayFromDict("card_types")
+    ->Option.map(cardTypes => {
+      card_types: Some(cardTypes),
+    })
+  {
+    apple_pay: paymentMethodBlockingWalletEntryMapper(walletDict, "apple_pay", legacyEntry),
+    google_pay: paymentMethodBlockingWalletEntryMapper(walletDict, "google_pay", legacyEntry),
+  }
+}
+
 let paymentMethodBlockingMapper: Dict.t<JSON.t> => paymentMethodBlocking = pmbDict => {
   let cardDict = pmbDict->getDictfromDict("card")
   let walletDict = pmbDict->getDictfromDict("wallet")
   {
     card: cardDict->isEmptyDict ? None : Some(cardDict->paymentMethodBlockingEntryMapper),
-    wallet: walletDict->isEmptyDict ? None : Some(walletDict->paymentMethodBlockingEntryMapper),
+    wallet: walletDict->isEmptyDict ? None : Some(walletDict->paymentMethodBlockingWalletMapper),
   }
 }
 

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -198,11 +198,8 @@ let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEnt
 
 let paymentMethodBlockingWalletEntryMapper = (walletDict, key, legacyEntry) => {
   let entryDict = walletDict->getDictfromDict(key)
-  if entryDict->isEmptyDict {
-    legacyEntry
-  } else {
+  entryDict->isEmptyDict ? legacyEntry : 
     Some(entryDict->paymentMethodBlockingEntryMapper)
-  }
 }
 
 let paymentMethodBlockingWalletMapper: Dict.t<

--- a/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentBehaviour.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentBehaviour.res
@@ -210,18 +210,22 @@ module PaymentMethodBlocking = {
       ),
     )
 
-    let blocklistWalletTypes = makeFieldInfo(
-      ~label="Card Types",
-      ~name="payment_method_blocking.wallet.card_types",
-      ~customInput=InputFields.multiSelectInput(
-        ~options=cardTypeOptions,
-        ~buttonText="Select Card Types",
-        ~showSelectionAsChips=false,
-        ~customButtonStyle="!rounded-lg",
-        ~fixedDropDownDirection=BottomRight,
-        ~searchable=true,
-      ),
-    )
+    let makeBlocklistWalletTypes = (walletType, label) =>
+      makeFieldInfo(
+        ~label,
+        ~name=`payment_method_blocking.wallet.${walletType}.card_types`,
+        ~customInput=InputFields.multiSelectInput(
+          ~options=cardTypeOptions,
+          ~buttonText="Select Card Types",
+          ~showSelectionAsChips=false,
+          ~customButtonStyle="!rounded-lg",
+          ~fixedDropDownDirection=BottomRight,
+          ~searchable=true,
+        ),
+      )
+
+    let blocklistApplePayCardTypes = makeBlocklistWalletTypes("apple_pay", "Card Types")
+    let blocklistGooglePayCardTypes = makeBlocklistWalletTypes("google_pay", "Card Types")
 
     <DesktopRow itemWrapperClass="mx-1">
       <div className="w-full py-8 flex flex-col gap-6">
@@ -230,7 +234,7 @@ module PaymentMethodBlocking = {
             {"Payment Method Blocking"->React.string}
           </p>
           <p className={`${body.md.medium} text-nd_gray-400 pt-2`}>
-            {"Block specific card types for card and wallet payment methods"->React.string}
+            {"Block specific card types for card, Apple Pay, and Google Pay payment methods"->React.string}
           </p>
         </div>
         <div className="flex flex-col gap-2">
@@ -243,11 +247,24 @@ module PaymentMethodBlocking = {
         </div>
         <div className="flex flex-col gap-2">
           <p className={`${body.md.semibold} text-nd_gray-700`}> {"Wallet"->React.string} </p>
-          <FieldRenderer
-            field={blocklistWalletTypes}
-            labelClass={`!${body.md.medium} !text-nd-gray-600`}
-            fieldWrapperClass="max-w-xl"
-          />
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <p className={`${body.md.medium} text-nd_gray-600`}> {"Apple Pay"->React.string} </p>
+              <FieldRenderer
+                field={blocklistApplePayCardTypes}
+                labelClass={`!${body.md.medium} !text-nd-gray-600`}
+                fieldWrapperClass="max-w-xl"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <p className={`${body.md.medium} text-nd_gray-600`}> {"Google Pay"->React.string} </p>
+              <FieldRenderer
+                field={blocklistGooglePayCardTypes}
+                labelClass={`!${body.md.medium} !text-nd-gray-600`}
+                fieldWrapperClass="max-w-xl"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </DesktopRow>


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR updates Payment Method Blocking in Payment Behaviour settings so wallet blocking is configured independently for Apple Pay and Google Pay.

Changes included:
- Replaces the single wallet card type selector with separate Apple Pay and Google Pay card type selectors.
- Updates the business profile payment method blocking type to model nested wallet entries.
- Updates profile extraction to read `payment_method_blocking.wallet.apple_pay.card_types` and `payment_method_blocking.wallet.google_pay.card_types`.
- Preserves backward compatibility by hydrating legacy `payment_method_blocking.wallet.card_types` into both wallet sections on read.
- Adds Playwright coverage to assert the new UI labels and submitted nested payload shape.

Closes #5316

<img width="1703" height="1033" alt="Screenshot 2026-08-04 at 7 24 33 PM" src="https://github.com/user-attachments/assets/6eaa224c-1a46-4574-9165-6368c7a1e054" />


## Motivation and Context

Wallet payment method blocking previously supported only a flat wallet-level `card_types` configuration. The API/UI now needs wallet-specific blocking so merchants can configure Apple Pay and Google Pay card type blocking independently.

## How did you test it?

- [x] Ran `npm run re:build`
- [x] Ran `npx prettier --check playwright-tests/e2e/7-developers/PaymentSettings.spec.ts playwright-tests/support/pages/developers/PaymentSettings.ts`
- [x] Ran `git diff --check`
- [ ] Targeted Playwright run could not complete locally because the shared signup hook failed before reaching the test body: `signupUser failed (404): IR_02 Unrecognized request URL`.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [x] Yes
- [ ] No

Backend PR URL: [PR](https://github.com/juspay/hyperswitch/pull/13508)

Requires backend support for nested wallet payment method blocking payload:
`payment_method_blocking.wallet.apple_pay.card_types` and `payment_method_blocking.wallet.google_pay.card_types`.

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
