### PR TITLE
fix: remove clipboard ID prefix detection in global search

### DIFF
--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBar.res
@@ -219,8 +219,8 @@ let make = () => {
     revertFocus(~inputRef)
   }
 
-  let onClipboardSuggestionClicked = (suggestion: clipboardSuggestion) => {
-    setLocalSearchText(_ => suggestion.id)
+  let onClipboardSuggestionClicked = (suggestion: string) => {
+    setLocalSearchText(_ => suggestion)
     setFilterText("")
     setClipboardSuggestion(_ => None)
     revertFocus(~inputRef)

--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBarHelper.res
@@ -235,16 +235,15 @@ module NoResults = {
 }
 
 module ClipboardSuggestion = {
-  open GlobalSearchBarUtils
   open FramerMotion.Motion
   @react.component
   let make = (~clipboardSuggestion, ~onClipboardSuggestionClicked) => {
     switch clipboardSuggestion {
-    | Some(suggestion: clipboardSuggestion) =>
+    | Some(suggestion: string) =>
       let filter: categoryOption = {
         categoryType: Payment_id,
-        options: [suggestion.id],
-        placeholder: suggestion.id,
+        options: [suggestion],
+        placeholder: suggestion,
       }
 
       <Div
@@ -258,7 +257,7 @@ module ClipboardSuggestion = {
         <div>
           <FilterOption
             onClick={_ => onClipboardSuggestionClicked(suggestion)}
-            value={suggestion.id}
+            value={suggestion}
             placeholder={Some("Click to search")}
             filter
             viewType=FiltersSugsestions

--- a/src/screens/Analytics/GlobalSearch/GlobalSearchBarUtils.res
+++ b/src/screens/Analytics/GlobalSearch/GlobalSearchBarUtils.res
@@ -661,20 +661,7 @@ let revertFocus = (~inputRef: React.ref<'a>) => {
   }
 }
 
-type clipboardIdType = PaymentId | RefundId
-
-type clipboardSuggestion = {
-  id: string,
-  idType: clipboardIdType,
-}
-
 let detectClipboardId = (text: string) => {
   let trimmed = text->String.trim
-  if trimmed->String.length > 4 && RegExp.test(%re("/^pay_[A-Za-z0-9_]+$/"), trimmed) {
-    Some({id: trimmed, idType: PaymentId})
-  } else if trimmed->String.length > 4 && RegExp.test(%re("/^ref_[A-Za-z0-9_]+$/"), trimmed) {
-    Some({id: trimmed, idType: RefundId})
-  } else {
-    None
-  }
+  trimmed->isNonEmptyString ? Some(trimmed) : None
 }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Remove the `pay_`/`ref_` prefix regex detection from the global search clipboard suggestion feature.
- Surface the raw copied clipboard text as the search suggestion instead of trying to classify it as a payment or refund ID.

## Motivation and Context

The clipboard suggestion feature tagged copied text as `PaymentId` or `RefundId` based on prefix matching, but the suggestion UI always rendered it under the `Payment_id` filter category since no `Refund_id` filter category exists in the codebase. This meant refund IDs copied to the clipboard were mislabeled as payment IDs, causing incorrect search filter behavior.

Closes #5362

## How did you test it?

- Ran `npx rescript build` successfully with no warnings.
- Reviewed the diff to confirm no unrelated files are included.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

after
<img width="1072" height="796" alt="Screenshot 2026-08-10 at 5 37 59 PM" src="https://github.com/user-attachments/assets/efffe638-01e1-49ce-bc03-35f172dd0b91" />

before
<img width="1122" height="666" alt="Screenshot 2026-08-10 at 5 36 24 PM" src="https://github.com/user-attachments/assets/bae38884-e503-4862-8bae-574ebcf8cc2c" />

