### PR TITLE
fix: edit entry resolution in staging entry exceptions

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
@@ -572,7 +572,8 @@ let getSectionRowDetails = (~sectionIndex: int, ~rowIndex: int, ~groupedEntries)
 
   <RenderIf condition={hasEntryMetadata}>
     <div className="p-4">
-      <div className="w-full bg-nd_gray-50 rounded-xl overflow-y-scroll !max-h-60 py-2 px-6">
+      <div
+        className="w-0 min-w-full bg-nd_gray-50 rounded-xl overflow-x-auto overflow-y-scroll !max-h-60 py-2 px-6">
         <PrettyPrintJson
           jsonToDisplay={filteredEntryMetadata->JSON.Encode.object->JSON.stringify}
         />
@@ -593,7 +594,8 @@ let getStagingEntryDetails = (~rowIndex: int, ~stagingEntries) => {
 
   <RenderIf condition={hasMetadata}>
     <div className="p-4">
-      <div className="w-full bg-nd_gray-50 rounded-xl overflow-y-scroll !max-h-60 py-2 px-6">
+      <div
+        className="w-0 min-w-full bg-nd_gray-50 rounded-xl overflow-x-auto overflow-y-scroll !max-h-60 py-2 px-6">
         <PrettyPrintJson jsonToDisplay={filteredMetadata->JSON.Encode.object->JSON.stringify} />
       </div>
     </div>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -212,15 +212,16 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
   let isEntryTypeChanged =
     currentData->getString("entry_type", "") != (initialEntryDetails.entry_type :> string)
   let isAmountChanged = currentData->getFloat("amount", 0.0) != initialEntryDetails.amount
+  let isCurrencyChanged = currentData->getString("currency", "") != initialEntryDetails.currency
   let isEffectiveAtChanged =
     currentData->getString("effective_at", "") != initialEntryDetails.effective_at
+
   let isMetadataChanged = {
-    let currentMetadataArray = currentData->getDictfromDict("metadata")->Dict.toArray
-    let initialMetadataArray = initialMetadata->Dict.toArray
-    currentMetadataArray->Array.length != initialMetadataArray->Array.length ||
-      currentMetadataArray->Array.some(((key, value)) => {
-        initialMetadata->Dict.get(key)->Option.mapOr(true, initialValue => initialValue != value)
-      })
+    let currentMetadata = currentData->getDictfromDict("metadata")
+    currentMetadata
+    ->Dict.keysToArray
+    ->Array.concat(initialMetadata->Dict.keysToArray)
+    ->Array.some(key => currentMetadata->getString(key, "") != initialMetadata->getString(key, ""))
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
 
@@ -228,6 +229,7 @@ let hasFormValuesChanged = (currentValues: JSON.t, initialEntryDetails: entryTyp
   isTransformationConfigChanged ||
   isEntryTypeChanged ||
   isAmountChanged ||
+  isCurrencyChanged ||
   isEffectiveAtChanged ||
   isMetadataChanged ||
   isOrderIdChanged

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionsUtils.res
@@ -118,13 +118,6 @@ let validateCurrencyField = (value: string): option<string> => {
   isValid ? None : Some("Must be a valid currency code (e.g., USD, EUR, INR)")
 }
 
-let validateDateTimeField = (value: string): option<string> => {
-  let dateTimePattern = %re("/^\d{2}-\d{2}-\d{4}(\s\d{2}:\d{2}:\d{2})?$/")
-  dateTimePattern->RegExp.test(value)
-    ? None
-    : Some("Must be in format DD-MM-YYYY or DD-MM-YYYY HH:mm:ss")
-}
-
 let validateBalanceDirectionField = (
   value: string,
   credit_values: array<string>,
@@ -166,7 +159,7 @@ let validateMetadataFieldValue = (
         | NumberField(rules) => validateNumberField(value, rules)
         | MinorUnitField(rules) => validateMinorUnitField(value, rules)
         | CurrencyField => validateCurrencyField(value)
-        | DateTimeField => validateDateTimeField(value)
+        | DateTimeField => None
         | BalanceDirectionField({credit_values, debit_values}) =>
           validateBalanceDirectionField(value, credit_values, debit_values)
         | UnknownFieldType => None

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionResolution.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsComponents/ReconEngineTransformedEntryExceptionResolution.res
@@ -124,12 +124,23 @@ module EditEntryModalContent = {
                 ~isRequired=true,
               )}
             />
-            {transformationConfigSelectInputField(
-              ~transformationsList,
-              ~disabled=false,
-              ~setMetadataSchema,
-              ~setIsMetadataLoading,
-            )}
+            <FormRenderer.FieldRenderer
+              labelClass="font-semibold"
+              field={FormRenderer.makeMultiInputFieldInfo(
+                ~label="Transformation Config",
+                ~comboCustomInput=transformationComboSelectInputField(
+                  ~transformationsList,
+                  ~disabled=false,
+                  ~setMetadataSchema,
+                  ~setIsMetadataLoading,
+                ),
+                ~inputFields=[
+                  FormRenderer.makeInputFieldInfo(~name="transformation.transformation_id"),
+                  FormRenderer.makeInputFieldInfo(~name="transformation.transformation_name"),
+                ],
+                ~isRequired=true,
+              )}
+            />
             {entryTypeSelectInputField(~disabled=false)}
             {currencySelectInputField(~entryDetails, ~disabled=false)}
             {amountTextInputField(~disabled=false)}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
@@ -107,7 +107,7 @@ module AccountComboSelectInput = {
         let prevAccountId = prevAccountIdRef.current
         if accountId !== prevAccountId && accountId->isNonEmptyString {
           prevAccountIdRef.current = accountId
-          formApi.change("transformation_id", ""->JSON.Encode.string)
+          formApi.change("transformation", Dict.make()->JSON.Encode.object)
           fetchTransformationConfigs(accountId)->ignore
         }
       },
@@ -140,6 +140,96 @@ let accountComboSelectInputField = (
     />
   }
   {fn, names: ["account.account_id", "account.account_name"]}
+}
+
+module TransformationComboSelectInput = {
+  @react.component
+  let make = (
+    ~transformationsList: array<transformationConfigType>,
+    ~disabled: bool,
+    ~fieldsArray: array<ReactFinalForm.fieldRenderProps>,
+    ~setMetadataSchema,
+    ~setIsMetadataLoading,
+  ) => {
+    open ReconEngineHooks
+
+    let transformationIdField = (
+      fieldsArray[0]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
+    ).input
+    let transformationNameField = (
+      fieldsArray[1]->Option.getOr(ReactFinalForm.fakeFieldRenderProps)
+    ).input
+    let formApi = ReactFinalForm.useForm()
+    let fetchMetadataSchema = useFetchMetadataSchema()
+
+    let handleFetchMetadataSchema = async (transformationId: string) => {
+      try {
+        setIsMetadataLoading(_ => true)
+        let schema =
+          (await fetchMetadataSchema(~transformationId))
+          ->getDictFromJsonObject
+          ->metadataSchemaItemToObjMapper
+        setMetadataSchema(_ => schema)
+        setIsMetadataLoading(_ => false)
+      } catch {
+      | _ => {
+          setMetadataSchema(_ => Dict.make()->metadataSchemaItemToObjMapper)
+          setIsMetadataLoading(_ => false)
+        }
+      }
+    }
+
+    let input: ReactFinalForm.fieldRenderPropsInput = {
+      ...transformationIdField,
+      onChange: ev => {
+        let transformationId = ev->Identity.formReactEventToString
+        let transformationName =
+          transformationsList
+          ->Array.find(config => config.transformation_id == transformationId)
+          ->Option.mapOr("", config => config.name)
+        transformationIdField.onChange(transformationId->Identity.anyTypeToReactEvent)
+        transformationNameField.onChange(transformationName->Identity.anyTypeToReactEvent)
+        formApi.change("metadata", Dict.make()->JSON.Encode.object)
+
+        if transformationId->isNonEmptyString {
+          handleFetchMetadataSchema(transformationId)->ignore
+        } else {
+          setMetadataSchema(_ => Dict.make()->metadataSchemaItemToObjMapper)
+          setIsMetadataLoading(_ => false)
+        }
+      },
+    }
+
+    <SelectBoxAdapter
+      input
+      options={transformationsList->Array.map((config): SelectBox.dropdownOption => {
+        {
+          value: config.transformation_id,
+          label: config.name,
+        }
+      })}
+      buttonText="Select transformation config"
+      allowMultiSelect=false
+      deselectDisable=false
+      isHorizontal=true
+      disableSelect=disabled
+      fullLength=true
+    />
+  }
+}
+
+let transformationComboSelectInputField = (
+  ~transformationsList: array<transformationConfigType>,
+  ~disabled: bool=false,
+  ~setMetadataSchema,
+  ~setIsMetadataLoading,
+): InputFields.comboCustomInputRecord => {
+  let fn = (fieldsArray: array<ReactFinalForm.fieldRenderProps>) => {
+    <TransformationComboSelectInput
+      transformationsList disabled fieldsArray setMetadataSchema setIsMetadataLoading
+    />
+  }
+  {fn, names: ["transformation.transformation_id", "transformation.transformation_name"]}
 }
 
 let entryTypeSelectInputField = (~disabled: bool=false) => {
@@ -588,7 +678,8 @@ let getSectionRowDetails = (~sectionIndex: int, ~rowIndex: int, ~groupedEntries)
 
   <RenderIf condition={hasEntryMetadata}>
     <div className="p-4">
-      <div className="w-full bg-nd_gray-50 rounded-xl overflow-y-scroll !max-h-60 py-2 px-6">
+      <div
+        className="w-0 min-w-full bg-nd_gray-50 rounded-xl overflow-x-auto overflow-y-scroll !max-h-60 py-2 px-6">
         <PrettyPrintJson
           jsonToDisplay={filteredEntryMetadata->JSON.Encode.object->JSON.stringify}
         />

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
@@ -168,6 +168,16 @@ let getInitialValuesForEditEntries = (entryDetails: processingEntryType) => {
     ("account_id", entryDetails.account.account_id->JSON.Encode.string),
     ("account_name", entryDetails.account.account_name->JSON.Encode.string),
   ]
+  let transformation = [
+    (
+      "transformation_id",
+      entryDetails.transformation_config.transformation_config_id->JSON.Encode.string,
+    ),
+    (
+      "transformation_name",
+      entryDetails.transformation_config.transformation_config_name->JSON.Encode.string,
+    ),
+  ]
   let fields = [
     ("account", account->getJsonFromArrayOfJson),
     ("entry_type", (entryDetails.entry_type :> string)->JSON.Encode.string),
@@ -175,10 +185,7 @@ let getInitialValuesForEditEntries = (entryDetails: processingEntryType) => {
     ("amount", entryDetails.amount->JSON.Encode.float),
     ("order_id", entryDetails.order_id->JSON.Encode.string),
     ("effective_at", entryDetails.effective_at->JSON.Encode.string),
-    (
-      "transformation_id",
-      entryDetails.transformation_config.transformation_config_id->JSON.Encode.string,
-    ),
+    ("transformation", transformation->getJsonFromArrayOfJson),
     (
       "metadata",
       entryDetails.metadata
@@ -199,29 +206,28 @@ let hasFormValuesChanged = (
   let isAccountChanged =
     currentAccountData->getString("account_id", "") != initialEntryDetails.account.account_id
   let isTransformationConfigChanged =
-    currentData
-    ->getDictfromDict("transformation_config")
-    ->getString("transformation_config_id", "") !=
+    currentData->getDictfromDict("transformation")->getString("transformation_id", "") !=
       initialEntryDetails.transformation_config.transformation_config_id
   let isEntryTypeChanged =
     currentData->getString("entry_type", "") != (initialEntryDetails.entry_type :> string)
   let isAmountChanged = currentData->getFloat("amount", 0.0) != initialEntryDetails.amount
+  let isCurrencyChanged = currentData->getString("currency", "") != initialEntryDetails.currency
   let isEffectiveAtChanged =
     currentData->getString("effective_at", "") != initialEntryDetails.effective_at
 
   let isMetadataChanged = {
-    let currentMetadataArray = currentData->getDictfromDict("metadata")->Dict.toArray
-    let initialMetadataArray = initialMetadata->Dict.toArray
-    currentMetadataArray->Array.length != initialMetadataArray->Array.length ||
-      currentMetadataArray->Array.some(((key, value)) => {
-        initialMetadata->Dict.get(key)->Option.mapOr(true, initialValue => initialValue != value)
-      })
+    let currentMetadata = currentData->getDictfromDict("metadata")
+    currentMetadata
+    ->Dict.keysToArray
+    ->Array.concat(initialMetadata->Dict.keysToArray)
+    ->Array.some(key => currentMetadata->getString(key, "") != initialMetadata->getString(key, ""))
   }
   let isOrderIdChanged = currentData->getString("order_id", "") != initialEntryDetails.order_id
   isAccountChanged ||
   isTransformationConfigChanged ||
   isEntryTypeChanged ||
   isAmountChanged ||
+  isCurrencyChanged ||
   isEffectiveAtChanged ||
   isMetadataChanged ||
   isOrderIdChanged
@@ -234,6 +240,7 @@ let validateEditEntryDetails = (
 ): JSON.t => {
   let data = values->getDictFromJsonObject
   let accountData = data->getDictfromDict("account")
+  let transformationData = data->getDictfromDict("transformation")
 
   let validationRules = [
     (
@@ -242,7 +249,12 @@ let validateEditEntryDetails = (
         ? requiredString("account.account_id", "Account cannot be empty!")
         : _ => None,
     ),
-    ("transformation_id", requiredString("transformation_id", "Cannot be empty!")),
+    (
+      "transformation",
+      transformationData->getString("transformation_id", "")->isEmptyString
+        ? requiredString("transformation.transformation_id", "Cannot be empty!")
+        : _ => None,
+    ),
     ("entry_type", requiredString("entry_type", "Cannot be empty!")),
     ("currency", requiredString("currency", "Cannot be empty!")),
     ("order_id", requiredString("order_id", "Cannot be empty!")),
@@ -283,6 +295,7 @@ let validateEditEntryDetails = (
 
 let getUpdatedEntry = (~entryDetails: processingEntryType, ~formData): processingEntryType => {
   let accountData = formData->getDictfromDict("account")
+  let transformationData = formData->getDictfromDict("transformation")
   {
     id: entryDetails.id,
     staging_entry_id: entryDetails.staging_entry_id,
@@ -297,12 +310,8 @@ let getUpdatedEntry = (~entryDetails: processingEntryType, ~formData): processin
     processing_mode: entryDetails.processing_mode,
     metadata: formData->getJsonObjectFromDict("metadata"),
     transformation_config: {
-      transformation_config_id: formData
-      ->getDictfromDict("transformation_config")
-      ->getString("transformation_config_id", ""),
-      transformation_config_name: formData
-      ->getDictfromDict("transformation_config")
-      ->getString("transformation_config_name", ""),
+      transformation_config_id: transformationData->getString("transformation_id", ""),
+      transformation_config_name: transformationData->getString("transformation_name", ""),
     },
     transformation_history_id: entryDetails.transformation_history_id,
     effective_at: formData->getString("effective_at", ""),


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes the **Edit Entry** resolution on the staging entry (transformed entry) exception screen.

**Transformation config was read under a key the form never has.** The Edit Entry form registered a flat `transformation_id` field, while `hasFormValuesChanged` and `getUpdatedEntry` read `transformation_config.transformation_config_id`. That key is always absent, so:

- the config always compared as "changed" → the `No changes` validation error never fired → **"Save changes" was enabled from the moment the modal opened**;
- a save wrote an empty config back, flipping the entry to `Pending` with a blank transformation config, a `Transformation Config changed to .` summary line, and `transformation_id: ""` in the update body.

The field now follows the same shape as the existing `Account` field — a `transformation` key holding `transformation_id` and `transformation_name`, backed by a new `TransformationComboSelectInput` modelled on `AccountComboSelectInput` (still resets `metadata` and refetches the metadata schema on change). Carrying the name means the entries table shows the config name instead of `N/A` after a config switch.

**Metadata was compared by key count.** `MetadataInput` reshapes the `metadata` form value to the transformation schema as soon as it loads, adding a row for every schema field including the ones with no value. The key count then differs from the entry's metadata and the form reports a change on open. Metadata is now compared by value, treating an absent key and an empty one as equal. Applied to both copies of `hasFormValuesChanged`, since the transaction exception Edit Entry has the identical defect from the same shared `MetadataInput`.

**Currency was never compared** in `hasFormValuesChanged`, so a currency-only edit left "Save changes" disabled even though `generateResolutionSummary` reported the change. Added to both copies.

**Expanded metadata widened the table.** The metadata block renders inside a `colSpan` cell of a `table-auto` table, so its content width was distributed across every column. It now uses `w-0 min-w-full` so it contributes nothing to the column-width calculation and stretches to the row width at layout time, with long JSON scrolling inside it. Applied to the three row-detail wrappers feeding that table.

## Motivation and Context

Closes #5398

The resolution flow could silently "resolve" an exception with no user edit and wipe the entry's transformation config in the process, which is data loss on a manual reconciliation path.

## How did you test it?

Manually, on the recon engine exception screens:

- Open **Edit Entry** on a staging entry exception → "Save changes" is disabled until a field is actually changed.
- Change a field → "Save changes" enables, the resolution summary lists the real change only, and no phantom `Transformation Config changed to .` line appears.
- Pick a different transformation config → id and name both carry through to the confirmation table.
- Change only the currency → "Save changes" enables.
- Expand metadata on the entries table → column widths stay put and long JSON scrolls inside the block.
- Same checks on the transaction exception Edit Entry for the shared metadata/currency changes.

`npm run re:build` passes with no warnings.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
