### PR TITLE
refactor: replace recon cursor pagination Prev/Next buttons with arrow icons

### DIFF
--- a/src/ReconEngine/ReconEngineHooks/ReconEngineCursorPaginationButtons.res
+++ b/src/ReconEngine/ReconEngineHooks/ReconEngineCursorPaginationButtons.res
@@ -10,19 +10,27 @@ let make = (
     cursor->Option.isNone || isLoading ? Button.Disabled : Button.Normal
 
   <RenderIf condition=hasData>
-    <div className="flex flex-row justify-end items-center gap-3 py-4">
+    <div className="flex flex-row justify-end items-center gap-2 py-4">
       <Button
-        text="Prev"
+        leftIcon={FontAwesome("chevron-left")}
         buttonType=Secondary
         buttonSize=Small
         buttonState={getButtonState(cursors.prev)}
+        customButtonStyle="!w-8 !px-0"
+        customIconMargin=""
+        showTooltip=true
+        tooltipText="Previous page"
         onClick={_ => onPrev()}
       />
       <Button
-        text="Next"
-        buttonType=Primary
+        leftIcon={FontAwesome("chevron-right")}
+        buttonType=Secondary
         buttonSize=Small
         buttonState={getButtonState(cursors.next)}
+        customButtonStyle="!w-8 !px-0"
+        customIconMargin=""
+        showTooltip=true
+        tooltipText="Next page"
         onClick={_ => onNext()}
       />
     </div>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Replaced the "Prev"/"Next" text buttons in `ReconEngineCursorPaginationButtons` with icon-only chevron-left / chevron-right arrow buttons, built with the shared `Button` component (icon-only via `leftIcon`, native disabled state, existing `Secondary` theming). Since this is the single shared cursor-pagination component, every recon screen using it (Pipelines, Transactions, Data Overview, Data Transformed Entries, Exceptions, Overview Details) picks up the change automatically.

<img width="1366" height="843" alt="image" src="https://github.com/user-attachments/assets/4f0ed871-ad71-4a23-8ebf-3e054a397158" />


## Motivation and Context

Reduces visual weight of pagination controls in dense recon tables.

Closes #5340

## How did you test it?

Manual: `npm run re:build` passes with no compile errors. Verified hover/disabled/focus states render correctly via the shared `Button` component's existing state handling.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
