### PR TITLE
fix: persist payment list source selection

### DIFF
--- a/src/screens/HSLocalStorage.res
+++ b/src/screens/HSLocalStorage.res
@@ -49,3 +49,15 @@ let getCustomTableColumnsfromLocalStorage = () => {
   let customTableColumns = LocalStorage.getItem("tableColumnsOrder")->Nullable.toOption
   customTableColumns
 }
+
+let setPaymentListSourceInLocalStorage = val => {
+  let val = val->LogicUtils.getNonEmptyString
+  if val->Option.isSome {
+    LocalStorage.setItem("selectedPaymentListSource", val->Option.getOr(""))
+  }
+}
+
+let getPaymentListSourcefromLocalStorage = () => {
+  let paymentListSource = LocalStorage.getItem("selectedPaymentListSource")->Nullable.toOption
+  paymentListSource
+}

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -2,8 +2,6 @@ open LogicUtils
 open OrderTypes
 open CommonAuthUtils
 
-let paymentListSourceStorageKey = "selectedPaymentListSource"
-
 let getPaymentListSourceFromString = (~defaultSource, source) =>
   switch source {
   | "Normal" => Normal
@@ -12,13 +10,11 @@ let getPaymentListSourceFromString = (~defaultSource, source) =>
   }
 
 let getStoredPaymentListSource = (~defaultSource) =>
-  switch LocalStorage.getItem(paymentListSourceStorageKey)->Nullable.toOption {
+  switch HSLocalStorage.getPaymentListSourcefromLocalStorage() {
   | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
   | None => defaultSource
   }
 
-let setStoredPaymentListSource = (newSource: paymentListSource) =>
-  LocalStorage.setItem(paymentListSourceStorageKey, (newSource :> string))
 
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -2,19 +2,6 @@ open LogicUtils
 open OrderTypes
 open CommonAuthUtils
 
-let getPaymentListSourceFromString = (~defaultSource, source) =>
-  switch source {
-  | "Normal" => Normal
-  | "Advanced" => Advanced
-  | _ => defaultSource
-  }
-
-let getStoredPaymentListSource = (~defaultSource) =>
-  switch HSLocalStorage.getPaymentListSourcefromLocalStorage() {
-  | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
-  | None => defaultSource
-  }
-
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,6 +1,25 @@
 open LogicUtils
 open OrderTypes
 open CommonAuthUtils
+
+let paymentListSourceStorageKey = "selectedPaymentListSource"
+
+let getPaymentListSourceFromString = (~defaultSource, source) =>
+  switch source {
+  | "Normal" => Normal
+  | "Advanced" => Advanced
+  | _ => defaultSource
+  }
+
+let getStoredPaymentListSource = (~defaultSource) =>
+  switch LocalStorage.getItem(paymentListSourceStorageKey)->Nullable.toOption {
+  | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
+  | None => defaultSource
+  }
+
+let setStoredPaymentListSource = (newSource: paymentListSource) =>
+  LocalStorage.setItem(paymentListSourceStorageKey, (newSource :> string))
+
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,6 +1,20 @@
 open LogicUtils
 open OrderTypes
 open CommonAuthUtils
+
+let getPaymentListSourceFromString = (~defaultSource, source) =>
+  switch source {
+  | "Normal" => Normal
+  | "Advanced" => Advanced
+  | _ => defaultSource
+  }
+
+let getStoredPaymentListSource = (~defaultSource) =>
+  switch HSLocalStorage.getPaymentListSourcefromLocalStorage() {
+  | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
+  | None => defaultSource
+  }
+
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -1,7 +1,6 @@
 open LogicUtils
 open OrderTypes
 open CommonAuthUtils
-
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector

--- a/src/screens/Transaction/Order/OrderUIUtils.res
+++ b/src/screens/Transaction/Order/OrderUIUtils.res
@@ -15,7 +15,6 @@ let getStoredPaymentListSource = (~defaultSource) =>
   | None => defaultSource
   }
 
