### PR TITLE
refactor: reorder recon transaction table columns to lead with signal, not identifiers

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/EntriesTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/EntriesTableEntity.res
@@ -59,10 +59,10 @@ let transactionEntriesDetailFields = [
   Amount,
   Currency,
   Status,
-  EntryId,
   OrderID,
   EffectiveAt,
   CreatedAt,
+  EntryId,
   Actions,
 ]
 
@@ -76,8 +76,8 @@ let getHeading = (colType: entryColType) => {
   | Currency => Table.makeHeaderInfo(~key="currency", ~title="Currency")
   | Status => Table.makeHeaderInfo(~key="status", ~title="Status")
   | Metadata => Table.makeHeaderInfo(~key="metadata", ~title="Metadata")
-  | CreatedAt => Table.makeHeaderInfo(~key="created_at", ~title="Created At")
-  | EffectiveAt => Table.makeHeaderInfo(~key="effective_at", ~title="Effective At")
+  | CreatedAt => Table.makeHeaderInfo(~key="created_at", ~title="Created At (System)")
+  | EffectiveAt => Table.makeHeaderInfo(~key="effective_at", ~title="Effective At (File)")
   | OrderID => Table.makeHeaderInfo(~key="order_id", ~title="Order ID")
   | Actions => Table.makeHeaderInfo(~key="actions", ~title="Actions")
   }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
@@ -19,7 +19,6 @@ type hierarchicalColType =
 let defaultColumns: array<hierarchicalColType> = [
   Flow,
   Date,
-  TransactionId,
   Status,
   EntryId,
   OrderId,
@@ -28,12 +27,12 @@ let defaultColumns: array<hierarchicalColType> = [
   Currency,
   DebitAmount,
   CreditAmount,
+  TransactionId,
 ]
 
 let allColumns: array<hierarchicalColType> = [
   Flow,
   Date,
-  TransactionId,
   Status,
   EntryId,
   OrderId,
@@ -42,6 +41,7 @@ let allColumns: array<hierarchicalColType> = [
   Currency,
   DebitAmount,
   CreditAmount,
+  TransactionId,
 ]
 
 let getHeading = (colType: hierarchicalColType) => {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Moves Transaction ID to the last column on the Transactions list page, so Status/Entry ID/Order ID/Account lead the row instead of an internal identifier.
- Moves Entry ID to just before the Actions column on the transaction detail page's Entries tab, for the same reason.
- Clarifies the Created At / Effective At column headers as "Created At (System)" / "Effective At (File)" since both timestamps sit side by side and were easy to conflate.

Closes #5350

## Motivation and Context

Both tables led with internal transaction/entry identifiers ahead of the status and matching fields users actually scan first, pushing the more relevant columns further right.

## How did you test it?

- Ran `npx rescript build` successfully.
- Ran the repository ReScript formatting check through the commit hook successfully.
- Verified in a local dev environment that the Transactions list page and the transaction detail Entries tab render with the new column order.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible