### PR TITLE
feat: add setup map page in recon engine

### DIFF
--- a/src/ReconEngine/ReconEngineApp/ReconEngineApp.res
+++ b/src/ReconEngine/ReconEngineApp/ReconEngineApp.res
@@ -14,6 +14,10 @@ let make = () => {
       <AccessControl isEnabled={featureFlagDetails.devReconEngineV1} authorization=Access>
         <ReconEngineOverviewContainer />
       </AccessControl>
+    | list{"v1", "recon-engine", "setup"} =>
+      <AccessControl isEnabled={featureFlagDetails.devReconEngineV1} authorization=Access>
+        <ReconEngineSetupExplainerPage />
+      </AccessControl>
     | list{"v1", "recon-engine", "transactions", ..._} =>
       <AccessControl
         isEnabled={featureFlagDetails.devReconEngineV1}
@@ -48,5 +52,6 @@ let make = () => {
     | _ => <EmptyPage path="/v1/recon-engine/overview" />
     }}
     <ReconEngineActivityFAB />
+    <ReconEngineSetupExplainerTrigger />
   </>
 }

--- a/src/ReconEngine/ReconEngineApp/ReconEngineSidebarValues.res
+++ b/src/ReconEngine/ReconEngineApp/ReconEngineSidebarValues.res
@@ -14,6 +14,14 @@ let reconEngineSidebars = (
     selectedIcon: "nd-overview-fill",
   })
 
