### PR TITLE
fix: prevent api key description text wrapping

### DIFF
--- a/src/screens/Developer/APIKeys/KeyManagementHelper.res
+++ b/src/screens/Developer/APIKeys/KeyManagementHelper.res
@@ -358,7 +358,7 @@ module ApiKeysTable = {
 
       switch colType {
       | Name => EllipsisText(item.name, "max-w-xs")
-      | Description => Text(item.description)
+      | Description => EllipsisText(item.description, "max-w-xs")
       | Prefix => Text(item.prefix->appendString)
       | Created => Date(item.created)
       | Expiration =>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Render API key descriptions with the existing ellipsis text cell used by API key names. Long descriptions now remain on one line and expose their complete value through the hover tooltip.

<img width="1420" height="460" alt="2026-08-04_23-44-09" src="https://github.com/user-attachments/assets/c989c7b9-ca89-4789-839a-a24d4849f617" />

<img width="1431" height="461" alt="2026-08-04_23-44-13" src="https://github.com/user-attachments/assets/d38b3498-d56c-491e-9717-bc72f56a86ba" />



## Motivation and Context

Long descriptions previously used a plain text table cell, causing them to wrap across multiple lines and create inconsistent row heights in the desktop API Keys table.

Fixes #5320

## How did you test it?

- Ran `npm run re:build` successfully.
- Ran `git diff --check` successfully.
- The commit hook ran `npm run re:format` successfully.

No unit test was added because this is a one-line presentation change using an existing, already shared table-cell primitive.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

Navigate to Developer > Keys and verify that a long API key description truncates to one line and displays its full value on hover.

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible