### PR TITLE
feat: enable column selection on recon exception transactions table

### DIFF
--- a/src/Recoils/TableAtoms.res
+++ b/src/Recoils/TableAtoms.res
@@ -44,3 +44,8 @@ let transactionsHierarchicalDefaultCols = Recoil.atom(
   "transactionsHierarchicalDefaultCols",
   HierarchicalTransactionsTableEntity.defaultColumns,
 )
+
+let exceptionTransactionsHierarchicalDefaultCols = Recoil.atom(
+  "exceptionTransactionsHierarchicalDefaultCols",
+  HierarchicalTransactionsTableEntity.defaultColumns,
+)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
@@ -38,6 +38,9 @@ let make = (~ruleId: string) => {
   let endTimeFilterKey = HSAnalyticsUtils.endTimeFilterKey
 
   let sortDict = Recoil.useRecoilValueFromAtom(LoadedTable.sortAtom)
+  let visibleColumns = Recoil.useRecoilValueFromAtom(
+    TableAtoms.exceptionTransactionsHierarchicalDefaultCols,
+  )
   let title = "Exception Transactions"
   let sortOrder = sortDict->getMappedValueFromDict(title, Desc, getSortOrder)
 
@@ -179,6 +182,9 @@ let make = (~ruleId: string) => {
         showCustomFilter=false
         refreshFilters=false
       />
+      <PortalCapture
+        key={`${title}CustomizeColumn`} name={`${title}CustomizeColumn`} customStyle="ml-auto"
+      />
     </div>
   }
 
@@ -211,8 +217,8 @@ let make = (~ruleId: string) => {
           offset
           setOffset
           currentFetchCount={transactions->Array.length}
-          customColumnMapper=TableAtoms.transactionsHierarchicalDefaultCols
-          defaultColumns
+          customColumnMapper=TableAtoms.exceptionTransactionsHierarchicalDefaultCols
+          defaultColumns=mandatoryColumns
           showSerialNumberInCustomizeColumns=false
           sortingBasedOnDisabled=false
           remoteSortEnabled=true
@@ -221,9 +227,8 @@ let make = (~ruleId: string) => {
           tableDataLoading={screenState === PageLoaderWrapper.Loading}
           dataLoading={screenState === PageLoaderWrapper.Loading}
           customizeColumnButtonIcon="nd-filter-horizontal"
-          hideRightTitleElement=true
           showAutoScroll=true
-          customSeparation=[(3, 4)]
+          customSeparation={getCustomSeparation(visibleColumns)}
           filters={<SearchInput
             inputText=searchText
             onChange={value => setSearchText(_ => value)}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
@@ -15,6 +15,8 @@ type hierarchicalColType =
   | Currency
   | DebitAmount
   | CreditAmount
+  | RuleName
+  | CreatedAt
 
 let defaultColumns: array<hierarchicalColType> = [
   Flow,
@@ -30,11 +32,16 @@ let defaultColumns: array<hierarchicalColType> = [
   CreditAmount,
 ]
 
+// Columns the customize-columns modal renders as locked (non-hideable)
+let mandatoryColumns: array<hierarchicalColType> = [TransactionId, Status]
+
 let allColumns: array<hierarchicalColType> = [
   Flow,
   Date,
   TransactionId,
   Status,
+  RuleName,
+  CreatedAt,
   EntryId,
   OrderId,
   Account,
@@ -43,6 +50,24 @@ let allColumns: array<hierarchicalColType> = [
   DebitAmount,
   CreditAmount,
 ]
+
+// Entry-level columns render one nested row per entry; used to compute where the
+// transaction-level / entry-level visual separation falls for a given visible set
+let entryLevelColumns: array<hierarchicalColType> = [
+  EntryId,
+  OrderId,
+  Account,
+  EntryStatus,
+  Currency,
+  DebitAmount,
+  CreditAmount,
+]
+
+let getCustomSeparation = (visibleColumns: array<hierarchicalColType>): array<(int, int)> => {
+  let firstEntryIndex =
+    visibleColumns->Array.findIndex(col => entryLevelColumns->Array.includes(col))
+  firstEntryIndex > 0 ? [(firstEntryIndex - 1, firstEntryIndex)] : []
+}
 
 let getHeading = (colType: hierarchicalColType) => {
   switch colType {
@@ -57,6 +82,8 @@ let getHeading = (colType: hierarchicalColType) => {
   | Currency => makeHeaderInfo(~key="currency", ~title="Currency")
   | DebitAmount => makeHeaderInfo(~key="debit_amount", ~title="Debit Amount")
   | CreditAmount => makeHeaderInfo(~key="credit_amount", ~title="Credit Amount")
+  | RuleName => makeHeaderInfo(~key="rule_name", ~title="Rule Name")
+  | CreatedAt => makeHeaderInfo(~key="created_at", ~title="Created At", ~customWidth="!w-24")
   }
 }
 
@@ -221,6 +248,8 @@ let getCell = (
         ->React.array}
       </div>
     CustomCell(creditAmountContent, "")
+  | RuleName => Text(transaction.rule.rule_name)
+  | CreatedAt => DateWithoutTime(transaction.created_at)
   }
 }
 


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Enables the customize-columns (column selection) feature on the recon Exception Transactions table (Exceptions → rule → transactions). The table already rendered through `LoadedTableWithCustomColumns` — the same component the orchestration payments list uses — but the feature was inert due to a few wiring gaps. This PR:

- Makes `allColumns` in `HierarchicalTransactionsTableEntity` a true superset of the defaults by adding two optional columns, **Rule Name** and **Created At** (hidden by default). Previously `allColumns` was identical to `defaultColumns`, so the modal had nothing to offer.
- Locks only **Transaction ID** and **Status** as mandatory (non-hideable) via a new `mandatoryColumns` set passed as the modal's `defaultColumns` prop; every other column is freely toggleable. The default visible set is unchanged — it still comes from the Recoil atom.
- Adds a dedicated `exceptionTransactionsHierarchicalDefaultCols` Recoil atom so the exceptions table no longer shares column state with the main Transactions screen (both previously used `transactionsHierarchicalDefaultCols`, so customizing one would have leaked into the other).
- Renders the customize-columns trigger by dropping `hideRightTitleElement=true` and adding a `PortalCapture` named after the table title in the filter row — the button portals into `{title}CustomizeColumn`, but this screen's `DynamicFilter` uses a different title, so the button previously had no capture to land in.
- Replaces the hardcoded positional `customSeparation=[(3, 4)]` with `getCustomSeparation(visibleColumns)`, which computes the transaction-level/entry-level divider from the currently visible columns, since hiding columns shifts the positional indices.

Column selections persist in localStorage per table title via the shared `LoadedTableWithCustomColumnsUtils` — no new persistence code.

Closes #5385

## Motivation and Context

Users viewing recon exceptions have different priorities (finance cares about amounts/currency, ops about order IDs) and currently get a fixed 11-column table. The orchestration column-selection infrastructure was already in place under this table; this wires it up. Column defaults and the mandatory set were agreed in #5385.

## How did you test it?

Manual testing on the exceptions screen: customize button appears in the filter row, hiding/showing columns updates the table, mandatory columns (Transaction ID, Status) are locked in the modal, selection survives reload, and the main Transactions table's columns are unaffected. `npm run re:build` compiles clean with no warnings.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

Backend PR URL:

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
