### PR TITLE
fix: default webhooks time range to today

### DIFF
--- a/src/screens/Developer/Webhooks/Webhooks.res
+++ b/src/screens/Developer/Webhooks/Webhooks.res
@@ -49,7 +49,7 @@ let make = () => {
     ~compareToStartTimeKey="",
     ~compareToEndTimeKey="",
     ~comparisonKey="",
-    ~range=30,
+    ~range=0,
     ~origin="orders",
     (),
   )
@@ -78,7 +78,7 @@ let make = () => {
   let fetchWebhooks = async (~searchType=?) => {
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-      let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=30)
+      let defaultDate = HSwitchRemoteFilter.getDateFilteredObject(~range=0)
       let start_time = filterValueJson->getString(startTimeFilterKey, defaultDate.start_time)
       let end_time = filterValueJson->getString(endTimeFilterKey, defaultDate.end_time)
 

--- a/src/screens/Developer/Webhooks/WebhooksUtils.res
+++ b/src/screens/Developer/Webhooks/WebhooksUtils.res
@@ -74,7 +74,7 @@ let (startTimeFilterKey, endTimeFilterKey) = ("start_time", "end_time")
 
 let getAllowedDateRange = {
   let endDate = Date.now()->Js.Date.fromFloat->DateTimeUtils.toUtc->DayJs.getDayJsForJsDate //->Date.toISOString->JSON.Encode.string
-  let startDate = endDate.subtract(90, "day")
+  let startDate = endDate.subtract(3, "day")
 
   let dateObject: Calendar.dateObj = {
     startDate: startDate.toString(),
@@ -110,7 +110,7 @@ let initialFixedFilter = () => [
           ],
           ~numMonths=2,
           ~disableApply=false,
-          ~dateRangeLimit=90,
+          ~dateRangeLimit=3,
           ~allowedDateRange=getAllowedDateRange,
         ),
         ~inputFields=[],


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Changes the Webhooks page default time range from the previous 30 days to Today and restrict time range selection to 3 days. Both the visible filter initialization and the API fallback now use midnight today through the current time.


https://github.com/user-attachments/assets/517d8479-6701-40fc-8a80-c57378530fab


https://github.com/user-attachments/assets/1fa33557-fdb6-4fba-948f-83bab4e316d8



## Motivation and Context

The Webhooks page should focus on current-day events when first opened.

Closes #5330

## How did you test it?

- Ran npm run re:build successfully.
- Ran git diff --check successfully.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran npm run re:build
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible