### PR TITLE
feat: add transformation config filter on transformed entries screen

### DIFF
--- a/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
+++ b/src/ReconEngine/ReconEngineHooks/ReconEngineHooks.res
@@ -115,6 +115,26 @@ let useGetIngestionConfigs = () => {
   }
 }
 
+let useGetTransformationConfigs = () => {
+  let getURL = useGetURL()
+  let fetchDetails = useGetMethod()
+
+  async (~queryParameters=None) => {
+    try {
+      let url = getURL(
+        ~entityName=V1(HYPERSWITCH_RECON),
+        ~methodType=Get,
+        ~hyperswitchReconType=#TRANSFORMATION_CONFIG,
+        ~queryParameters,
+      )
+      let res = await fetchDetails(url)
+      res->getArrayDataFromJson(transformationConfigItemToObjMapper)
+    } catch {
+    | _ => Exn.raiseError("Something went wrong")
+    }
+  }
+}
+
 let useGetReconRuleList = () => {
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataOverview/ReconEngineDataOverviewComponents/ReconEngineDataOverviewTransformedEntries.res
@@ -17,8 +17,10 @@ let make = (
   )
   let getStagingEntriesOverview = useGetStagingEntriesOverview()
   let getAccounts = useGetAccounts()
+  let getTransformationConfigs = useGetTransformationConfigs()
   let showToast = ToastAdapter.useShowToast()
   let (accountData, setAccountData) = React.useState(_ => [])
+  let (transformationConfigData, setTransformationConfigData) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
   let searchTypeRef = React.useRef(SearchStagingEntryId)
   let (searchText, setSearchText) = React.useState(_ => stagingEntryId->Option.getOr(""))
@@ -72,12 +74,16 @@ let make = (
     })
   }
 
-  let fetchAccounts = async () => {
+  let fetchAccountAndTransformationConfigs = async () => {
     try {
-      let accounts = await getAccounts()
+      let (accounts, transformationConfigs) = await Promise.all2((
+        getAccounts(),
+        getTransformationConfigs(),
+      ))
       setAccountData(_ => accounts)
+      setTransformationConfigData(_ => transformationConfigs)
     } catch {
-    | _ => showToast(~message="Failed to fetch accounts", ~toastType=ToastError)
+    | _ => showToast(~message="Failed to fetch accounts or transformations", ~toastType=ToastError)
     }
   }
 
@@ -87,6 +93,14 @@ let make = (
       value: account.account_id,
     })
 
