### PR TITLE
fix: gate Hyperswitch-branded auth prompts behind branding flag

### DIFF
--- a/src/entryPoints/AuthModule/Common/CommonAuth.res
+++ b/src/entryPoints/AuthModule/Common/CommonAuth.res
@@ -46,7 +46,7 @@ module Header = {
     let {globalUIConfig: {font: {textColor}}} = React.useContext(ThemeProvider.themeContext)
     let {isSignUpAllowed} = AuthModuleHooks.useAuthMethods()
     let form = ReactFinalForm.useForm()
-    let {email: isMagicLinkEnabled} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+    let {email: isMagicLinkEnabled, branding} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let authId = HyperSwitchEntryUtils.getSessionData(~key="auth_id")
 
     let headerStyle = switch authType {
@@ -59,7 +59,7 @@ module Header = {
 
     let cardHeaderText = switch authType {
     | LoginWithPassword | LoginWithEmail => "Hey there, Welcome back!"
-    | SignUP => "Welcome to Hyperswitch"
+    | SignUP => branding ? "Welcome" : "Welcome to Hyperswitch"
     | MagicLinkEmailSent
     | ForgetPasswordEmailSent
     | ResendVerifyEmailSent => "Please check your inbox"
@@ -127,7 +127,7 @@ module Header = {
       | LoginWithPassword | LoginWithEmail =>
         <RenderIf condition={signUpAllowed}>
           {getHeaderLink(
-            ~prefix="New to Hyperswitch?",
+            ~prefix={branding ? "New here?" : "New to Hyperswitch?"},
             ~authType=SignUP,
             ~path="/register",
             ~suffix="Sign up",
@@ -136,7 +136,7 @@ module Header = {
 
       | SignUP =>
         getHeaderLink(
-          ~prefix="Already using Hyperswitch?",
+          ~prefix={branding ? "Already have an account?" : "Already using Hyperswitch?"},
           ~authType=isMagicLinkEnabled ? LoginWithEmail : LoginWithPassword,
           ~path=`/login?auth_id=${authId}`,
           ~suffix="Sign in",


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
When the `branding` feature flag is OFF, the sign-in / sign-up pages still showed Hyperswitch-branded copy. This gates them behind `branding`, mirroring how `AuthWrapper.res` already hides the footer & T&C when branding is off.

Changes in `src/entryPoints/AuthModule/Common/CommonAuth.res` (`Header` component):
- Destructure `branding` from `featureFlagAtom`.
- "New to Hyperswitch?" → "New here?" when branding is off.
- "Already using Hyperswitch?" → "Already have an account?" when branding is off.
- Signup heading "Welcome to Hyperswitch" → "Welcome" when branding is off.

## Motivation and Context
Closes #5324. Branding flag was inconsistently applied — footer/T&C hidden but auth header prompts still leaked the Hyperswitch name.

## How did you test it?
- `npm run re:build` — green (3170/3170 modules compiled).
- `npm run build:prod` (webpack) — compiled successfully (only pre-existing asset-size warnings).

## Where to test it?
- [x] SANDBOX

## Backend Dependency
- [x] No

## Feature Flag
- [x] Existing feature flag updated

Feature flag name(s): branding

## Checklist
- [x] I ran `npm run re:build`
- [x] I reviewed submitted code