### PR TITLE
fix: gate OMP create access on permission groups instead of hardcoded role IDs

### DIFF
--- a/src/Hypersense/HypersenseScreens/HypersenseConfiguration.res
+++ b/src/Hypersense/HypersenseScreens/HypersenseConfiguration.res
@@ -4,8 +4,8 @@ let make = () => {
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {setCreateNewMerchant} = React.useContext(ProductSelectionProvider.defaultContext)
   let userHasCreateMerchantAccess = OMPCreateAccessHook.useOMPCreateAccessHook([
-    #tenant_admin,
-    #org_admin,
+    #Tenant,
+    #Organization,
   ])
 
   <div className="flex flex-1 flex-col gap-14 items-center justify-center w-full h-screen">

--- a/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingHome.res
+++ b/src/IntelligentRouting/IntelligentRoutingScreens/IntelligentRoutingHome.res
@@ -9,8 +9,8 @@ let make = () => {
   let {setShowSideBar} = React.useContext(GlobalProvider.defaultContext)
 
   let userHasCreateMerchantAccess = OMPCreateAccessHook.useOMPCreateAccessHook([
-    #tenant_admin,
-    #org_admin,
+    #Tenant,
+    #Organization,
   ])
   let mixpanelEvent = MixpanelHook.useSendEvent()
 

--- a/src/Recon/ReconScreens/ReconConfiguration/ConnectProcessors/ConnectProcessorsHelper.res
+++ b/src/Recon/ReconScreens/ReconConfiguration/ConnectProcessors/ConnectProcessorsHelper.res
@@ -80,13 +80,13 @@ module AddNewOMPButton = {
   ) => {
     open ConnectorUtils
 
-    let allowedRoles = switch user {
-    | #Organization => [#tenant_admin]
-    | #Merchant => [#tenant_admin, #org_admin]
-    | #Profile => [#tenant_admin, #org_admin, #merchant_admin]
+    let allowedEntities = switch user {
+    | #Organization => [#Tenant]
+    | #Merchant => [#Tenant, #Organization]
+    | #Profile => [#Tenant, #Organization, #Merchant]
     | _ => []
     }
-    let hasOMPCreateAccess = OMPCreateAccessHook.useOMPCreateAccessHook(allowedRoles)
+    let hasOMPCreateAccess = OMPCreateAccessHook.useOMPCreateAccessHook(allowedEntities)
     let cursorStyles = GroupAccessUtils.cursorStyles(hasOMPCreateAccess)
     let connectorsList = switch filterConnector {
     | Some(connector) => prodConnectorList->Array.filter(item => item != connector)

--- a/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
+++ b/src/Recon/ReconScreens/ReconOnboarding/ReconOnboardingHelper.res
@@ -8,8 +8,8 @@ module ReconOnboardingLanding = {
     )
     let {setShowSideBar} = React.useContext(GlobalProvider.defaultContext)
     let userHasCreateMerchantAccess = OMPCreateAccessHook.useOMPCreateAccessHook([
-      #tenant_admin,
-      #org_admin,
+      #Tenant,
+      #Organization,
     ])
 
     let mixpanelEvent = MixpanelHook.useSendEvent()

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingLanding.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingLanding.res
@@ -5,8 +5,8 @@ let make = (~createMerchant) => {
   let mixpanelEvent = MixpanelHook.useSendEvent()
   let {setCreateNewMerchant} = React.useContext(ProductSelectionProvider.defaultContext)
   let userHasCreateMerchantAccess = OMPCreateAccessHook.useOMPCreateAccessHook([
-    #tenant_admin,
-    #org_admin,
+    #Tenant,
+    #Organization,
   ])
 
   <div className="flex flex-1 flex-col gap-6 items-center w-full">

--- a/src/Vault/VaultScreens/VaultHome.res
+++ b/src/Vault/VaultScreens/VaultHome.res
@@ -6,8 +6,8 @@ let make = () => {
   let mixpanelEvent = MixpanelHook.useSendEvent()
 
   let userHasCreateMerchantAccess = OMPCreateAccessHook.useOMPCreateAccessHook([
-    #tenant_admin,
-    #org_admin,
+    #Tenant,
+    #Organization,
   ])
 
   <div className="flex flex-1 flex-col gap-14 items-center justify-center w-full h-screen">

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -182,13 +182,13 @@ module AddNewOMPButton = {
     ~customHRTagStyle="",
     ~addItemBtnStyle="",
   ) => {
-    let allowedRoles = switch user {
-    | #Organization => [#tenant_admin]
-    | #Merchant => [#tenant_admin, #org_admin]
-    | #Profile => [#tenant_admin, #org_admin, #merchant_admin]
+    let allowedEntities = switch user {
+    | #Organization => [#Tenant]
+    | #Merchant => [#Tenant, #Organization]
+    | #Profile => [#Tenant, #Organization, #Merchant]
     | _ => []
     }
-    let hasOMPCreateAccess = OMPCreateAccessHook.useOMPCreateAccessHook(allowedRoles)
+    let hasOMPCreateAccess = OMPCreateAccessHook.useOMPCreateAccessHook(allowedEntities)
     let cursorStyles = GroupAccessUtils.cursorStyles(hasOMPCreateAccess)
 
     <ACLDiv

--- a/src/screens/OrchestrationHooks/OMPCreateAccessHook.res
+++ b/src/screens/OrchestrationHooks/OMPCreateAccessHook.res
@@ -1,17 +1,16 @@
-type adminType = [#tenant_admin | #org_admin | #merchant_admin | #non_admin]
+/*
+ Grants create access for an org/merchant/profile when the user's role is scoped to one of
+ the allowed parent entities and holds the `account_manage` permission group, mirroring the
+ backend permission check. This keeps custom roles with the required permission groups on
+ par with the built-in admin roles.
+*/
+let useOMPCreateAccessHook: array<
+  UserInfoTypes.entity,
+> => CommonAuthTypes.authorization = allowedEntities => {
+  let {checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
+  let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
 
-let roleIdVariantMapper: string => adminType = roleId => {
-  switch roleId {
-  | "tenant_admin" => #tenant_admin
-  | "org_admin" => #org_admin
-  | "merchant_admin" => #merchant_admin
-  | _ => #non_admin
-  }
-}
-
-let useOMPCreateAccessHook: array<adminType> => CommonAuthTypes.authorization = allowedRoles => {
-  let {roleId} = React.useContext(UserInfoProvider.defaultContext).getResolvedUserInfo()
-  let roleIdTypedValue = roleId->roleIdVariantMapper
-
-  allowedRoles->Array.includes(roleIdTypedValue) ? Access : NoAccess
+  checkUserEntity(allowedEntities)
+    ? userHasAccess(~groupAccess=UserManagementTypes.AccountManage)
+    : NoAccess
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

`useOMPCreateAccessHook` now grants org/merchant/profile create access based on the user's role entity scope plus the `account_manage` permission group, instead of matching hardcoded built-in role IDs. This makes the OMP "Create new" buttons work for custom roles with the required permission groups, consistent with the backend permission check.

## Motivation and Context

Fixes #5346

## How did you test it?

Compiled with `npm run re:build` and reviewed all `useOMPCreateAccessHook` call sites. Built-in admin roles keep the same access (their entity scope and permission groups match the previous role-ID gating); custom roles now follow their assigned permission groups.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

Backend PR URL:

## Feature Flag

- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
