### PR TITLE
feat: add status filter on transformed entry exceptions screen

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
@@ -116,6 +116,13 @@ let initialDisplayFilters = (~accountOptions) => {
     {label: "Debit", value: "debit"},
   ]
 
+  let statusOptions = ReconEngineFilterUtils.getStagingEntryStatusOptions([
+    NeedsManualReview,
+    Processed,
+    Pending,
+    Void,
+  ])
+
   [
     (
       {
@@ -125,6 +132,26 @@ let initialDisplayFilters = (~accountOptions) => {
           ~customInput=InputFields.filterMultiSelectInput(
             ~options=entryTypeOptions,
             ~buttonText="Select Entry Type",
+            ~showSelectionAsChips=false,
+            ~searchable=true,
+            ~showToolTip=true,
+            ~showNameAsToolTip=true,
+            ~customButtonStyle="bg-none",
+            ~fixedDropDownDirection=BottomRight,
+            (),
+          ),
+        ),
+        localFilter: Some((_, _) => []->Array.map(Nullable.make)),
+      }: EntityType.initialFilters<'t>
+    ),
+    (
+      {
+        field: FormRenderer.makeFieldInfo(
+          ~label="status",
+          ~name="status",
+          ~customInput=InputFields.filterMultiSelectInput(
+            ~options=statusOptions,
+            ~buttonText="Select Status",
             ~showSelectionAsChips=false,
             ~searchable=true,
             ~showToolTip=true,


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Adds a **Status** filter to the Transformed Entry Exceptions screen (Recon → Exceptions → Transformed Entries), which until now exposed only Entry Type and Account. This PR:

- Adds a `status` multi-select to `initialDisplayFilters` in `ReconEngineTransformedEntryExceptionsUtils`, placed between the existing Entry Type and Account filters.
- Sources its options from the shared `ReconEngineFilterUtils.getStagingEntryStatusOptions` helper — the same one the Transformed Entries data screen uses — so labels and values stay consistent across recon screens. Options offered are **Needs Manual Review**, **Processed**, **Pending**, and **Void**; `archived` is deliberately excluded because `ApiStagingEntryListFiltersV2::validate` on the backend rejects it with `UnsupportedStatus`.

No request-shaping changes were needed: `buildProcessingEntriesV2Body` already reads `status` out of the filter dict and forwards it to the v2 staging-entries list endpoint, and `ReconEngineTransformedEntryExceptions.res` already falls back to `needs_manual_review` when the status filter is empty. So the screen still opens on the exception queue by default and only widens once the user explicitly picks statuses. The change is confined to a single file.

Closes #5387

## Motivation and Context

The screen hardcodes `needs_manual_review` as the status whenever no status filter is present. That is the right landing view, but it means users have no way to see what happened to an exception after acting on it — an entry that was ignored (`void`), re-processed (`processed`), or is back in the queue after an edit (`pending`) just disappears from the list with no way to bring it back. The backend filter already supported all four statuses; this wires up the UI for them. Option set and default behavior were agreed in #5387.

## How did you test it?

Manual testing on the Transformed Entry Exceptions screen: the Status dropdown renders in the filter row, selecting one or more statuses refetches the list with those statuses in the request body, clearing the selection restores the default `needs_manual_review` view, and the filter composes correctly with the Entry Type, Account, global date range, and search filters. Cursor pagination resets to the first page on filter change.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

Backend PR URL:

## Feature Flag

- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
