### PR TITLE
feat: add CUG routing header to dashboard API requests

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -15,6 +15,7 @@ dynamo_simulation_template_url=""
 branding=false
 connector_clone=false
 send_v1_dummy_api_key_header=false
+cug_user=false
 mixpanel=false
 test_live_toggle=false
 is_live_mode=false

--- a/src/Recoils/FeatureFlagAtom.res
+++ b/src/Recoils/FeatureFlagAtom.res
@@ -1,0 +1,4 @@
+let featureFlagAtom: Recoil.recoilAtom<FeatureFlagUtils.featureFlag> = Recoil.atom(
+  "featureFlag",
+  JSON.Encode.null->FeatureFlagUtils.featureFlagType,
+)

--- a/src/Recoils/HyperswitchAtom.res
+++ b/src/Recoils/HyperswitchAtom.res
@@ -27,10 +27,7 @@ let themeListAtom: Recoil.recoilAtom<JSON.t> = Recoil.atom("themeListAtom", JSON
 
 let enumVariantAtom = Recoil.atom("enumVariantDetails", "")
 
-let featureFlagAtom: Recoil.recoilAtom<FeatureFlagUtils.featureFlag> = Recoil.atom(
-  "featureFlag",
-  JSON.Encode.null->FeatureFlagUtils.featureFlagType,
-)
+let featureFlagAtom = FeatureFlagAtom.featureFlagAtom
 // Seeded with the sandbox defaults since the feature flags are not resolved yet
 // at module init; HyperSwitchEntry overwrites this once the config is fetched.
 let connectorDisplayListAtom: Recoil.recoilAtom<

--- a/src/entryPoints/FeatureFlagUtils.res
+++ b/src/entryPoints/FeatureFlagUtils.res
@@ -88,6 +88,7 @@ type featureFlag = {
   devClickhouseAggregate: bool,
   connectorClone: bool,
   sendV1DummyApiKeyHeader: bool,
+  cugUser: bool,
   devSuperposition: bool,
 }
 
@@ -179,6 +180,7 @@ let featureFlagType = (featureFlags: JSON.t) => {
     devClickhouseAggregate: dict->getBool("dev_clickhouse_aggregate", false),
     connectorClone: dict->getBool("connector_clone", false),
     sendV1DummyApiKeyHeader,
+    cugUser: dict->getBool("cug_user", false),
     devSuperposition: dict->getBool("dev_superposition", false),
   }
 }

--- a/src/hooks/AuthHooks.res
+++ b/src/hooks/AuthHooks.res
@@ -22,6 +22,7 @@ let getHeaders = (
   ~merchantId,
   ~profileId,
   ~sendV1DummyApiKeyHeader,
+  ~cugUser,
   ~version: UserInfoTypes.version,
 ) => {
   let isMixpanel = uri->String.includes("mixpanel")
@@ -48,6 +49,9 @@ let getHeaders = (
     }
     if xFeatureRoute {
       headersForXFeature(~headers, ~uri)
+    }
+    if cugUser {
+      headers->Dict.set("x-cug-user", "true")
     }
 
     // this header is specific to Intelligent Routing (Dynamic Routing)
@@ -86,6 +90,7 @@ let useApiFetcher = () => {
   let url = RescriptReactRouter.useUrl()
   let setReqProgress = Recoil.useSetRecoilState(ApiProgressHooks.pendingRequestCount)
   let {setEmbeddedStateToError} = React.useContext(EmbeddedCheckProvider.embeddedContext)
+  let {cugUser} = FeatureFlagAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   React.useCallback(
     (
@@ -151,6 +156,7 @@ let useApiFetcher = () => {
               ~merchantId,
               ~profileId,
               ~sendV1DummyApiKeyHeader,
+              ~cugUser,
               ~version,
             ),
             ~signal?, // to be used in case of aborting requests
@@ -202,6 +208,6 @@ let useApiFetcher = () => {
         )
       })
     },
-    [],
+    [cugUser],
   )
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Adds the `cug_user` dashboard feature flag with a safe default of `false`.
- Adds `x-cug-user: true` centrally to dashboard backend API requests when the flag is enabled.
- Isolates the feature-flag atom so the shared request hook can consume it without introducing a module dependency cycle.
- Keeps third-party Mixpanel requests excluded from dashboard routing headers.

https://github.com/user-attachments/assets/7a3134b1-f3dd-4255-9aef-30de83517331

## Motivation and Context

CUG deployments need all dashboard backend API traffic to carry a routing header so webhook and other API requests reach the CUG deployment without modifying individual API call sites.

Closes #5396

## How did you test it?

- Ran `npm run re:build` successfully in a clean isolated checkout.
- Ran `npm run re:format:check` successfully.
- Ran the production webpack bundle successfully.
- Ran `git diff --check` successfully.
- Audited dashboard network paths and confirmed browser API traffic uses the shared fetcher.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [x] PROD

Test on the CUG deployment with `default__features__cug_user=true` and verify dashboard backend requests contain `x-cug-user: true`.

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [x] New feature flag added
- [ ] Existing feature flag updated
- [ ] No feature flag changes

Feature flag name(s): `cug_user`

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
