### PR TITLE
fix: recon engine map multiple expected entries found exception

### DIFF
--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -198,8 +198,7 @@ let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEnt
 
 let paymentMethodBlockingWalletEntryMapper = (walletDict, key, legacyEntry) => {
   let entryDict = walletDict->getDictfromDict(key)
-  entryDict->isEmptyDict ? legacyEntry : 
-    Some(entryDict->paymentMethodBlockingEntryMapper)
+  entryDict->isEmptyDict ? legacyEntry : Some(entryDict->paymentMethodBlockingEntryMapper)
 }
 
 let paymentMethodBlockingWalletMapper: Dict.t<

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
@@ -470,7 +470,7 @@ module ExceptionDataDisplay = {
         "No Expectation Entry Found",
         "No corresponding expectation entry was found for the transformed entry.",
       )
-    | MultipleExceptedEntriesFound => (
+    | MultipleExpectedEntriesFound => (
         "Multiple Excepted Entries Found",
         "Multiple excepted entries were found for the transformed entry.",
       )

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
@@ -471,8 +471,8 @@ module ExceptionDataDisplay = {
         "No corresponding expectation entry was found for the transformed entry.",
       )
     | MultipleExpectedEntriesFound => (
-        "Multiple Excepted Entries Found",
-        "Multiple excepted entries were found for the transformed entry.",
+        "Multiple Expected Entries Found",
+        "Multiple expected entries were found for the transformed entry.",
       )
     | MissingMatchField => (
         "Missing Match Field",

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesStatCards.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesStatCards.res
@@ -45,7 +45,7 @@ let make = (~refreshTrigger=false) => {
       setStagingOverviewData(_ => stagingOverviewData)
       setScreenState(_ => PageLoaderWrapper.Success)
     } catch {
-    | _ => setScreenState(_ => PageLoaderWrapper.Error("Failed to fetch"))
+    | _ => setScreenState(_ => PageLoaderWrapper.Custom)
     }
   }
 

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -301,7 +301,7 @@ type needsManualReviewType =
   | @as("missing_search_identifier_value") MissingSearchIdentifierValue
   | @as("duplicate_entry") DuplicateEntry
   | @as("no_expectation_entry_found") NoExpectationEntryFound
-  | @as("multiple_excepted_entries_found") MultipleExceptedEntriesFound
+  | @as("multiple_expected_entries_found") MultipleExpectedEntriesFound
   | @as("missing_match_field") MissingMatchField
   | @as("missing_unique_field") MissingUniqueField
   | @as("missing_grouping_field") MissingGroupingField


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Recon engine map multiple expected entries found exception

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