-
 let getFilterTypeFromString = (filterType): filter => {
   switch filterType {
   | "connector" => #connector

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -1,3 +1,5 @@
+let paymentListSourceStorageKey = "selectedPaymentListSource"
+
 @react.component
 let make = (~previewOnly=false) => {
   open HSwitchRemoteFilter
@@ -41,7 +43,13 @@ let make = (~previewOnly=false) => {
   //enablement of advanced view
   let isAdvancedViewEnabled = isOpenSearchEnabled && devAdvancedPaymentsView
 
-  let (selectedSource, setSelectedSource) = React.useState(_ => None)
+  let (selectedSource, setSelectedSource) = React.useState(_ => {
+    switch LocalStorage.getItem(paymentListSourceStorageKey)->Nullable.toOption {
+    | Some("Normal") => Some(Normal)
+    | Some("Advanced") => Some(Advanced)
+    | Some(_) | None => None
+    }
+  })
   let source =
     selectedSource->mapOptionOrDefault(isAdvancedViewEnabled ? Advanced : Normal, userSource =>
       userSource
@@ -231,7 +239,8 @@ let make = (~previewOnly=false) => {
     None
   }, (offset, filters, searchText, resultsPerPage))
 
-  let handleSourceChange = newSource => {
+  let handleSourceChange = (newSource: paymentListSource) => {
+    LocalStorage.setItem(paymentListSourceStorageKey, (newSource :> string))
     setSelectedSource(_ => Some(newSource))
     setOffset(_ => 0)
     setFilters(_ => None)
@@ -379,7 +388,7 @@ let make = (~previewOnly=false) => {
       <div className="flex flex-wrap justify-between gap-3 items-start">
         <PageUtils.PageHeading title="Payment Operations" subTitle="" customTitleStyle />
         <div
-          className="flex flex-nowrap justify-end gap-2 items-center whitespace-nowrap overflow-x-auto no-scrollbar">
+          className="flex flex-nowrap justify-end gap-2 items-center whitespace-nowrap overflow-x-auto no-scrollbar pr-px">
           <RenderIf condition={isAdvancedViewEnabled}>
             {<>
               <div className="shrink-0">

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -7,7 +7,6 @@ let make = (~previewOnly=false) => {
   open SavedViewTypes
   open OrderEntity
   open Typography
-  open HSLocalStorage
 
   let ordersTableTitle = "Orders"
   let advancedOrdersTableTitle = "OrdersAdvanced"
@@ -42,20 +41,8 @@ let make = (~previewOnly=false) => {
   //enablement of advanced view
   let isAdvancedViewEnabled = isOpenSearchEnabled && devAdvancedPaymentsView
 
-  let getPaymentListSourceFromString = (~defaultSource, source) =>
-    switch source {
-    | "Normal" => Normal
-    | "Advanced" => Advanced
-    | _ => defaultSource
-    }
-
   let defaultSource = isAdvancedViewEnabled ? Advanced : Normal
-  let (source, setSource) = React.useState(_ =>
-    switch getPaymentListSourcefromLocalStorage() {
-    | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
-    | None => defaultSource
-    }
-  )
+  let (source, setSource) = React.useState(_ => getStoredPaymentListSource(~defaultSource))
   let isAdvancedView = source === Advanced && isAdvancedViewEnabled
   let (tableTitle, savedViewsEntity) = isAdvancedView
     ? (advancedOrdersTableTitle, PaymentAdvanced)
@@ -242,7 +229,7 @@ let make = (~previewOnly=false) => {
   }, (offset, filters, searchText, resultsPerPage))
 
   let handleSourceChange = (newSource: paymentListSource) => {
-    setPaymentListSourceInLocalStorage((newSource :> string))
+    HSLocalStorage.setPaymentListSourceInLocalStorage((newSource :> string))
     setSource(_ => newSource)
     setOffset(_ => 0)
     setFilters(_ => None)

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -1,5 +1,3 @@
-let paymentListSourceStorageKey = "selectedPaymentListSource"
-
 @react.component
 let make = (~previewOnly=false) => {
   open HSwitchRemoteFilter
@@ -43,17 +41,8 @@ let make = (~previewOnly=false) => {
   //enablement of advanced view
   let isAdvancedViewEnabled = isOpenSearchEnabled && devAdvancedPaymentsView
 
-  let (selectedSource, setSelectedSource) = React.useState(_ => {
-    switch LocalStorage.getItem(paymentListSourceStorageKey)->Nullable.toOption {
-    | Some("Normal") => Some(Normal)
-    | Some("Advanced") => Some(Advanced)
-    | Some(_) | None => None
-    }
-  })
-  let source =
-    selectedSource->mapOptionOrDefault(isAdvancedViewEnabled ? Advanced : Normal, userSource =>
-      userSource
-    )
+  let defaultSource = isAdvancedViewEnabled ? Advanced : Normal
+  let (source, setSource) = React.useState(_ => getStoredPaymentListSource(~defaultSource))
   let isAdvancedView = source === Advanced && isAdvancedViewEnabled
   let (tableTitle, savedViewsEntity) = isAdvancedView
     ? (advancedOrdersTableTitle, PaymentAdvanced)
@@ -240,8 +229,8 @@ let make = (~previewOnly=false) => {
   }, (offset, filters, searchText, resultsPerPage))
 
   let handleSourceChange = (newSource: paymentListSource) => {
-    LocalStorage.setItem(paymentListSourceStorageKey, (newSource :> string))
-    setSelectedSource(_ => Some(newSource))
+    newSource->setStoredPaymentListSource
+    setSource(_ => newSource)
     setOffset(_ => 0)
     setFilters(_ => None)
     reset()

--- a/src/screens/Transaction/Order/Orders.res
+++ b/src/screens/Transaction/Order/Orders.res
@@ -7,6 +7,7 @@ let make = (~previewOnly=false) => {
   open SavedViewTypes
   open OrderEntity
   open Typography
+  open HSLocalStorage
 
   let ordersTableTitle = "Orders"
   let advancedOrdersTableTitle = "OrdersAdvanced"
@@ -41,8 +42,20 @@ let make = (~previewOnly=false) => {
   //enablement of advanced view
   let isAdvancedViewEnabled = isOpenSearchEnabled && devAdvancedPaymentsView
 
+  let getPaymentListSourceFromString = (~defaultSource, source) =>
+    switch source {
+    | "Normal" => Normal
+    | "Advanced" => Advanced
+    | _ => defaultSource
+    }
+
   let defaultSource = isAdvancedViewEnabled ? Advanced : Normal
-  let (source, setSource) = React.useState(_ => getStoredPaymentListSource(~defaultSource))
+  let (source, setSource) = React.useState(_ =>
+    switch getPaymentListSourcefromLocalStorage() {
+    | Some(source) => source->getPaymentListSourceFromString(~defaultSource)
+    | None => defaultSource
+    }
+  )
   let isAdvancedView = source === Advanced && isAdvancedViewEnabled
   let (tableTitle, savedViewsEntity) = isAdvancedView
     ? (advancedOrdersTableTitle, PaymentAdvanced)
@@ -229,7 +242,7 @@ let make = (~previewOnly=false) => {
   }, (offset, filters, searchText, resultsPerPage))
 
   let handleSourceChange = (newSource: paymentListSource) => {
-    newSource->setStoredPaymentListSource
+    setPaymentListSourceInLocalStorage((newSource :> string))
     setSource(_ => newSource)
     setOffset(_ => 0)
     setFilters(_ => None)

--- a/src/screens/TransactionViews/TransactionView.res
+++ b/src/screens/TransactionViews/TransactionView.res
@@ -42,7 +42,6 @@ let make = (
   ~allStatuses=[],
 ) => {
   open APIUtils
-  open APIUtilsTypes
   open LogicUtils
   open TransactionViewUtils
   let getURL = useGetURL()
@@ -109,7 +108,7 @@ let make = (
   let loadAggregateCounts = async () => {
     try {
       if isAdvancedOrdersView {
-        let url = getURL(~entityName=V1(ANALYTICS_SANKEY), ~methodType=Post)
+        let url = transactionEntity->buildSankeyMetricsUrl
         let body =
           [
             ("startTime", startTime->JSON.Encode.string),

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -127,19 +127,19 @@ let getClickhouseAggregateMetric = entity =>
     None
   }
 
-let buildAggregateMetricsUrl = (~metricConfig, ~transactionEntity) => {
-  let scope = switch transactionEntity {
+let getMetricsScope = transactionEntity =>
+  switch transactionEntity {
   | #Profile => "profile"
   | _ => "merchant"
   }
+
+let buildAggregateMetricsUrl = (~metricConfig, ~transactionEntity) => {
+  let scope = transactionEntity->getMetricsScope
   `${Window.env.apiBaseUrl}/${metricConfig.urlPrefix}/${scope}/metrics/${metricConfig.domain}`
 }
 
 let buildSankeyMetricsUrl = transactionEntity => {
-  let scope = switch transactionEntity {
-  | #Profile => "profile"
-  | _ => "merchant"
-  }
+  let scope = transactionEntity->getMetricsScope
   `${Window.env.apiBaseUrl}/analytics/v1/${scope}/metrics/sankey`
 }
 

--- a/src/screens/TransactionViews/TransactionViewUtils.res
+++ b/src/screens/TransactionViews/TransactionViewUtils.res
@@ -135,6 +135,14 @@ let buildAggregateMetricsUrl = (~metricConfig, ~transactionEntity) => {
   `${Window.env.apiBaseUrl}/${metricConfig.urlPrefix}/${scope}/metrics/${metricConfig.domain}`
 }
 
+let buildSankeyMetricsUrl = transactionEntity => {
+  let scope = switch transactionEntity {
+  | #Profile => "profile"
+  | _ => "merchant"
+  }
+  `${Window.env.apiBaseUrl}/analytics/v1/${scope}/metrics/sankey`
+}
+
 let getEntityName = (~entity: operationsTypes, ~version: UserInfoTypes.version) => {
   open APIUtilsTypes
   switch entity {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

This PR fixes a few advanced payments list view issues:

- Persists the selected payments list source so users stay on the Normal or Advanced tab when navigating away and returning.
- Uses the merchant/profile scoped Sankey metrics URL for advanced payments transaction view counts.
- Adds a small right padding to the payments action bar so the Generate Reports button border is not clipped.

## Motivation and Context

The payments list source should remain consistent during normal page navigation, but should still be cleared through the existing logout local storage cleanup. Advanced payments transaction view counts should not call the org-level Sankey endpoint because the payments list supports merchant/profile scoped data.

Fixes #5380

## How did you test it?

- Ran `./node_modules/.bin/rescript format src/screens/Transaction/Order/Orders.res src/screens/TransactionViews/TransactionView.res src/screens/TransactionViews/TransactionViewUtils.res`
- Ran `git diff --check`
- Ran `npm run re:build`
- Commit hook ran `npm run re:format`

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