+  let reconSetupMap = LinkWithTag({
+    name: "Setup Map",
+    link: `/v1/recon-engine/setup`,
+    access: Access,
+    icon: "nd-workflow",
+    iconTag: "betaTag",
+  })
+
   let reconTransactions = Link({
     name: "Transactions",
     link: `/v1/recon-engine/transactions`,
@@ -66,7 +74,7 @@ let reconEngineSidebars = (
     selectedIcon: "nd-pipelines-fill",
   })
 
-  let sidebars = [reconOverview, reconTransactions, exceptions, reconRuleCreation]
+  let sidebars = [reconOverview, reconSetupMap, reconTransactions, exceptions, reconRuleCreation]
 
   if isReconEnginePipelinesEnabled {
     sidebars->Array.push(reconPipelines)

--- a/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
+++ b/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
@@ -115,6 +115,26 @@ let useGetIngestionConfigs = () => {
   }
 }
 
+let useGetTransformationConfigs = () => {
+  let getURL = useGetURL()
+  let fetchDetails = useGetMethod()
+
+  async (~queryParameters=None) => {
+    try {
+      let url = getURL(
+        ~entityName=V1(HYPERSWITCH_RECON),
+        ~methodType=Get,
+        ~hyperswitchReconType=#TRANSFORMATION_CONFIG,
+        ~queryParameters,
+      )
+      let res = await fetchDetails(url)
+      res->getArrayDataFromJson(transformationConfigItemToObjMapper)
+    } catch {
+    | _ => Exn.raiseError("Something went wrong")
+    }
+  }
+}
+
 let useGetReconRuleList = () => {
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()

--- a/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerNode.res
+++ b/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerNode.res
@@ -1,0 +1,58 @@
+open Typography
+open ReconEngineSetupExplainerTypes
+
+let getStageTag = (kind: explainerNodeKind): string => {
+  switch kind {
+  | IngestionNode => "Step 1 · Data Source"
+  | TransformationNode => "Step 2 · Transformation"
+  | AccountNode => "Step 3 · Account"
+  | RuleNode => "Step 4 · Recon Rule"
+  }
+}
+
+@react.component
+let make = (~data: explainerNodeData) => {
+  open ReactFlow
+
+  let onClick = _ => {
+    switch data.onNodeClick {
+    | Some(clickHandler) => clickHandler()
+    | None => ()
+    }
+  }
+
+  let cursorClass = data.onNodeClick->Option.isSome ? "cursor-pointer" : ""
+
+  <div
+    className={`flex flex-col rounded-xl border border-nd_gray-200 bg-white w-80 relative p-4 ${cursorClass}`}
+    onClick>
+    <HandleComponent \"type"="target" position={positionLeft} />
+    <HandleComponent \"type"="source" position={positionRight} />
+    <div className="absolute -top-0 -left-0">
+      <div
+        className={`${body.xs.medium} text-nd_gray-600 bg-nd_gray-100 px-3 py-1 rounded-tl-xl border border-t-0 border-l-0 border-nd_gray-200 rounded-br-xl`}>
+        {data.kind->getStageTag->React.string}
+      </div>
+    </div>
+    <div className="flex flex-row items-center justify-between gap-2 pt-6">
+      <p className={`${body.md.semibold} text-nd_gray-800 truncate`}>
+        {data.label->React.string}
+      </p>
+      <RenderIf condition={data.showStatus}>
+        {data.isActive
+          ? <p
+              className={`${body.xs.medium} text-nd_green-600 bg-nd_green-50 px-2 py-0.5 rounded-full`}>
+              {"Active"->React.string}
+            </p>
+          : <p
+              className={`${body.xs.medium} text-nd_gray-500 bg-nd_gray-100 px-2 py-0.5 rounded-full`}>
+              {"Inactive"->React.string}
+            </p>}
+      </RenderIf>
+    </div>
+    <RenderIf condition={data.badgeText->LogicUtils.isNonEmptyString}>
+      <p className={`${body.xs.medium} text-nd_gray-400 mt-1`}> {data.badgeText->React.string} </p>
+    </RenderIf>
+    <p className={`${body.sm.medium} text-nd_gray-500 mt-2`}> {data.description->React.string} </p>
+  </div>
+}

--- a/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerPage.res
+++ b/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerPage.res
@@ -1,0 +1,187 @@
+open Typography
+open ReconEngineSetupExplainerTypes
+
+module LegendStep = {
+  @react.component
+  let make = (~step, ~title, ~description) => {
+    <div className="flex flex-col gap-1 flex-1 min-w-0">
+      <div className="flex items-center gap-2">
+        <span
+          className={`${body.xs.semibold} text-nd_gray-600 bg-nd_gray-100 rounded-full w-5 h-5 flex items-center justify-center shrink-0`}>
+          {step->React.string}
+        </span>
+        <p className={`${body.md.semibold} text-nd_gray-800`}> {title->React.string} </p>
+      </div>
+      <p className={`${body.sm.medium} text-nd_gray-500`}> {description->React.string} </p>
+    </div>
+  }
+}
+
+module SetupFlowWithControls = {
+  @react.component
+  let make = (~nodes, ~edges, ~onNodesChange, ~onEdgesChange, ~isFullscreen, ~toggleFullscreen) => {
+    open ReactFlow
+
+    let reactFlow = useReactFlow()
+
+    React.useEffect(() => {
+      let timeoutId = setTimeout(() => reactFlow.fitView()->ignore, 0)
+      Some(() => clearTimeout(timeoutId))
+    }, [isFullscreen])
+
+    let fullscreenLabel = isFullscreen ? "Exit fullscreen" : "Enter fullscreen"
+
+    <ReactFlowComponent
+      nodes
+      edges
+      nodeTypes={{"explainerNode": ReconEngineSetupExplainerNode.make}}
+      onNodesChange
+      onEdgesChange
+      fitView={true}
+      fitViewOptions={{"padding": 0.15}}
+      nodesDraggable={true}
+      nodesConnectable={false}
+      elementsSelectable={true}
+      panOnDrag={true}
+      zoomOnScroll={true}
+      zoomOnPinch={true}
+      zoomOnDoubleClick={true}
+      minZoom={0.2}
+      maxZoom={1.5}
+      proOptions={{"hideAttribution": true}}>
+      <Background variant="dots" gap={20} size={1} />
+      <Controls showZoom={true} showFitView={true} showInteractive={false} />
+      <Panel position="top-right">
+        <div
+          className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-white border border-nd_gray-200 shadow-sm cursor-pointer"
+          title=fullscreenLabel
+          onClick={_ => toggleFullscreen()}>
+          <Icon name={isFullscreen ? "compress-alt" : "expand-alt"} size=13 />
+          <p className={`${body.sm.semibold} text-nd_gray-500`}>
+            {fullscreenLabel->React.string}
+          </p>
+        </div>
+      </Panel>
+    </ReactFlowComponent>
+  }
+}
+
+@react.component
+let make = () => {
+  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
+  let getAccounts = ReconEngineHooks.useGetAccounts()
+  let getIngestionConfigs = ReconEngineHooks.useGetIngestionConfigs()
+  let getTransformationConfigs = ReconEngineHooks.useGetTransformationConfigs()
+  let getReconRuleList = ReconEngineHooks.useGetReconRuleList()
+  let (nodes, setNodes, onNodesChange) = ReactFlow.useNodesState([])
+  let (edges, setEdges, onEdgesChange) = ReactFlow.useEdgesState([])
+  let (isFullscreen, setIsFullscreen) = React.useState(_ => false)
+
+  let toggleFullscreen = () => setIsFullscreen(prev => !prev)
+
+  React.useEffect(() => {
+    let handleKeyUp = ev => {
+      open ReactEvent.Keyboard
+      if ev->key === "Escape" || ev->keyCode === 27 {
+        setIsFullscreen(_ => false)
+      }
+    }
+    if isFullscreen {
+      Window.addEventListener("keyup", handleKeyUp)
+    }
+    Some(() => Window.removeEventListener("keyup", handleKeyUp))
+  }, [isFullscreen])
+
+  let handleNodeClick = (kind: explainerNodeKind, entityId: string) => {
+    let url = switch kind {
+    | RuleNode => Some(`/v1/recon-engine/rules/${entityId}`)
+    | AccountNode
+    | TransformationNode =>
+      Some("/v1/recon-engine/transformed-entries")
+    | IngestionNode => None
+    }
+    switch url {
+    | Some(url) => RescriptReactRouter.push(GlobalVars.appendDashboardPath(~url))
+    | None => ()
+    }
+  }
+
+  let fetchSetupData = async () => {
+    try {
+      setScreenState(_ => PageLoaderWrapper.Loading)
+      let (accounts, ingestionConfigs, transformationConfigs, rules) = await Promise.all4((
+        getAccounts(),
+        getIngestionConfigs(),
+        getTransformationConfigs(),
+        getReconRuleList(),
+      ))
+      let (newNodes, newEdges) = ReconEngineSetupExplainerUtils.generateSetupNodesAndEdges(
+        ~accounts,
+        ~ingestionConfigs,
+        ~transformationConfigs,
+        ~rules,
+        ~onNodeClick=handleNodeClick,
+      )
+      if newNodes->Array.length > 0 {
+        setNodes(_ => newNodes)->ignore
+        setEdges(_ => newEdges)->ignore
+        setScreenState(_ => PageLoaderWrapper.Success)
+      } else {
+        setScreenState(_ => PageLoaderWrapper.Custom)
+      }
+    } catch {
+    | _ => setScreenState(_ => PageLoaderWrapper.Error("Failed to load your reconciliation setup"))
+    }
+  }
+
+  React.useEffect(() => {
+    fetchSetupData()->ignore
+    None
+  }, [])
+
+  let fullScreenClass = isFullscreen
+    ? "fixed inset-0 z-50 h-screen w-screen rounded-none"
+    : "h-45-rem w-full rounded-xl"
+
+  <div className="flex flex-col">
+    <PageUtils.PageHeading
+      title="Setup Map"
+      subTitle="A live map of your current setup — how files flow in, become entries, and get reconciled by your rules."
+    />
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-row gap-6 rounded-xl border border-nd_gray-150 bg-nd_gray-25 p-4">
+        <LegendStep
+          step="1" title="Data Sources" description="Files arrive from your systems and providers"
+        />
+        <LegendStep
+          step="2" title="Transformations" description="Each file is parsed into normalized entries"
+        />
+        <LegendStep
+          step="3" title="Accounts" description="Entries are posted to double-entry accounts"
+        />
+        <LegendStep
+          step="4"
+          title="Recon Rules"
+          description="Rules pair entries across accounts; anything unmatched becomes an exception"
+        />
+      </div>
+      <div className={`border border-nd_gray-200 overflow-hidden bg-white ${fullScreenClass}`}>
+        <PageLoaderWrapper
+          screenState
+          customUI={<NoDataFound
+            message="No reconciliation setup configured yet. Set up ingestion, transformations and rules to see your flow here."
+            renderType=Painting
+          />}
+          customLoader={<Shimmer styleClass="h-45-rem w-full rounded-xl" />}>
+          <div className="h-full overflow-hidden">
+            <ReactFlow.ReactFlowProvider>
+              <SetupFlowWithControls
+                nodes edges onNodesChange onEdgesChange isFullscreen toggleFullscreen
+              />
+            </ReactFlow.ReactFlowProvider>
+          </div>
+        </PageLoaderWrapper>
+      </div>
+    </div>
+  </div>
+}

--- a/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerTrigger.res
+++ b/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerTrigger.res
@@ -1,0 +1,19 @@
+@react.component
+let make = () => {
+  <div className="fixed top-180-px -translate-y-1/2 z-20 right-0">
+    <div
+      className="relative group cursor-pointer"
+      title="How does my reconciliation setup work?"
+      onClick={_ =>
+        RescriptReactRouter.push(GlobalVars.appendDashboardPath(~url="/v1/recon-engine/setup"))}>
+      <div
+        className="flex items-center justify-center w-12 h-14 bg-nd_gray-700 rounded-l-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:w-14 hover:bg-nd_gray-800">
+        <Icon
+          name="nd-info-circle"
+          size=20
+          className="text-white transition-transform duration-200 group-hover:scale-105"
+        />
+      </div>
+    </div>
+  </div>
+}

--- a/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerTypes.res
+++ b/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerTypes.res
@@ -1,0 +1,51 @@
+type explainerNodeKind =
+  | IngestionNode
+  | TransformationNode
+  | AccountNode
+  | RuleNode
+
+type explainerNodeData = {
+  kind: explainerNodeKind,
+  label: string,
+  description: string,
+  badgeText: string,
+  isActive: bool,
+  showStatus: bool,
+  onNodeClick: option<unit => unit>,
+}
+
+type nodePositionType = {
+  x: float,
+  y: float,
+}
+
+type nodeType = {
+  id: string,
+  @as("type") nodeType: string,
+  position: nodePositionType,
+  data: explainerNodeData,
+}
+
+type edgeStyleType = {
+  stroke: string,
+  strokeWidth: float,
+}
+
+type edgeMarkerType = {@as("type") edgeMarkerType: string}
+
+type edgePathOptionsType = {
+  offset: float,
+  borderRadius: float,
+}
+
+type edgeType = {
+  id: string,
+  source: string,
+  target: string,
+  @as("type") edgeType: string,
+  label?: string,
+  animated?: bool,
+  markerEnd?: edgeMarkerType,
+  style?: edgeStyleType,
+  pathOptions?: edgePathOptionsType,
+}

--- a/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerUtils.res
+++ b/src/ReconEngine/ReconEngineSetupExplainer/ReconEngineSetupExplainerUtils.res
@@ -1,0 +1,327 @@
+open LogicUtils
+open ReconEngineSetupExplainerTypes
+
+let ingestionNodeId = id => `ing-${id}`
+let transformationNodeId = id => `trf-${id}`
+let accountNodeId = id => `acc-${id}`
+let ruleNodeId = id => `rule-${id}`
+
+let columnX = (kind: explainerNodeKind): float => {
+  switch kind {
+  | IngestionNode => 0.0
+  | TransformationNode => 680.0
+  | AccountNode => 1360.0
+  | RuleNode => 2040.0
+  }
+}
+
+let verticalGap = 230.0
+
+let edgeStroke: edgeStyleType = {stroke: "#94A3B8", strokeWidth: 1.5}
+
+let getIngestionSourceLabel = (config: ReconEngineTypes.ingestionConfigType): string => {
+  switch config.data
+  ->getDictFromJsonObject
+  ->getString("ingestion_type", "")
+  ->String.toLowerCase {
+  | "manual" => "Files are uploaded manually from the dashboard"
+  | "sftp" | "sftp_internal" => "Files arrive automatically over SFTP"
+  | "adyen" => "Adyen pushes settlement files automatically"
+  | _ => "Files arrive from this data source"
+  }
+}
+
+let getIngestionTypeBadge = (config: ReconEngineTypes.ingestionConfigType): string => {
+  config.data
+  ->getDictFromJsonObject
+  ->getString("ingestion_type", "")
+  ->snakeToTitle
+}
+
+let averageY = (ys: array<float>, ~fallback: float): float => {
+  switch ys->Array.length {
+  | 0 => fallback
+  | length => ys->Array.reduce(0.0, (acc, y) => acc +. y) /. Int.toFloat(length)
+  }
+}
+
+// Place a column of nodes as close as possible to the row of the nodes they
+// connect to (desiredY), pushing colliding nodes down just enough to keep a
+// minimum vertical gap. This keeps each chain in its own horizontal band.
+let placeColumn = (items: array<'a>, ~desiredY: 'a => float): array<('a, float)> => {
+  let prevY = ref(Float.Constants.negativeInfinity)
+  items
+  ->Array.map(item => (item, desiredY(item)))
+  ->Array.toSorted(((_, y1), (_, y2)) => y1 -. y2)
+  ->Array.map(((item, desired)) => {
+    let y = Math.max(desired, prevY.contents +. verticalGap)
+    prevY := y
+    (item, y)
+  })
+}
+
+let makeNode = (
+  ~id,
+  ~kind,
+  ~label,
+  ~description,
+  ~badgeText="",
+  ~isActive=true,
+  ~showStatus=true,
+  ~y: float,
+  ~onNodeClick=None,
+): nodeType => {
+  id,
+  nodeType: "explainerNode",
+  position: {x: kind->columnX, y},
+  data: {
+    kind,
+    label,
+    description,
+    badgeText,
+    isActive,
+    showStatus,
+    onNodeClick,
+  },
+}
+
+let makeEdge = (~source, ~target, ~label="", ~animated=false): edgeType => {
+  id: `${source}-to-${target}`,
+  source,
+  target,
+  edgeType: "smoothstep",
+  label: ?(label->isNonEmptyString ? Some(label) : None),
+  animated,
+  markerEnd: {edgeMarkerType: ReactFlow.markerTypeArrowClosed},
+  style: edgeStroke,
+}
+
+let generateSetupNodesAndEdges = (
+  ~accounts: array<ReconEngineTypes.accountType>,
+  ~ingestionConfigs: array<ReconEngineTypes.ingestionConfigType>,
+  ~transformationConfigs: array<ReconEngineTypes.transformationConfigType>,
+  ~rules: array<ReconEngineRulesTypes.rulePayload>,
+  ~onNodeClick: option<(explainerNodeKind, string) => unit>=?,
+): (array<nodeType>, array<edgeType>) => {
+  let clickHandler = (kind, entityId) =>
+    onNodeClick->Option.map(handler => () => handler(kind, entityId))
+
+  // Nodes with no resolvable upstream link land below the real chains.
+  let maxRows =
+    [
+      ingestionConfigs->Array.length,
+      transformationConfigs->Array.length,
+      accounts->Array.length,
+      rules->Array.length,
+    ]->Array.reduce(0, (acc, count) => Math.Int.max(acc, count))
+  let orphanY = Int.toFloat(maxRows) *. verticalGap
+
+  let ingestionYs = Dict.make()
+  ingestionConfigs->Array.forEachWithIndex((config, index) =>
+    ingestionYs->Dict.set(config.ingestion_id, Int.toFloat(index) *. verticalGap)
+  )
+
+  let placedTransformations =
+    transformationConfigs->placeColumn(~desiredY=config =>
+      ingestionYs->Dict.get(config.ingestion_id)->Option.getOr(orphanY)
+    )
+  let transformationYs = Dict.make()
+  placedTransformations->Array.forEach(((config, y)) =>
+    transformationYs->Dict.set(config.transformation_id, y)
+  )
+
+  let placedAccounts = accounts->placeColumn(~desiredY=account => {
+    let feederYs =
+      transformationConfigs
+      ->Array.filter(config => config.account_id === account.account_id)
+      ->Array.filterMap(config => transformationYs->Dict.get(config.transformation_id))
+    let fallback =
+      ingestionConfigs
+      ->Array.find(config => config.account_id === account.account_id)
+      ->Option.flatMap(config => ingestionYs->Dict.get(config.ingestion_id))
+      ->Option.getOr(orphanY)
+    feederYs->averageY(~fallback)
+  })
+  let accountYs = Dict.make()
+  placedAccounts->Array.forEach(((account, y)) => accountYs->Dict.set(account.account_id, y))
+
+  let placedRules = rules->placeColumn(~desiredY=rule => {
+    let (sourceAccountId, targetAccounts) = ReconEngineRulesUtils.getSourceAndTargetAccountDetails(
+      rule.strategy,
+    )
+    [sourceAccountId]
+    ->Array.concat(targetAccounts->Array.map(target => target.account_id))
+    ->Array.filterMap(accountId => accountYs->Dict.get(accountId))
+    ->averageY(~fallback=orphanY)
+  })
+
+  // Second pass: re-center each data source between the transformations it
+  // feeds, so a source with several transformations sits mid-band.
+  let placedIngestions = ingestionConfigs->placeColumn(~desiredY=config => {
+    let fedYs =
+      transformationConfigs
+      ->Array.filter(transformation => transformation.ingestion_id === config.ingestion_id)
+      ->Array.filterMap(transformation =>
+        transformationYs->Dict.get(transformation.transformation_id)
+      )
+    let fallback = ingestionYs->Dict.get(config.ingestion_id)->Option.getOr(orphanY)
+    fedYs->averageY(~fallback)
+  })
+
+  let ingestionNodes =
+    placedIngestions->Array.map(((config, y)) =>
+      makeNode(
+        ~id=config.ingestion_id->ingestionNodeId,
+        ~kind=IngestionNode,
+        ~label=config.name,
+        ~description=config->getIngestionSourceLabel,
+        ~badgeText=config->getIngestionTypeBadge,
+        ~isActive=config.is_active,
+        ~y,
+        ~onNodeClick=clickHandler(IngestionNode, config.ingestion_id),
+      )
+    )
+
+  let transformationNodes = placedTransformations->Array.map(((config, y)) => {
+    let accountName = ReconEngineRulesUtils.getAccountName(config.account_id, accounts)
+    makeNode(
+      ~id=config.transformation_id->transformationNodeId,
+      ~kind=TransformationNode,
+      ~label=config.name,
+      ~description=`Parses each file row into entries for ${accountName}`,
+      ~isActive=config.is_active,
+      ~y,
+      ~onNodeClick=clickHandler(TransformationNode, config.transformation_id),
+    )
+  })
+
+  let accountNodes =
+    placedAccounts->Array.map(((account, y)) =>
+      makeNode(
+        ~id=account.account_id->accountNodeId,
+        ~kind=AccountNode,
+        ~label=account.account_name,
+        ~description="Double-entry account holding this party's entries",
+        ~badgeText=`${(account.account_type :> string)->capitalizeString} · ${account.currency}`,
+        ~showStatus=false,
+        ~y,
+        ~onNodeClick=clickHandler(AccountNode, account.account_id),
+      )
+    )
+
+  let ruleNodes = placedRules->Array.map(((rule, y)) => {
+    let description =
+      rule.rule_description->isNonEmptyString
+        ? rule.rule_description
+        : "Pairs entries across its source and target accounts"
+    makeNode(
+      ~id=rule.rule_id->ruleNodeId,
+      ~kind=RuleNode,
+      ~label=rule.rule_name,
+      ~description,
+      ~badgeText=ReconEngineRulesUtils.getReconStrategyDisplayName(rule.strategy),
+      ~isActive=rule.is_active,
+      ~y,
+      ~onNodeClick=clickHandler(RuleNode, rule.rule_id),
+    )
+  })
+
+  let ingestionIds = ingestionConfigs->Array.map(config => config.ingestion_id)
+  let accountIds = accounts->Array.map(account => account.account_id)
+
+  let transformationEdges = transformationConfigs->Array.flatMap(config => {
+    let sourceEdges =
+      ingestionIds->Array.includes(config.ingestion_id)
+        ? [
+            makeEdge(
+              ~source=config.ingestion_id->ingestionNodeId,
+              ~target=config.transformation_id->transformationNodeId,
+              ~label="feeds",
+            ),
+          ]
+        : []
+    let targetEdges =
+      accountIds->Array.includes(config.account_id)
+        ? [
+            makeEdge(
+              ~source=config.transformation_id->transformationNodeId,
+              ~target=config.account_id->accountNodeId,
+              ~label="creates entries in",
+            ),
+          ]
+        : []
+    sourceEdges->Array.concat(targetEdges)
+  })
+
+  let transformedIngestionIds = transformationConfigs->Array.map(config => config.ingestion_id)
+
+  let directIngestionEdges =
+    ingestionConfigs
+    ->Array.filter(config =>
+      !(transformedIngestionIds->Array.includes(config.ingestion_id)) &&
+      accountIds->Array.includes(config.account_id)
+    )
+    ->Array.map(config =>
+      makeEdge(
+        ~source=config.ingestion_id->ingestionNodeId,
+        ~target=config.account_id->accountNodeId,
+        ~label="posts to",
+      )
+    )
+
+  let ruleEdges = rules->Array.flatMap(rule => {
+    let (sourceAccountId, targetAccounts) = ReconEngineRulesUtils.getSourceAndTargetAccountDetails(
+      rule.strategy,
+    )
+    let sourceEdges =
+      accountIds->Array.includes(sourceAccountId)
+        ? [
+            makeEdge(
+              ~source=sourceAccountId->accountNodeId,
+              ~target=rule.rule_id->ruleNodeId,
+              ~label="source entries",
+              ~animated=true,
+            ),
+          ]
+        : []
+    let targetEdges =
+      targetAccounts
+      ->Array.filter(target => accountIds->Array.includes(target.account_id))
+      ->Array.map(target => {
+        let label = switch (target.split_value, target.split_type) {
+        | (Some(value), Some("percentage")) => `target · ${(value *. 100.0)->Float.toString}%`
+        | (Some(value), Some(_)) => `target · ${value->Float.toString}`
+        | _ => "target entries"
+        }
+        makeEdge(
+          ~source=target.account_id->accountNodeId,
+          ~target=rule.rule_id->ruleNodeId,
+          ~label,
+          ~animated=true,
+        )
+      })
+    sourceEdges->Array.concat(targetEdges)
+  })
+
+  let nodes =
+    ingestionNodes
+    ->Array.concat(transformationNodes)
+    ->Array.concat(accountNodes)
+    ->Array.concat(ruleNodes)
+
+  // Stagger the bend distance per edge so parallel edges get their own
+  // routing channel instead of merging into a single line.
+  let edges =
+    transformationEdges
+    ->Array.concat(directIngestionEdges)
+    ->Array.concat(ruleEdges)
+    ->Array.mapWithIndex((edge, index) => {
+      ...edge,
+      pathOptions: {
+        offset: 30.0 +. Int.toFloat(mod(index, 8)) *. 24.0,
+        borderRadius: 8.0,
+      },
+    })
+
+  (nodes, edges)
+}

--- a/src/screens/Sidebar/Sidebar.res
+++ b/src/screens/Sidebar/Sidebar.res
@@ -185,13 +185,13 @@ module SidebarItem = {
           <Link to_={GlobalVars.appendDashboardPath(~url=`${link}${getSearchParamByLink(link)}`)}>
             <div
               onClick={_ => isMobileView ? setIsSidebarExpanded(_ => false) : ()}
-              className={`${textColor} flex flex-row items-center cursor-pointer transition duration-300 ${selectedClass} px-3 py-1.5 mx-1 ${hoverColor}`}>
-              <SidebarOption name icon isSidebarExpanded isSelected />
+              className={`${textColor} relative overflow-hidden flex flex-row rounded-lg items-center cursor-pointer ${hoverColor} ${selectedClass}`}>
+              <SidebarOption name icon isSidebarExpanded isSelected showIcon />
               <RenderIf condition={isSidebarExpanded}>
                 <Icon
                   size={iconSize->Option.getOr(26)}
                   name=iconTag
-                  className={`ml-2 ${iconStyles->Option.getOr("w-26 h-26")}`}
+                  className={iconStyles->Option.getOr("w-26 h-26")}
                 />
               </RenderIf>
             </div>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a **Setup Map** page (Beta) to the recon engine that renders the merchant's live configuration as an interactive left-to-right flow diagram: Data Sources (ingestion configs) → Transformations → Accounts → Recon Rules.

- New sidebar entry `Setup Map` (with Beta tag) under Reconciliation, routed at `/v1/recon-engine/setup`
- Diagram is built from existing list APIs (accounts, ingestion configs, transformation configs, recon rules); adds a `useGetTransformationConfigs` list hook
- Band-based layout keeps each pipeline chain in its own horizontal row: transformations sit beside their data source, accounts beside the transformations feeding them, rules beside their source/target accounts, with collision resolution and per-edge routing lanes so arrows stay separated
- Each node carries plain-English copy (how files arrive, which account entries are created in, what a rule pairs) plus active/inactive status; a legend strip explains the four stages
- Node click-through navigates to the relevant page (rule details / transformed entries); fullscreen toggle for large setups
- Floating edge button on every recon page navigates to the Setup Map
- Fixes stale styling in the shared sidebar `LinkWithTag` branch so tagged items align with sibling links

## Motivation and Context

Recon users cannot easily understand how their configuration fits together — tabs are named after recon rules and screens use terms like transformation config and staging entries without context. This gives them a self-explanatory, end-to-end view of their own setup.

Closes #5383

## How did you test it?

Tested manually on a sandbox merchant with a multi-chain setup (5 data sources, 8 transformations, 5 accounts, 4 rules): verified layout grouping, edge separation, empty/error states, click-through navigation, fullscreen, and sidebar alignment of the Beta tag.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s): (page is gated by the existing `devReconEngineV1` flag)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible