### PR TITLE
refactor: unify live and sandbox connector lists into a single config source

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -97,20 +97,14 @@ dev_sort_enabled=true
 dev_saved_views=false
 dev_clickhouse_aggregate=false
 [default.connector_list_for_live]
-paymentProcessors = ["adyen","authorizedotnet","archipel","airwallex","bankofamerica","bluesnap","bambora","braintree","calida","checkout","cryptopay","cashtocode","cybersource","coingate","datatrans","fiuu","gigadat","iatapay","klarna","loonio","mifinity","mollie","nexixpay","nmi","novalnet","nuvei","paypal","paybox","payme","peachpayments","redsys","stripe","trustpay","volt","worldpay","worldpayxml","zift","zsl","zen","worldpaymodular","payjustnow","payjustnowinstore","payload","finix"]
-threedsAuthProcessors = ["netcetera","juspaythreedsserver","ctp_visa"]
-payoutProcessors = ["adyen","adyenplatform","cybersource","ebanx","paypal","stripe","wise","nomupay","nuvei","gigadat","loonio","worldpay","worldpayxml"]
-vaultProcessors = ["vgs"]
-
-[default.connector_list_for_sandbox]
-paymentProcessors = ["stripe","paypal","aci","adyen","affirm","airwallex","authorizedotnet","bankofamerica","bambora","billwerk","bitpay","blackhawknetwork","bluesnap","braintree","cashtocode","checkbook","checkout","coinbase","coingate","cryptopay","cybersource","datatrans","dlocal","dwolla","elavon","fiserv","fiservemea","forte","globalpay","globepay","gocardless","helcim","iatapay","klarna","mifinity","mollie","multisafepay","nexinets","nmi","noon","nuvei","opennode","payjustnow","payme","payu","peachpayments","powertranz","prophetpay","rapyd","shift4","stax","trustpay","tsys","volt","worldline","worldpay","worldpayxml","zen","zsl","placetopay","razorpay","bamboraapac","itaubank","plaid","square","paybox","fiuu","wellsfargo","novalnet","deutschebank","nexixpay","nordea","jpmorgan","xendit","inespay","moneris","redsys","hipay","paystack","facilitapay","archipel","authipay","worldpayvantiv","barclaycard","silverflow","tokenio","payload","paytm","phonepe","flexiti","breadpay","calida","paysafe","gigadat","loonio","tesouro","finix","zift","payjustnowinstore","fiservcommercehub","amazonpay","worldpaymodular","santander","revolv3","truelayer","trustly","imerchantsolutions","payconex","tsys_transit","givepayments"]
-threedsAuthProcessors = ["threedsecureio","netcetera","ctp_mastercard","juspaythreedsserver","ctp_visa","cardinal"]
-payoutProcessors = ["adyen","adyenplatform","cybersource","ebanx","itaubank","paypal","stripe","wise","nomupay","nuvei","gigadat","loonio","worldpay","worldpayxml","truelayer","envoy","trustly"]
-vaultProcessors = ["vgs"]
-pmAuthProcessors = ["plaid"]
-billingProcessors = ["chargebee"]
-surchargeProcessors = ["interpayments"]
-taxProcessors = ["taxjar"]
+paymentProcessors = []
+threedsAuthProcessors = []
+payoutProcessors = []
+vaultProcessors = []
+pmAuthProcessors = []
+billingProcessors = []
+surchargeProcessors = []
+taxProcessors = []
 
 [default.connector_clone]
 paymentProcessors = ["peachpayments"]

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -198,8 +198,7 @@ let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEnt
 
 let paymentMethodBlockingWalletEntryMapper = (walletDict, key, legacyEntry) => {
   let entryDict = walletDict->getDictfromDict(key)
-  entryDict->isEmptyDict ? legacyEntry : 
-    Some(entryDict->paymentMethodBlockingEntryMapper)
+  entryDict->isEmptyDict ? legacyEntry : Some(entryDict->paymentMethodBlockingEntryMapper)
 }
 
 let paymentMethodBlockingWalletMapper: Dict.t<

--- a/src/Recoils/HyperswitchAtom.res
+++ b/src/Recoils/HyperswitchAtom.res
@@ -31,17 +31,13 @@ let featureFlagAtom: Recoil.recoilAtom<FeatureFlagUtils.featureFlag> = Recoil.at
   "featureFlag",
   JSON.Encode.null->FeatureFlagUtils.featureFlagType,
 )
-let connectorListForLiveAtom: Recoil.recoilAtom<
-  ConnectorListFromConfigTypes.connectorListForLive,
+// Seeded with the sandbox defaults since the feature flags are not resolved yet
+// at module init; HyperSwitchEntry overwrites this once the config is fetched.
+let connectorDisplayListAtom: Recoil.recoilAtom<
+  ConnectorListFromConfigTypes.connectorDisplayList,
 > = Recoil.atom(
-  "connectorListForLive",
-  JSON.Encode.null->ConnectorListFromConfigUtils.getConnectorListForLive,
-)
-let connectorListForSandboxAtom: Recoil.recoilAtom<
-  ConnectorListFromConfigTypes.connectorListForSandbox,
-> = Recoil.atom(
-  "connectorListForSandbox",
-  JSON.Encode.null->ConnectorListFromConfigUtils.getConnectorListForSandbox,
+  "connectorDisplayList",
+  JSON.Encode.null->ConnectorListFromConfigUtils.getConnectorDisplayList(~isLiveMode=false),
 )
 let connectorCloneAllowListAtom: Recoil.recoilAtom<array<string>> = Recoil.atom(
   "connectorCloneAllowList",

--- a/src/embeddable/EmbeddableEntry.res
+++ b/src/embeddable/EmbeddableEntry.res
@@ -16,6 +16,7 @@ module EmbeddableEntryComponent = {
   let make = () => {
     let fetchDetails = APIUtils.useGetMethod()
     let setFeatureFlag = HyperswitchAtom.featureFlagAtom->Recoil.useSetRecoilState
+    let setConnectorDisplayList = HyperswitchAtom.connectorDisplayListAtom->Recoil.useSetRecoilState
     let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
 
     let configEnv = (urlConfig: JSON.t) => {
@@ -35,7 +36,12 @@ module EmbeddableEntryComponent = {
         let apiURL = `${GlobalVars.getHostUrlWithBasePath}/config/feature?domain=""` // todo: domain shall be removed from query params later
         let res = await fetchDetails(apiURL)
         let featureFlags = res->FeatureFlagUtils.featureFlagType
+        let connectorDisplayList =
+          res->ConnectorListFromConfigUtils.getConnectorDisplayList(
+            ~isLiveMode=featureFlags.isLiveMode,
+          )
         setFeatureFlag(_ => featureFlags)
+        setConnectorDisplayList(_ => connectorDisplayList)
         let _ = configEnv(res) // to set initial env
         // Delay added on Expecting feature flag recoil gets updated
         await HyperSwitchUtils.delay(1000)

--- a/src/entryPoints/ConnectorListFromConfigTypes.res
+++ b/src/entryPoints/ConnectorListFromConfigTypes.res
@@ -1,17 +1,10 @@
-type connectorListForLive = {
-  paymentProcessorsLiveList: array<ConnectorTypes.connectorTypes>,
-  payoutProcessorsLiveList: array<ConnectorTypes.connectorTypes>,
-  threeDsAuthenticatorProcessorsLiveList: array<ConnectorTypes.connectorTypes>,
-  vaultProcessorsLiveList: array<ConnectorTypes.connectorTypes>,
-}
-
-type connectorListForSandbox = {
-  paymentProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  payoutProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  threeDsAuthenticatorProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  vaultProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  pmAuthProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  billingProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  surchargeProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
-  taxProcessorsSandboxList: array<ConnectorTypes.connectorTypes>,
+type connectorDisplayList = {
+  paymentProcessorsList: array<ConnectorTypes.connectorTypes>,
+  payoutProcessorsList: array<ConnectorTypes.connectorTypes>,
+  threeDsAuthenticatorProcessorsList: array<ConnectorTypes.connectorTypes>,
+  vaultProcessorsList: array<ConnectorTypes.connectorTypes>,
+  pmAuthProcessorsList: array<ConnectorTypes.connectorTypes>,
+  billingProcessorsList: array<ConnectorTypes.connectorTypes>,
+  surchargeProcessorsList: array<ConnectorTypes.connectorTypes>,
+  taxProcessorsList: array<ConnectorTypes.connectorTypes>,
 }

--- a/src/entryPoints/ConnectorListFromConfigUtils.res
+++ b/src/entryPoints/ConnectorListFromConfigUtils.res
@@ -27,84 +27,56 @@ let resolveConnectorListFromConfig = (~connectorDict, ~key, ~connectorType, ~fal
   fromConfig->isNonEmptyArray ? fromConfig : fallback
 }
 
-let getConnectorListForLive = (list: JSON.t): connectorListForLive => {
+// Single source of truth for the connectors shown across the app. The config
+// table is read as-is; `isLiveMode` only decides which hardcoded list stands in
+// when a category is absent or has no valid entries in the config.
+let getConnectorDisplayList = (~isLiveMode, list: JSON.t): connectorDisplayList => {
   open ConnectorUtils
   let connectorDict = list->getDictFromJsonObject->getDictfromDict("connector_list_for_live")
   {
-    paymentProcessorsLiveList: resolveConnectorListFromConfig(
+    paymentProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="paymentProcessors",
       ~connectorType=Processor,
-      ~fallback=connectorListForLive,
+      ~fallback=isLiveMode ? connectorListForLive : connectorList,
     ),
-    payoutProcessorsLiveList: resolveConnectorListFromConfig(
+    payoutProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="payoutProcessors",
       ~connectorType=PayoutProcessor,
-      ~fallback=payoutConnectorListForLive,
+      ~fallback=isLiveMode ? payoutConnectorListForLive : payoutConnectorList,
     ),
-    threeDsAuthenticatorProcessorsLiveList: resolveConnectorListFromConfig(
+    threeDsAuthenticatorProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="threedsAuthProcessors",
       ~connectorType=ThreeDsAuthenticator,
-      ~fallback=threedsAuthenticatorListForLive,
+      ~fallback=isLiveMode ? threedsAuthenticatorListForLive : threedsAuthenticatorList,
     ),
-    vaultProcessorsLiveList: resolveConnectorListFromConfig(
+    vaultProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="vaultProcessors",
       ~connectorType=VaultProcessor,
       ~fallback=vaultProcessorList,
     ),
-  }
-}
-
-let getConnectorListForSandbox = (list: JSON.t): connectorListForSandbox => {
-  open ConnectorUtils
-  let connectorDict = list->getDictFromJsonObject->getDictfromDict("connector_list_for_sandbox")
-  {
-    paymentProcessorsSandboxList: resolveConnectorListFromConfig(
-      ~connectorDict,
-      ~key="paymentProcessors",
-      ~connectorType=Processor,
-      ~fallback=connectorList,
-    ),
-    payoutProcessorsSandboxList: resolveConnectorListFromConfig(
-      ~connectorDict,
-      ~key="payoutProcessors",
-      ~connectorType=PayoutProcessor,
-      ~fallback=payoutConnectorList,
-    ),
-    threeDsAuthenticatorProcessorsSandboxList: resolveConnectorListFromConfig(
-      ~connectorDict,
-      ~key="threedsAuthProcessors",
-      ~connectorType=ThreeDsAuthenticator,
-      ~fallback=threedsAuthenticatorList,
-    ),
-    vaultProcessorsSandboxList: resolveConnectorListFromConfig(
-      ~connectorDict,
-      ~key="vaultProcessors",
-      ~connectorType=VaultProcessor,
-      ~fallback=vaultProcessorList,
-    ),
-    pmAuthProcessorsSandboxList: resolveConnectorListFromConfig(
+    pmAuthProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="pmAuthProcessors",
       ~connectorType=PMAuthenticationProcessor,
       ~fallback=pmAuthenticationConnectorList,
     ),
-    billingProcessorsSandboxList: resolveConnectorListFromConfig(
+    billingProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="billingProcessors",
       ~connectorType=BillingProcessor,
       ~fallback=billingProcessorList,
     ),
-    surchargeProcessorsSandboxList: resolveConnectorListFromConfig(
+    surchargeProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="surchargeProcessors",
       ~connectorType=SurchargeProcessor,
       ~fallback=surchargeProcessorList,
     ),
-    taxProcessorsSandboxList: resolveConnectorListFromConfig(
+    taxProcessorsList: resolveConnectorListFromConfig(
       ~connectorDict,
       ~key="taxProcessors",
       ~connectorType=TaxProcessor,

--- a/src/entryPoints/HyperSwitchEntry.res
+++ b/src/entryPoints/HyperSwitchEntry.res
@@ -8,8 +8,7 @@ module HyperSwitchEntryComponent = {
     let url = RescriptReactRouter.useUrl()
     let (_zone, setZone) = React.useContext(UserTimeZoneProvider.userTimeContext)
     let setFeatureFlag = featureFlagAtom->Recoil.useSetRecoilState
-    let setConnectorListForLive = connectorListForLiveAtom->Recoil.useSetRecoilState
-    let setConnectorListForSandbox = connectorListForSandboxAtom->Recoil.useSetRecoilState
+    let setConnectorDisplayList = connectorDisplayListAtom->Recoil.useSetRecoilState
     let setConnectorCloneAllowList = connectorCloneAllowListAtom->Recoil.useSetRecoilState
     let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
     let {getThemesJson} = React.useContext(ThemeProvider.themeContext)
@@ -83,12 +82,10 @@ module HyperSwitchEntryComponent = {
           )}` // todo: domain shall be removed from query params later
         let res = await fetchDetails(apiURL)
         let featureFlags = res->FeatureFlagUtils.featureFlagType
-        let connectorListForLive = res->getConnectorListForLive
-        let connectorListForSandbox = res->getConnectorListForSandbox
+        let connectorDisplayList = res->getConnectorDisplayList(~isLiveMode=featureFlags.isLiveMode)
         let connectorCloneAllowList = res->ConnectorCloneConfigUtils.getConnectorCloneAllowList
         setFeatureFlag(_ => featureFlags)
-        setConnectorListForLive(_ => connectorListForLive)
-        setConnectorListForSandbox(_ => connectorListForSandbox)
+        setConnectorDisplayList(_ => connectorDisplayList)
         setConnectorCloneAllowList(_ => connectorCloneAllowList)
         let _ = configEnv(res) // to set initial env
         let _ = await getThemesJson(~themesID=themeId, ~domain)

--- a/src/entryPoints/SidebarHooks.res
+++ b/src/entryPoints/SidebarHooks.res
@@ -6,8 +6,7 @@ open HyperswitchAtom
 
 let useGetHsSidebarValues = () => {
   let featureFlagDetails = featureFlagAtom->Recoil.useRecoilValueFromAtom
-  let connectorListForLive = connectorListForLiveAtom->Recoil.useRecoilValueFromAtom
-  let connectorListForSandbox = connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let connectorDisplayList = connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
   let {userHasResourceAccess, userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let {getResolvedUserInfo, checkUserEntity} = React.useContext(UserInfoProvider.defaultContext)
   let {userEntity} = getResolvedUserInfo()
@@ -16,7 +15,6 @@ let useGetHsSidebarValues = () => {
     payOut,
     default,
     surcharge: isSurchargeEnabled,
-    isLiveMode,
     threedsAuthenticator,
     disputeAnalytics,
     configurePmts,
@@ -70,7 +68,6 @@ let useGetHsSidebarValues = () => {
       ~isCurrentMerchantPlatform,
     ),
     default->connectors(
-      ~isLiveMode,
       ~isFrmEnabled=frm,
       ~isPayoutsEnabled=payOut,
       ~isThreedsConnectorEnabled=threedsAuthenticator,
@@ -82,8 +79,7 @@ let useGetHsSidebarValues = () => {
       ~isSurchargeProcessor=surchargeProcessor,
       ~isCurrentMerchantPlatform,
       ~isCurrentMerchantConnected,
-      ~connectorListForLive,
-      ~connectorListForSandbox,
+      ~connectorDisplayList,
     ),
     default->analytics(
       disputeAnalytics,

--- a/src/entryPoints/SidebarValues.res
+++ b/src/entryPoints/SidebarValues.res
@@ -129,35 +129,25 @@ let operations = (
     : emptyComponent
 }
 
-let paymentProcessor = (
-  isLiveMode,
-  userHasResourceAccess,
-  ~paymentProcessorsLiveList,
-  ~paymentProcessorsSandboxList,
-) => {
+let paymentProcessor = (userHasResourceAccess, ~paymentProcessorsList) => {
   SubLevelLink({
     name: "Payment Processors",
     link: `/connectors`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=isLiveMode ? paymentProcessorsLiveList : paymentProcessorsSandboxList,
+      ~processorList=paymentProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let payoutConnectors = (
-  ~isLiveMode,
-  ~userHasResourceAccess,
-  ~payoutProcessorsLiveList,
-  ~payoutProcessorsSandboxList,
-) => {
+let payoutConnectors = (~userHasResourceAccess, ~payoutProcessorsList) => {
   SubLevelLink({
     name: "Payout Processors",
     link: `/payoutconnectors`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=isLiveMode ? payoutProcessorsLiveList : payoutProcessorsSandboxList,
+      ~processorList=payoutProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
@@ -172,85 +162,73 @@ let fraudAndRisk = (~userHasResourceAccess) => {
   })
 }
 
-let threeDsConnector = (
-  ~isLiveMode,
-  ~userHasResourceAccess,
-  ~threeDsAuthenticatorProcessorsLiveList,
-  ~threeDsAuthenticatorProcessorsSandboxList,
-) => {
+let threeDsConnector = (~userHasResourceAccess, ~threeDsAuthenticatorProcessorsList) => {
   SubLevelLink({
     name: "3DS Authenticators",
     link: "/3ds-authenticators",
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=isLiveMode
-        ? threeDsAuthenticatorProcessorsLiveList
-        : threeDsAuthenticatorProcessorsSandboxList,
+      ~processorList=threeDsAuthenticatorProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let pmAuthenticationProcessor = (~userHasResourceAccess, ~pmAuthProcessorsSandboxList) => {
+let pmAuthenticationProcessor = (~userHasResourceAccess, ~pmAuthProcessorsList) => {
   SubLevelLink({
     name: "PM Auth Processor",
     link: `/pm-authentication-processor`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=pmAuthProcessorsSandboxList,
+      ~processorList=pmAuthProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let taxProcessor = (~userHasResourceAccess, ~taxProcessorsSandboxList) => {
+let taxProcessor = (~userHasResourceAccess, ~taxProcessorsList) => {
   SubLevelLink({
     name: "Tax Processor",
     link: `/tax-processor`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=taxProcessorsSandboxList,
+      ~processorList=taxProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let billingProcessor = (~userHasResourceAccess, ~billingProcessorsSandboxList) => {
+let billingProcessor = (~userHasResourceAccess, ~billingProcessorsList) => {
   SubLevelLink({
     name: "Billing Processor",
     link: `/billing-processor`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=billingProcessorsSandboxList,
+      ~processorList=billingProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let vaultProcessor = (
-  ~isLiveMode,
-  ~userHasResourceAccess,
-  ~vaultProcessorsLiveList,
-  ~vaultProcessorsSandboxList,
-) => {
+let vaultProcessor = (~userHasResourceAccess, ~vaultProcessorsList) => {
   SubLevelLink({
     name: "Vault Processor",
     link: `/vault-processor`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=isLiveMode ? vaultProcessorsLiveList : vaultProcessorsSandboxList,
+      ~processorList=vaultProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
 }
 
-let surchargeProcessor = (~userHasResourceAccess, ~surchargeProcessorsSandboxList) => {
+let surchargeProcessor = (~userHasResourceAccess, ~surchargeProcessorsList) => {
   SubLevelLink({
     name: "Surcharge Processor",
     link: `/surcharge-processor`,
     access: userHasResourceAccess(~resourceAccess=Connector),
     searchOptions: getSearchOptionsForProcessors(
-      ~processorList=surchargeProcessorsSandboxList,
+      ~processorList=surchargeProcessorsList,
       ~getNameFromString=getConnectorNameString,
     ),
   })
@@ -258,7 +236,6 @@ let surchargeProcessor = (~userHasResourceAccess, ~surchargeProcessorsSandboxLis
 
 let connectors = (
   isConnectorsEnabled,
-  ~isLiveMode,
   ~isFrmEnabled,
   ~isPayoutsEnabled,
   ~isThreedsConnectorEnabled,
@@ -270,72 +247,33 @@ let connectors = (
   ~userHasResourceAccess,
   ~isCurrentMerchantPlatform,
   ~isCurrentMerchantConnected,
-  ~connectorListForLive: ConnectorListFromConfigTypes.connectorListForLive,
-  ~connectorListForSandbox: ConnectorListFromConfigTypes.connectorListForSandbox,
+  ~connectorDisplayList: ConnectorListFromConfigTypes.connectorDisplayList,
 ) => {
   let {
-    paymentProcessorsLiveList,
-    payoutProcessorsLiveList,
-    threeDsAuthenticatorProcessorsLiveList,
-    vaultProcessorsLiveList,
-  } = connectorListForLive
-  let {
-    paymentProcessorsSandboxList,
-    payoutProcessorsSandboxList,
-    threeDsAuthenticatorProcessorsSandboxList,
-    vaultProcessorsSandboxList,
-    pmAuthProcessorsSandboxList,
-    billingProcessorsSandboxList,
-    surchargeProcessorsSandboxList,
-    taxProcessorsSandboxList,
-  } = connectorListForSandbox
+    paymentProcessorsList,
+    payoutProcessorsList,
+    threeDsAuthenticatorProcessorsList,
+    vaultProcessorsList,
+    pmAuthProcessorsList,
+    billingProcessorsList,
+    surchargeProcessorsList,
+    taxProcessorsList,
+  } = connectorDisplayList
   let connectorLinkArray = if isCurrentMerchantPlatform {
     let links = []
     if isVaultProcessor {
-      links
-      ->Array.push(
-        vaultProcessor(
-          ~isLiveMode,
-          ~userHasResourceAccess,
-          ~vaultProcessorsLiveList,
-          ~vaultProcessorsSandboxList,
-        ),
-      )
-      ->ignore
+      links->Array.push(vaultProcessor(~userHasResourceAccess, ~vaultProcessorsList))->ignore
     }
     links
   } else {
-    let links = [
-      paymentProcessor(
-        isLiveMode,
-        userHasResourceAccess,
-        ~paymentProcessorsLiveList,
-        ~paymentProcessorsSandboxList,
-      ),
-    ]
+    let links = [paymentProcessor(userHasResourceAccess, ~paymentProcessorsList)]
 
     if isPayoutsEnabled {
-      links
-      ->Array.push(
-        payoutConnectors(
-          ~isLiveMode,
-          ~userHasResourceAccess,
-          ~payoutProcessorsLiveList,
-          ~payoutProcessorsSandboxList,
-        ),
-      )
-      ->ignore
+      links->Array.push(payoutConnectors(~userHasResourceAccess, ~payoutProcessorsList))->ignore
     }
     if isThreedsConnectorEnabled {
       links
-      ->Array.push(
-        threeDsConnector(
-          ~isLiveMode,
-          ~userHasResourceAccess,
-          ~threeDsAuthenticatorProcessorsLiveList,
-          ~threeDsAuthenticatorProcessorsSandboxList,
-        ),
-      )
+      ->Array.push(threeDsConnector(~userHasResourceAccess, ~threeDsAuthenticatorProcessorsList))
       ->ignore
     }
 
@@ -345,36 +283,25 @@ let connectors = (
 
     if isPMAuthenticationProcessor {
       links
-      ->Array.push(pmAuthenticationProcessor(~userHasResourceAccess, ~pmAuthProcessorsSandboxList))
+      ->Array.push(pmAuthenticationProcessor(~userHasResourceAccess, ~pmAuthProcessorsList))
       ->ignore
     }
 
     if isTaxProcessor {
-      links->Array.push(taxProcessor(~userHasResourceAccess, ~taxProcessorsSandboxList))->ignore
+      links->Array.push(taxProcessor(~userHasResourceAccess, ~taxProcessorsList))->ignore
     }
     if isBillingProcessor {
-      links
-      ->Array.push(billingProcessor(~userHasResourceAccess, ~billingProcessorsSandboxList))
-      ->ignore
+      links->Array.push(billingProcessor(~userHasResourceAccess, ~billingProcessorsList))->ignore
     }
 
     if isSurchargeProcessor {
       links
-      ->Array.push(surchargeProcessor(~userHasResourceAccess, ~surchargeProcessorsSandboxList))
+      ->Array.push(surchargeProcessor(~userHasResourceAccess, ~surchargeProcessorsList))
       ->ignore
     }
 
     if isVaultProcessor && !isCurrentMerchantConnected {
-      links
-      ->Array.push(
-        vaultProcessor(
-          ~isLiveMode,
-          ~userHasResourceAccess,
-          ~vaultProcessorsLiveList,
-          ~vaultProcessorsSandboxList,
-        ),
-      )
-      ->ignore
+      links->Array.push(vaultProcessor(~userHasResourceAccess, ~vaultProcessorsList))->ignore
     }
     links
   }

--- a/src/screens/Connectors/BillingProcessor/BillingProcessorList.res
+++ b/src/screens/Connectors/BillingProcessor/BillingProcessorList.res
@@ -3,8 +3,8 @@ let make = () => {
   let connectorList = ConnectorListInterface.useFilteredConnectorList(
     ~retainInList=BillingProcessor,
   )
-  let {billingProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {billingProcessorsList} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
@@ -92,7 +92,7 @@ let make = () => {
             ConnectorTypes.BillingProcessor,
             configuredConnectors,
           )}
-          connectorsAvailableForIntegration={billingProcessorsSandboxList}
+          connectorsAvailableForIntegration={billingProcessorsList}
           urlPrefix="billing-processor/new"
           connectorType=ConnectorTypes.BillingProcessor
         />

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -18,7 +18,7 @@ let getStepName = step => {
   }
 }
 // Any connector added to these lists must also be added to the matching
-// connector_list_for_live key in config/config.toml, otherwise it won't appear
+// connector_list_for_live key in the env config otherwise it won't appear
 // once the config-driven list takes over. These lists remain the fallback used
 // when a category is missing from the config.
 

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -18,8 +18,9 @@ let getStepName = step => {
   }
 }
 // Any connector added to these lists must also be added to the matching
-// connector_list_for_live / connector_list_for_sandbox key in config/config.toml,
-// otherwise it won't appear once the config-driven list takes over.
+// connector_list_for_live key in config/config.toml, otherwise it won't appear
+// once the config-driven list takes over. These lists remain the fallback used
+// when a category is missing from the config.
 
 let payoutConnectorList: array<connectorTypes> = [
   PayoutProcessor(ADYEN),

--- a/src/screens/Connectors/PMAuthenticationProcessor/PMAuthenticationConnectorList.res
+++ b/src/screens/Connectors/PMAuthenticationProcessor/PMAuthenticationConnectorList.res
@@ -7,8 +7,8 @@ let make = () => {
   let (searchText, setSearchText) = React.useState(_ => "")
   let (filteredConnectorData, setFilteredConnectorData) = React.useState(_ => [])
   let connectorList = ConnectorListInterface.useFilteredConnectorList(~retainInList=PMAuthProcessor)
-  let {pmAuthProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {pmAuthProcessorsList} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
 
   let filterLogic = ReactDebounce.useDebounced(ob => {
     open LogicUtils
@@ -90,7 +90,7 @@ let make = () => {
             ConnectorTypes.PMAuthenticationProcessor,
             configuredConnectors,
           )}
-          connectorsAvailableForIntegration={pmAuthProcessorsSandboxList}
+          connectorsAvailableForIntegration={pmAuthProcessorsList}
           urlPrefix="pm-authentication-processor/new"
           connectorType=ConnectorTypes.PMAuthenticationProcessor
         />

--- a/src/screens/Connectors/PaymentProcessor/ConnectorList.res
+++ b/src/screens/Connectors/PaymentProcessor/ConnectorList.res
@@ -70,11 +70,8 @@ let make = (
     ~retainInList=PaymentProcessor,
   )
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
-  let {paymentProcessorsLiveList} =
-    HyperswitchAtom.connectorListForLiveAtom->Recoil.useRecoilValueFromAtom
-  let {paymentProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {paymentProcessorsList: connectorsAvailableForIntegration} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
 
   let getConnectorListAndUpdateState = async () => {
     try {
@@ -119,10 +116,6 @@ let make = (
     }
     setFilteredConnectorData(_ => filteredList)
   }, ~wait=200)
-
-  let connectorsAvailableForIntegration = featureFlagDetails.isLiveMode
-    ? paymentProcessorsLiveList
-    : paymentProcessorsSandboxList
 
   <div>
     <PageLoaderWrapper screenState>

--- a/src/screens/Connectors/PayoutProcessor/PayoutProcessorList.res
+++ b/src/screens/Connectors/PayoutProcessor/PayoutProcessorList.res
@@ -10,11 +10,8 @@ let make = () => {
   let (processorModal, setProcessorModal) = React.useState(_ => false)
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let connectorList = ConnectorListInterface.useFilteredConnectorList(~retainInList=PayoutProcessor)
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
-  let {payoutProcessorsLiveList} =
-    HyperswitchAtom.connectorListForLiveAtom->Recoil.useRecoilValueFromAtom
-  let {payoutProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {payoutProcessorsList: payoutConnectorList} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
 
   let getConnectorListAndUpdateState = async () => {
     try {
@@ -63,10 +60,6 @@ let make = () => {
     }
     setFilteredConnectorData(_ => filteredList)
   }, ~wait=200)
-
-  let payoutConnectorList = featureFlagDetails.isLiveMode
-    ? payoutProcessorsLiveList
-    : payoutProcessorsSandboxList
 
   <div>
     <PageLoaderWrapper screenState>

--- a/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorList.res
+++ b/src/screens/Connectors/SurchargeProcessor/SurchargeProcessorList.res
@@ -3,8 +3,8 @@ let make = () => {
   let connectorList = ConnectorListInterface.useFilteredConnectorList(
     ~retainInList=SurchargeProcessor,
   )
-  let {surchargeProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {surchargeProcessorsList} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
@@ -92,7 +92,7 @@ let make = () => {
             ConnectorTypes.SurchargeProcessor,
             configuredConnectors,
           )}
-          connectorsAvailableForIntegration={surchargeProcessorsSandboxList}
+          connectorsAvailableForIntegration={surchargeProcessorsList}
           urlPrefix="surcharge-processor/new"
           connectorType=ConnectorTypes.SurchargeProcessor
         />

--- a/src/screens/Connectors/TaxProcessor/TaxProcessorList.res
+++ b/src/screens/Connectors/TaxProcessor/TaxProcessorList.res
@@ -1,8 +1,7 @@
 @react.component
 let make = () => {
   let connectorList = ConnectorListInterface.useFilteredConnectorList(~retainInList=TaxProcessor)
-  let {taxProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {taxProcessorsList} = HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
@@ -89,7 +88,7 @@ let make = () => {
             ConnectorTypes.TaxProcessor,
             configuredConnectors,
           )}
-          connectorsAvailableForIntegration={taxProcessorsSandboxList}
+          connectorsAvailableForIntegration={taxProcessorsList}
           urlPrefix="tax-processor/new"
           connectorType=ConnectorTypes.TaxProcessor
         />

--- a/src/screens/Connectors/ThreeDsProcessors/ThreeDsConnectorList.res
+++ b/src/screens/Connectors/ThreeDsProcessors/ThreeDsConnectorList.res
@@ -1,15 +1,12 @@
 @react.component
 let make = () => {
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Success)
   let (configuredConnectors, setConfiguredConnectors) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let (searchText, setSearchText) = React.useState(_ => "")
-  let {threeDsAuthenticatorProcessorsLiveList} =
-    HyperswitchAtom.connectorListForLiveAtom->Recoil.useRecoilValueFromAtom
-  let {threeDsAuthenticatorProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {threeDsAuthenticatorProcessorsList} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
   let (
     filteredConnectorData: array<
       RescriptCore.Nullable.t<ConnectorTypes.connectorPayloadCommonType>,
@@ -103,9 +100,7 @@ let make = () => {
             ConnectorTypes.ThreeDsAuthenticator,
             configuredConnectors,
           )}
-          connectorsAvailableForIntegration={featureFlagDetails.isLiveMode
-            ? threeDsAuthenticatorProcessorsLiveList
-            : threeDsAuthenticatorProcessorsSandboxList}
+          connectorsAvailableForIntegration={threeDsAuthenticatorProcessorsList}
           urlPrefix="3ds-authenticators/new"
           connectorType=ConnectorTypes.ThreeDsAuthenticator
         />

--- a/src/screens/Connectors/VaultProcessors/VaultProcessorsList.res
+++ b/src/screens/Connectors/VaultProcessors/VaultProcessorsList.res
@@ -6,12 +6,9 @@ let make = () => {
   let (offset, setOffset) = React.useState(_ => 0)
   let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let (searchText, setSearchText) = React.useState(_ => "")
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let (filteredConnectorData, setFilteredConnectorData) = React.useState(_ => [])
-  let {vaultProcessorsLiveList} =
-    HyperswitchAtom.connectorListForLiveAtom->Recoil.useRecoilValueFromAtom
-  let {vaultProcessorsSandboxList} =
-    HyperswitchAtom.connectorListForSandboxAtom->Recoil.useRecoilValueFromAtom
+  let {vaultProcessorsList: connectorsAvailableForIntegration} =
+    HyperswitchAtom.connectorDisplayListAtom->Recoil.useRecoilValueFromAtom
 
   let businessProfileRecoilVal =
     HyperswitchAtom.businessProfileFromIdAtomInterface->Recoil.useRecoilValueFromAtom
@@ -56,9 +53,6 @@ let make = () => {
     getConnectorList()->ignore
     None
   }, [])
-  let connectorsAvailableForIntegration = featureFlagDetails.isLiveMode
-    ? vaultProcessorsLiveList
-    : vaultProcessorsSandboxList
   <div>
     <PageUtils.PageHeading
       title={"Vault Processor"} subTitle={"Connect and configure Vault Processor"}

--- a/src/server/config.mjs
+++ b/src/server/config.mjs
@@ -163,13 +163,6 @@ const configHandler = async (
         "connector_list_for_live",
       );
     }
-    if (merchantConfig && merchantConfig["connector_list_for_sandbox"]) {
-      merchantConfig["connector_list_for_sandbox"] = updateConnectorListWithEnv(
-        merchantConfig["connector_list_for_sandbox"],
-        domain,
-        "connector_list_for_sandbox",
-      );
-    }
     if (merchantConfig && merchantConfig["connector_clone"]) {
       merchantConfig["connector_clone"] = updateConnectorListWithEnv(
         merchantConfig["connector_clone"],


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
This pr unifies the connector_list_for_live and connector_list_for_sandbox into one array. Now connector_list_for_live is the source of truth and based on env the array can be changed.
<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?
### Fallback behaviour — category key empty / missing / all-invalid in `[default.connector_list_for_live]`

| Category | `is_live_mode=true` | `is_live_mode=false` |
| --- | --- | --- |
| Payment Processors | 44 | 110 |
| Payout Processors | 13 | 17 |
| 3DS Authenticators | 3 | 6 |
| Vault Processor | 1 (VGS) | 1 (VGS) |
| PM Auth Processor | 1 (Plaid) | 1 (Plaid) |
| Billing Processor | 1 (Chargebee) | 1 (Chargebee) |
| Surcharge Processor | 1 (Interpayments) | 1 (Interpayments) |
| Tax Processor | 1 (Taxjar) | 1 (Taxjar) |

### Config populated

| Config | Mode | Expected |
| --- | --- | --- |
| `paymentProcessors = ["adyen","stripe","checkout"]` | live | 3 cards, in config order |
| `paymentProcessors = ["adyen","stripe","checkout"]` | non-live | **also 3**, not 110 |
| `paymentProcessors = ["adyen","stripe","nomuuupayyy"]` | either | 2 cards — bad entry dropped silently, no fallback |
| `paymentProcessors = ["AdYen","adyen","ADYEN"]` | either | 1 card — lowercased + deduped |
| `payoutProcessors = ["taxjar","chargebee","adyen","stripe"]` | either | 2 cards (Adyen, Stripe) — cross-category names don't map under `PayoutProcessor` |
| whole `[default.connector_list_for_live]` table deleted | either | every category falls back per the table above, no crash |


<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->
Removed connector_list_for_sandbox now connector_list_for_live needs to be popoulated for sandbox in the configs.

- [ ] New feature flag added
- [x] Existing feature flag updated
- [ ] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