+  let transformationConfigOptions =
+    transformationConfigData->Array.map((
+      config: ReconEngineTypes.transformationConfigType,
+    ): FilterSelectBox.dropdownOption => {
+      label: config.name,
+      value: config.transformation_id,
+    })
+
   let handleSearchSubmit = (selectedType: option<string>) => {
     let newSearchType = selectedType->mapOptionOrDefault(SearchStagingEntryId, searchTypeFromString)
     searchTypeRef.current = newSearchType
@@ -94,7 +108,7 @@ let make = (
   }
 
   React.useEffect(() => {
-    fetchAccounts()->ignore
+    fetchAccountAndTransformationConfigs()->ignore
     None
   }, [])
 
@@ -110,7 +124,7 @@ let make = (
     <div className="flex flex-row -ml-1.5">
       <DynamicFilter
         title="ReconEngineExceptionStagingFilters"
-        initialFilters={initialDisplayFilters(~accountOptions)}
+        initialFilters={initialDisplayFilters(~accountOptions, ~transformationConfigOptions)}
         options=[]
         popupFilterFields=[]
         initialFixedFilters=[]

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
@@ -70,21 +70,16 @@ let make = () => {
       value: config.transformation_id,
     })
 
-  let fetchAccounts = async () => {
+  let fetchAccountAndTransformationConfigs = async () => {
     try {
-      let accounts = await getAccounts()
+      let (accounts, transformationConfigs) = await Promise.all2((
+        getAccounts(),
+        getTransformationConfigs(),
+      ))
       setAccountData(_ => accounts)
-    } catch {
-    | _ => showToast(~message="Failed to fetch accounts", ~toastType=ToastError)
-    }
-  }
-
-  let fetchTransformationConfigs = async () => {
-    try {
-      let transformationConfigs = await getTransformationConfigs()
       setTransformationConfigData(_ => transformationConfigs)
     } catch {
-    | _ => showToast(~message="Failed to fetch transformations", ~toastType=ToastError)
+    | _ => showToast(~message="Failed to fetch accounts or transformations", ~toastType=ToastError)
     }
   }
 
@@ -95,8 +90,7 @@ let make = () => {
   }
 
   React.useEffect(() => {
-    fetchAccounts()->ignore
-    fetchTransformationConfigs()->ignore
+    fetchAccountAndTransformationConfigs()->ignore
     None
   }, [])
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntries.res
@@ -14,6 +14,7 @@ let make = () => {
     ~itemMapper=ReconEngineUtils.processingItemToObjMapper,
   )
   let getAccounts = useGetAccounts()
+  let getTransformationConfigs = useGetTransformationConfigs()
   let getURL = useGetURL()
   let fetchDetails = useGetMethod()
   let {updateExistingKeys, filterValueJson, filterValue, filterKeys} = React.useContext(
@@ -50,6 +51,7 @@ let make = () => {
   }, ~persistKey=Some("recon-engine-transformed-entries"))
 
   let (accountData, setAccountData) = React.useState(_ => [])
+  let (transformationConfigData, setTransformationConfigData) = React.useState(_ => [])
   let (offset, setOffset) = React.useState(_ => 0)
 
   let accountOptions =
@@ -58,6 +60,14 @@ let make = () => {
     ): FilterSelectBox.dropdownOption => {
       label: account.account_name,
       value: account.account_id,
+    })
+
+  let transformationConfigOptions =
+    transformationConfigData->Array.map((
+      config: ReconEngineTypes.transformationConfigType,
+    ): FilterSelectBox.dropdownOption => {
+      label: config.name,
+      value: config.transformation_id,
     })
 
   let fetchAccounts = async () => {
@@ -69,6 +79,15 @@ let make = () => {
     }
   }
 
+  let fetchTransformationConfigs = async () => {
+    try {
+      let transformationConfigs = await getTransformationConfigs()
+      setTransformationConfigData(_ => transformationConfigs)
+    } catch {
+    | _ => showToast(~message="Failed to fetch transformations", ~toastType=ToastError)
+    }
+  }
+
   let handleSearchSubmit = (selectedType: option<string>) => {
     let newSearchType = selectedType->mapOptionOrDefault(SearchStagingEntryId, searchTypeFromString)
     searchTypeRef.current = newSearchType
@@ -77,6 +96,7 @@ let make = () => {
 
   React.useEffect(() => {
     fetchAccounts()->ignore
+    fetchTransformationConfigs()->ignore
     None
   }, [])
 
@@ -91,7 +111,7 @@ let make = () => {
     <div className="flex flex-row -ml-1.5">
       <DynamicFilter
         title="ReconEngineDataTransformedEntriesFilters"
-        initialFilters={initialDisplayFilters(~accountOptions)}
+        initialFilters={initialDisplayFilters(~accountOptions, ~transformationConfigOptions)}
         options=[]
         popupFilterFields=[]
         initialFixedFilters=[]

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
@@ -250,42 +250,13 @@ let getLineageSections = (~ingestionHistoryData, ~transformationHistoryData, ~en
   },
 ]
 
-let initialDisplayFilters = (
-  ~transformationConfigOptions: array<FilterSelectBox.dropdownOption>=[],
-  ~accountOptions,
-) => {
+let initialDisplayFilters = (~transformationConfigOptions, ~accountOptions) => {
   let entryTypeOptions: array<FilterSelectBox.dropdownOption> = [
     {label: "Credit", value: "credit"},
     {label: "Debit", value: "debit"},
   ]
 
   let statusOptions = getStagingEntryStatusOptions([Processed, Pending, NeedsManualReview, Void])
-
-  let transformationConfigFilter =
-    transformationConfigOptions->isNonEmptyArray
-      ? [
-          (
-            {
-              field: FormRenderer.makeFieldInfo(
-                ~label="Transformation",
-                ~name="transformation_config_ids",
-                ~customInput=InputFields.filterMultiSelectInput(
-                  ~options=transformationConfigOptions,
-                  ~buttonText="Select Transformation",
-                  ~showSelectionAsChips=false,
-                  ~searchable=true,
-                  ~showToolTip=true,
-                  ~showNameAsToolTip=true,
-                  ~customButtonStyle="bg-none",
-                  ~fixedDropDownDirection=BottomRight,
-                  (),
-                ),
-              ),
-              localFilter: Some((_, _) => []->Array.map(Nullable.make)),
-            }: EntityType.initialFilters<'t>
-          ),
-        ]
-      : []
 
   [
     (
@@ -348,5 +319,25 @@ let initialDisplayFilters = (
         localFilter: Some((_, _) => []->Array.map(Nullable.make)),
       }: EntityType.initialFilters<'t>
     ),
-  ]->Array.concat(transformationConfigFilter)
+    (
+      {
+        field: FormRenderer.makeFieldInfo(
+          ~label="Transformation",
+          ~name="transformation_config_ids",
+          ~customInput=InputFields.filterMultiSelectInput(
+            ~options=transformationConfigOptions,
+            ~buttonText="Select Transformation",
+            ~showSelectionAsChips=false,
+            ~searchable=true,
+            ~showToolTip=true,
+            ~showNameAsToolTip=true,
+            ~customButtonStyle="bg-none",
+            ~fixedDropDownDirection=BottomRight,
+            (),
+          ),
+        ),
+        localFilter: Some((_, _) => []->Array.map(Nullable.make)),
+      }: EntityType.initialFilters<'t>
+    ),
+  ]
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
@@ -57,6 +57,8 @@ let buildProcessingEntriesV2Body = (
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let accountIdFilter = filterValueJson->getStrArrayFromDict("account_ids", [])
+  let transformationConfigIdFilter =
+    filterValueJson->getStrArrayFromDict("transformation_config_ids", [])
 
   let startTime = filterValueJson->getString("startTime", "")
   let endTime = filterValueJson->getString("endTime", "")
@@ -71,6 +73,13 @@ let buildProcessingEntriesV2Body = (
 
   if accountIdFilter->isNonEmptyArray {
     filtersDict->Dict.set("account_ids", accountIdFilter->getJsonFromArrayOfString)
+  }
+
+  if transformationConfigIdFilter->isNonEmptyArray {
+    filtersDict->Dict.set(
+      "transformation_config_ids",
+      transformationConfigIdFilter->getJsonFromArrayOfString,
+    )
   }
 
   if searchText->isNonEmptyString {
@@ -241,13 +250,42 @@ let getLineageSections = (~ingestionHistoryData, ~transformationHistoryData, ~en
   },
 ]
 
-let initialDisplayFilters = (~accountOptions) => {
+let initialDisplayFilters = (
+  ~transformationConfigOptions: array<FilterSelectBox.dropdownOption>=[],
+  ~accountOptions,
+) => {
   let entryTypeOptions: array<FilterSelectBox.dropdownOption> = [
     {label: "Credit", value: "credit"},
     {label: "Debit", value: "debit"},
   ]
 
   let statusOptions = getStagingEntryStatusOptions([Processed, Pending, NeedsManualReview, Void])
+
+  let transformationConfigFilter =
+    transformationConfigOptions->isNonEmptyArray
+      ? [
+          (
+            {
+              field: FormRenderer.makeFieldInfo(
+                ~label="Transformation",
+                ~name="transformation_config_ids",
+                ~customInput=InputFields.filterMultiSelectInput(
+                  ~options=transformationConfigOptions,
+                  ~buttonText="Select Transformation",
+                  ~showSelectionAsChips=false,
+                  ~searchable=true,
+                  ~showToolTip=true,
+                  ~showNameAsToolTip=true,
+                  ~customButtonStyle="bg-none",
+                  ~fixedDropDownDirection=BottomRight,
+                  (),
+                ),
+              ),
+              localFilter: Some((_, _) => []->Array.map(Nullable.make)),
+            }: EntityType.initialFilters<'t>
+          ),
+        ]
+      : []
 
   [
     (
@@ -310,5 +348,5 @@ let initialDisplayFilters = (~accountOptions) => {
         localFilter: Some((_, _) => []->Array.map(Nullable.make)),
       }: EntityType.initialFilters<'t>
     ),
-  ]
+  ]->Array.concat(transformationConfigFilter)
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Adds a **Transformation** filter to the Transformed Entries screen (Recon → Data → Transformed Entries), which until now exposed only Entry Type, Status and Account. This PR:

- Adds a `useGetTransformationConfigs` list hook in `ReconEngineHooks` for `GET /transformations/configs`. The existing `useGetTransformationConfig` fetches a single config by ID, so it couldn't be reused; the list endpoint's filters (`ingestion_id`, `account_id`, `is_active`, `time_range`) are all optional, so calling it with no query params returns every config in the profile.
- Teaches `buildProcessingEntriesV2Body` to read `transformation_config_ids` out of the filter dict and forward it inside `filters`, guarded on non-empty like the other array filters.
- Adds a `transformation_config_ids` multi-select to `initialDisplayFilters` in `ReconEngineDataTransformedEntriesUtils`, matching the shape of the existing Entry Type, Status and Account filters. The new `transformationConfigOptions` argument is optional and defaults to `[]`, in which case the filter is not rendered at all — so `ReconEngineDataOverviewTransformedEntries`, which shares this function but is already scoped to a single transformation history, is unchanged.
- Fetches the configs on mount in `ReconEngineDataTransformedEntries.res` (with an error toast, mirroring how accounts are fetched) and maps them to dropdown options — labelled by config name, valued by `transformation_id`.

No backend change is needed: `ApiStagingEntryListFiltersV2` already accepts `transformation_config_ids`. With nothing selected the key is omitted entirely, so the default view is unchanged.

Note: the same filter on the **Transformed Entry Exceptions** screen is being added separately in #5332, so this PR deliberately leaves that screen alone — the two only overlap in `buildProcessingEntriesV2Body`, which both screens already share.

Closes #5389

## Motivation and Context

Transformation configs are the unit users reason about when bad entries spike: one mis-mapped column in a single config produces a burst of entries that need attention. Today the only ways to isolate them are eyeballing the Transformation column row by row, or pasting a `transformation_history_id` into the search box — which narrows to a single *run* rather than to the config across all its runs. Account is a poor proxy, since one account can be fed by several transformation configs. Scope and behaviour were agreed in #5389.

## How did you test it?

Manual testing on the Transformed Entries screen: the Transformation dropdown renders in the filter row and is populated with the profile's configs, selecting one or more refetches the list with `transformation_config_ids` in the request body, clearing the selection restores the unfiltered view, and the filter composes correctly with Entry Type, Status, Account, the global date range, and search. Cursor pagination resets to the first page on filter change. The Data → Overview transformed-entries table still renders its original three filters.

## Where to test it?

- [x] SANDBOX

## Backend Dependency

- [x] No

Backend PR URL:

## Feature Flag

- [x] No feature flag changes

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
