### PR TITLE
feat: support prefix and suffix operators in recon transformation skip rules

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -579,6 +579,10 @@ let describeSkipConditionOperator = (operator: skipConditionOperator): string =>
   | NotEquals => "≠"
   | Contains => "contains"
   | NotContains => "does not contain"
+  | StartsWith => "starts with"
+  | NotStartsWith => "does not start with"
+  | EndsWith => "ends with"
+  | NotEndsWith => "does not end with"
   | UnknownSkipConditionOperator => "unknown"
   }
 

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -116,6 +116,10 @@ type skipConditionOperator =
   | NotEquals
   | Contains
   | NotContains
+  | StartsWith
+  | NotStartsWith
+  | EndsWith
+  | NotEndsWith
   | UnknownSkipConditionOperator
 
 type skipCondition = {

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -338,6 +338,10 @@ let skipConditionOperatorMapper = (str): skipConditionOperator => {
   | "not_equals" => NotEquals
   | "contains" => Contains
   | "not_contains" => NotContains
+  | "starts_with" => StartsWith
+  | "not_starts_with" => NotStartsWith
+  | "ends_with" => EndsWith
+  | "not_ends_with" => NotEndsWith
   | _ => UnknownSkipConditionOperator
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds the four new backend skip-condition operators to the recon engine's transformation skip rules, so they are parsed and rendered instead of falling back to `unknown`.

- `ReconEngineTypes.res`: extends the `skipConditionOperator` variant with `StartsWith`, `NotStartsWith`, `EndsWith`, `NotEndsWith`.
- `ReconEngineUtils.res`: maps the backend's snake_case tags (`starts_with`, `not_starts_with`, `ends_with`, `not_ends_with`) in `skipConditionOperatorMapper`.
- `ReconEnginePipelinesUtils.res`: renders them in `describeSkipConditionOperator` as `starts with` / `does not start with` / `ends with` / `does not end with`, matching the existing `contains` / `does not contain` phrasing.

These show up in the **Skip rules** section of the transformation run details modal on the pipeline details page, e.g. `Skip rows where status starts with "REF"`.

## Motivation and Context

Closes juspay/hyperswitch-control-center-cloud#431

The backend added `StartsWith`, `NotStartsWith`, `EndsWith` and `NotEndsWith` to its `SkipOperator` enum. The frontend models the operator as a typed variant, so any transformation configured with one of the new operators was mapped to `UnknownSkipConditionOperator` and displayed as `status unknown "REF"`.

## How did you test it?

Verified the mapper and the renderer end to end against the compiled output, covering every operator plus the unknown fallback:

| Backend value | Variant | Rendered |
| --- | --- | --- |
| `equals` | `Equals` | `status = "REF"` |
| `not_equals` | `NotEquals` | `status ≠ "REF"` |
| `contains` | `Contains` | `status contains "REF"` |
| `not_contains` | `NotContains` | `status does not contain "REF"` |
| `starts_with` | `StartsWith` | `status starts with "REF"` |
| `not_starts_with` | `NotStartsWith` | `status does not start with "REF"` |
| `ends_with` | `EndsWith` | `status ends with "REF"` |
| `not_ends_with` | `NotEndsWith` | `status does not end with "REF"` |
| any unrecognised value | `UnknownSkipConditionOperator` | `status unknown "REF"` |

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

- [x] Yes
- [ ] No

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible


<img width="612" height="77" alt="Screenshot 2026-08-10 at 4 03 13 PM" src="https://github.com/user-attachments/assets/2bb59c61-2f13-4341-9f78-f2b9b2b8cf84" />


<img width="468" height="315" alt="Screenshot 2026-08-10 at 4 03 22 PM" src="https://github.com/user-attachments/assets/b91fcbfe-ae3d-48a2-a8f2-dd0a417822f8" />

