### PR TITLE
feat: add substatus level filters in transformed entries

### DIFF
--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -192,64 +192,46 @@ let getGroupedTransactionStatusOptions = (statusList: array<domainTransactionSta
   })
 }
 
-let stagingEntryManualReviewReasons: array<stagingEntryManualReviewData> = [
-  NoRulesFound,
-  CurrencyMismatch,
-  MissingSearchIdentifierValue,
-  DuplicateEntry,
-  NoExpectationEntryFound,
-  MultipleExpectedEntriesFound,
-  MissingMatchField,
-  MissingUniqueField,
-  MissingGroupingField,
-  InternalError,
-]
-
-let stagingEntryStatusOptGroup = "Entry Status"
-let manualReviewOptGroup = "Needs Manual Review"
-
-let getStagingEntryDetailedStatusGroupedValueAndLabel = (status: domainStagingEntryStatus): (
+let getStagingEntryStatusGroupedValueAndLabel = (status: domainStagingEntryStatus): (
   string,
   string,
   string,
 ) => {
   switch status {
-  | Pending => ("pending", "Pending", stagingEntryStatusOptGroup)
-  | Processed => ("processed", "Processed", stagingEntryStatusOptGroup)
-  | Void => ("void", "Void", stagingEntryStatusOptGroup)
-  | Archived => ("archived", "Archived", stagingEntryStatusOptGroup)
-  | NeedsManualReview(UnknownStagingEntryManualReviewData) => (
-      "needs_manual_review",
-      "Needs Manual Review",
-      stagingEntryStatusOptGroup,
-    )
+  | Pending => ("pending", "Pending", "Entry Status")
+  | Processed => ("processed", "Processed", "Entry Status")
+  | Void => ("void", "Void", "Entry Status")
+  | Archived => ("archived", "Archived", "Entry Status")
+  | NeedsManualReview(UnknownStagingEntryManualReviewData)
+  | UnknownDomainStagingEntryStatus => ("", "", "")
   | NeedsManualReview(reason) => {
       let reasonValue = (reason :> string)
-      (`needs_manual_review_${reasonValue}`, reasonValue->snakeToTitle, manualReviewOptGroup)
+      (`needs_manual_review_${reasonValue}`, reasonValue->snakeToTitle, "Needs Manual Review")
     }
-  | UnknownDomainStagingEntryStatus => ("", "", "")
   }
 }
 
-let stagingEntryDetailedStatusFilterOptions: array<domainStagingEntryStatus> = Array.concat(
-  [Pending, Processed, Void],
-  stagingEntryManualReviewReasons->Array.map(reason => NeedsManualReview(reason)),
-)
-
-let stagingEntryDetailedStatuses: array<domainStagingEntryStatus> = Array.concat(
-  [NeedsManualReview(UnknownStagingEntryManualReviewData)],
-  stagingEntryDetailedStatusFilterOptions,
-)
-
-let getStagingEntryDetailedStatusFromValue = (value: string): domainStagingEntryStatus =>
-  stagingEntryDetailedStatuses
+let getStagingEntryStatusFromValue = (
+  value: string,
+  statusList: array<domainStagingEntryStatus>,
+): domainStagingEntryStatus =>
+  statusList
   ->Array.find(status => {
-    let (statusValue, _, _) = getStagingEntryDetailedStatusGroupedValueAndLabel(status)
+    let (statusValue, _, _) = getStagingEntryStatusGroupedValueAndLabel(status)
     statusValue === value
   })
   ->Option.getOr(UnknownDomainStagingEntryStatus)
 
-let encodeStagingEntryDetailedStatus = (status: domainStagingEntryStatus): option<JSON.t> => {
+let getStagingEntryStatusValueFromStatusList = (statusList: array<domainStagingEntryStatus>): array<
+  string,
+> => {
+  statusList->Array.filterMap(status => {
+    let (value, _, _) = getStagingEntryStatusGroupedValueAndLabel(status)
+    value->isNonEmptyString ? Some(value) : None
+  })
+}
+
+let getStagingEntryStatusPayload = (statusList: array<domainStagingEntryStatus>): array<JSON.t> => {
   let encode = (coarseStatus, subStatus) => {
     let fields = [("status", coarseStatus->JSON.Encode.string)]
     switch subStatus {
@@ -259,25 +241,25 @@ let encodeStagingEntryDetailedStatus = (status: domainStagingEntryStatus): optio
     Some(fields->getJsonFromArrayOfJson)
   }
 
-  switch status {
-  | Pending => encode("pending", None)
-  | Processed => encode("processed", None)
-  | Void => encode("void", None)
-  | Archived => encode("archived", None)
-  | NeedsManualReview(UnknownStagingEntryManualReviewData) => encode("needs_manual_review", None)
-  | NeedsManualReview(reason) => encode("needs_manual_review", Some((reason :> string)))
-  | UnknownDomainStagingEntryStatus => None
-  }
+  statusList->Array.filterMap(status =>
+    switch status {
+    | Pending => encode("pending", None)
+    | Processed => encode("processed", None)
+    | Void => encode("void", None)
+    | Archived => encode("archived", None)
+    | NeedsManualReview(UnknownStagingEntryManualReviewData)
+    | UnknownDomainStagingEntryStatus =>
+      None
+    | NeedsManualReview(reason) => encode("needs_manual_review", Some((reason :> string)))
+    }
+  )
 }
 
-let getStagingEntryDetailedStatusPayload = (statusList: array<domainStagingEntryStatus>): JSON.t =>
-  statusList->Array.filterMap(encodeStagingEntryDetailedStatus)->JSON.Encode.array
-
-let getGroupedStagingEntryDetailedStatusOptions = (
-  statusList: array<domainStagingEntryStatus>,
-): array<FilterSelectBox.dropdownOption> => {
+let getGroupedStagingEntryStatusOptions = (statusList: array<domainStagingEntryStatus>): array<
+  FilterSelectBox.dropdownOption,
+> => {
   statusList->Array.map(status => {
-    let (value, label, optGroup) = getStagingEntryDetailedStatusGroupedValueAndLabel(status)
+    let (value, label, optGroup) = getStagingEntryStatusGroupedValueAndLabel(status)
 
     {
       FilterSelectBox.label,

--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -151,21 +151,6 @@ let getTransactionStatusGroupedValueAndLabel = (status: domainTransactionStatus)
   }
 }
 
-let getProcessingEntryStatusValueAndLabel = (status: processingEntryStatus): (string, string) => {
-  let value: string = (status :> string)->camelToSnake
-  let label = (status :> string)->snakeToTitle
-  (value, label)
-}
-
-let getProcessingEntryStatusValueFromStatusList = (statusList: array<processingEntryStatus>): array<
-  string,
-> => {
-  statusList->Array.map(status => {
-    let (value, _) = getProcessingEntryStatusValueAndLabel(status)
-    value
-  })
-}
-
 let getIngestionTransformationHistoryStatusValueFromStatusList = (
   statusList: array<ingestionTransformationStatusType>,
 ): array<string> => {
@@ -207,15 +192,97 @@ let getGroupedTransactionStatusOptions = (statusList: array<domainTransactionSta
   })
 }
 
-let getStagingEntryStatusOptions = (statusList: array<processingEntryStatus>): array<
-  FilterSelectBox.dropdownOption,
-> => {
+let stagingEntryManualReviewReasons: array<stagingEntryManualReviewData> = [
+  NoRulesFound,
+  CurrencyMismatch,
+  MissingSearchIdentifierValue,
+  DuplicateEntry,
+  NoExpectationEntryFound,
+  MultipleExpectedEntriesFound,
+  MissingMatchField,
+  MissingUniqueField,
+  MissingGroupingField,
+  InternalError,
+]
+
+let stagingEntryStatusOptGroup = "Entry Status"
+let manualReviewOptGroup = "Needs Manual Review"
+
+let getStagingEntryDetailedStatusGroupedValueAndLabel = (status: domainStagingEntryStatus): (
+  string,
+  string,
+  string,
+) => {
+  switch status {
+  | Pending => ("pending", "Pending", stagingEntryStatusOptGroup)
+  | Processed => ("processed", "Processed", stagingEntryStatusOptGroup)
+  | Void => ("void", "Void", stagingEntryStatusOptGroup)
+  | Archived => ("archived", "Archived", stagingEntryStatusOptGroup)
+  | NeedsManualReview(UnknownStagingEntryManualReviewData) => (
+      "needs_manual_review",
+      "Needs Manual Review",
+      stagingEntryStatusOptGroup,
+    )
+  | NeedsManualReview(reason) => {
+      let reasonValue = (reason :> string)
+      (`needs_manual_review_${reasonValue}`, reasonValue->snakeToTitle, manualReviewOptGroup)
+    }
+  | UnknownDomainStagingEntryStatus => ("", "", "")
+  }
+}
+
+let stagingEntryDetailedStatusFilterOptions: array<domainStagingEntryStatus> = Array.concat(
+  [Pending, Processed, Void],
+  stagingEntryManualReviewReasons->Array.map(reason => NeedsManualReview(reason)),
+)
+
+let stagingEntryDetailedStatuses: array<domainStagingEntryStatus> = Array.concat(
+  [NeedsManualReview(UnknownStagingEntryManualReviewData)],
+  stagingEntryDetailedStatusFilterOptions,
+)
+
+let getStagingEntryDetailedStatusFromValue = (value: string): domainStagingEntryStatus =>
+  stagingEntryDetailedStatuses
+  ->Array.find(status => {
+    let (statusValue, _, _) = getStagingEntryDetailedStatusGroupedValueAndLabel(status)
+    statusValue === value
+  })
+  ->Option.getOr(UnknownDomainStagingEntryStatus)
+
+let encodeStagingEntryDetailedStatus = (status: domainStagingEntryStatus): option<JSON.t> => {
+  let encode = (coarseStatus, subStatus) => {
+    let fields = [("status", coarseStatus->JSON.Encode.string)]
+    switch subStatus {
+    | Some(sub) => fields->Array.push(("sub_status", sub->JSON.Encode.string))
+    | None => ()
+    }
+    Some(fields->getJsonFromArrayOfJson)
+  }
+
+  switch status {
+  | Pending => encode("pending", None)
+  | Processed => encode("processed", None)
+  | Void => encode("void", None)
+  | Archived => encode("archived", None)
+  | NeedsManualReview(UnknownStagingEntryManualReviewData) => encode("needs_manual_review", None)
+  | NeedsManualReview(reason) => encode("needs_manual_review", Some((reason :> string)))
+  | UnknownDomainStagingEntryStatus => None
+  }
+}
+
+let getStagingEntryDetailedStatusPayload = (statusList: array<domainStagingEntryStatus>): JSON.t =>
+  statusList->Array.filterMap(encodeStagingEntryDetailedStatus)->JSON.Encode.array
+
+let getGroupedStagingEntryDetailedStatusOptions = (
+  statusList: array<domainStagingEntryStatus>,
+): array<FilterSelectBox.dropdownOption> => {
   statusList->Array.map(status => {
-    let (value, label) = getProcessingEntryStatusValueAndLabel(status)
+    let (value, label, optGroup) = getStagingEntryDetailedStatusGroupedValueAndLabel(status)
 
     {
       FilterSelectBox.label,
       value,
+      optGroup,
     }
   })
 }

--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -209,6 +209,13 @@ let allStagingEntryManualReviewStatuses: array<domainStagingEntryStatus> = [
   NeedsManualReview(InternalError),
 ]
 
+let allStagingEntryStatuses: array<domainStagingEntryStatus> = [
+  Pending,
+  Processed,
+  Void,
+  ...allStagingEntryManualReviewStatuses,
+]
+
 let getStagingEntryStatusGroupedValueAndLabel = (status: domainStagingEntryStatus): (
   string,
   string,

--- a/src/ReconEngine/ReconEngineFilterUtils.res
+++ b/src/ReconEngine/ReconEngineFilterUtils.res
@@ -196,6 +196,19 @@ let getGroupedTransactionStatusOptions = (statusList: array<domainTransactionSta
   })
 }
 
+let allStagingEntryManualReviewStatuses: array<domainStagingEntryStatus> = [
+  NeedsManualReview(NoRulesFound),
+  NeedsManualReview(CurrencyMismatch),
+  NeedsManualReview(MissingSearchIdentifierValue),
+  NeedsManualReview(DuplicateEntry),
+  NeedsManualReview(NoExpectationEntryFound),
+  NeedsManualReview(MultipleExpectedEntriesFound),
+  NeedsManualReview(MissingMatchField),
+  NeedsManualReview(MissingUniqueField),
+  NeedsManualReview(MissingGroupingField),
+  NeedsManualReview(InternalError),
+]
+
 let getStagingEntryStatusGroupedValueAndLabel = (status: domainStagingEntryStatus): (
   string,
   string,

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesComponents/ReconEngineDataTransformedEntriesOverviewCards.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesComponents/ReconEngineDataTransformedEntriesOverviewCards.res
@@ -76,27 +76,9 @@ let make = (~selectedTransformationHistoryId: option<string>) => {
   }
 
   let settingActiveView = () => {
-    let appliedStatusFilter = filterValueJson->getArrayFromDict(customFilterKey, [])
-    let appliedStatusArray = appliedStatusFilter->getStrArrayFromJsonArray
-
-    let allViewStatuses = AllViewType->getViewStatusFilter->String.split(",")
-    let isAllView =
-      appliedStatusArray->Array.toSorted(compareLogic) ==
-        allViewStatuses->Array.toSorted(compareLogic)
-
-    if isAllView {
-      setActiveView(_ => AllViewType)
-    } else if appliedStatusFilter->Array.length == 1 {
-      let status =
-        appliedStatusFilter
-        ->getValueFromArray(0, ""->JSON.Encode.string)
-        ->getStringFromJson("")
-
-      let viewType = status->getViewTypeFromStatus
-      setActiveView(_ => viewType)
-    } else {
-      setActiveView(_ => UnknownTransformedEntriesViewType)
-    }
+    let appliedStatusArray =
+      filterValueJson->getArrayFromDict(customFilterKey, [])->getStrArrayFromJsonArray
+    setActiveView(_ => appliedStatusArray->getViewTypeFromStatusFilter)
   }
 
   React.useEffect(() => {

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
@@ -50,10 +50,25 @@ let buildProcessingEntriesV2Body = (
   ~transformationHistoryIds: array<string>=[],
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
+  let statusOptions: array<domainStagingEntryStatus> = [
+    Pending,
+    Processed,
+    Void,
+    NeedsManualReview(NoRulesFound),
+    NeedsManualReview(CurrencyMismatch),
+    NeedsManualReview(MissingSearchIdentifierValue),
+    NeedsManualReview(DuplicateEntry),
+    NeedsManualReview(NoExpectationEntryFound),
+    NeedsManualReview(MultipleExpectedEntriesFound),
+    NeedsManualReview(MissingMatchField),
+    NeedsManualReview(MissingUniqueField),
+    NeedsManualReview(MissingGroupingField),
+    NeedsManualReview(InternalError),
+  ]
   let detailedStatuses =
     statusFilter->isEmptyArray
-      ? [Pending, Processed, Void, NeedsManualReview(UnknownStagingEntryManualReviewData)]
-      : statusFilter->Array.map(getStagingEntryDetailedStatusFromValue)
+      ? statusOptions
+      : statusFilter->Array.map(value => getStagingEntryStatusFromValue(value, statusOptions))
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let accountIdFilter = filterValueJson->getStrArrayFromDict("account_ids", [])
@@ -65,7 +80,10 @@ let buildProcessingEntriesV2Body = (
   let hasTimeRange = startTime->isNonEmptyString && endTime->isNonEmptyString
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set("detailed_status", detailedStatuses->getStagingEntryDetailedStatusPayload)
+  filtersDict->Dict.set(
+    "detailed_status",
+    detailedStatuses->getStagingEntryStatusPayload->JSON.Encode.array,
+  )
 
   if entryTypeFilter->isNonEmptyArray {
     filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
@@ -169,20 +187,47 @@ let getTotalEntries = (accountsOverview: array<accountStagingEntriesOverview>): 
 
 let getViewStatusFilter = (view: transformedEntriesViewType): string => {
   switch view {
-  | AllViewType => "pending,processed,needs_manual_review,void"
-  | ProcessedViewType => "processed"
-  | NeedsManualReviewViewType => "needs_manual_review"
-  | UnknownTransformedEntriesViewType => ""
+  | AllViewType => [
+      Pending,
+      Processed,
+      Void,
+      NeedsManualReview(NoRulesFound),
+      NeedsManualReview(CurrencyMismatch),
+      NeedsManualReview(MissingSearchIdentifierValue),
+      NeedsManualReview(DuplicateEntry),
+      NeedsManualReview(NoExpectationEntryFound),
+      NeedsManualReview(MultipleExpectedEntriesFound),
+      NeedsManualReview(MissingMatchField),
+      NeedsManualReview(MissingUniqueField),
+      NeedsManualReview(MissingGroupingField),
+      NeedsManualReview(InternalError),
+    ]
+  | ProcessedViewType => [Processed]
+  | NeedsManualReviewViewType => [
+      NeedsManualReview(NoRulesFound),
+      NeedsManualReview(CurrencyMismatch),
+      NeedsManualReview(MissingSearchIdentifierValue),
+      NeedsManualReview(DuplicateEntry),
+      NeedsManualReview(NoExpectationEntryFound),
+      NeedsManualReview(MultipleExpectedEntriesFound),
+      NeedsManualReview(MissingMatchField),
+      NeedsManualReview(MissingUniqueField),
+      NeedsManualReview(MissingGroupingField),
+      NeedsManualReview(InternalError),
+    ]
+  | UnknownTransformedEntriesViewType => []
   }
+  ->getStagingEntryStatusValueFromStatusList
+  ->Array.joinWith(",")
 }
 
-let getViewTypeFromStatus = (status: string): transformedEntriesViewType => {
-  switch status {
-  | "processed" => ProcessedViewType
-  | "needs_manual_review" => NeedsManualReviewViewType
-  | "pending,processed,needs_manual_review,void" => AllViewType
-  | _ => UnknownTransformedEntriesViewType
-  }
+let getViewTypeFromStatusFilter = (appliedStatuses: array<string>): transformedEntriesViewType => {
+  let sorted = appliedStatuses->Array.toSorted(compareLogic)
+  [AllViewType, ProcessedViewType, NeedsManualReviewViewType]
+  ->Array.find(view =>
+    view->getViewStatusFilter->String.split(",")->Array.toSorted(compareLogic) == sorted
+  )
+  ->Option.getOr(UnknownTransformedEntriesViewType)
 }
 
 let cardDetails = (~stagingOverviewData: array<accountStagingEntriesOverview>) => {
@@ -263,9 +308,21 @@ let initialDisplayFilters = (~accountOptions) => {
     {label: "Debit", value: "debit"},
   ]
 
-  let statusOptions = getGroupedStagingEntryDetailedStatusOptions(
-    stagingEntryDetailedStatusFilterOptions,
-  )
+  let statusOptions = getGroupedStagingEntryStatusOptions([
+    Pending,
+    Processed,
+    Void,
+    NeedsManualReview(NoRulesFound),
+    NeedsManualReview(CurrencyMismatch),
+    NeedsManualReview(MissingSearchIdentifierValue),
+    NeedsManualReview(DuplicateEntry),
+    NeedsManualReview(NoExpectationEntryFound),
+    NeedsManualReview(MultipleExpectedEntriesFound),
+    NeedsManualReview(MissingMatchField),
+    NeedsManualReview(MissingUniqueField),
+    NeedsManualReview(MissingGroupingField),
+    NeedsManualReview(InternalError),
+  ])
 
   [
     (

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
@@ -50,25 +50,12 @@ let buildProcessingEntriesV2Body = (
   ~transformationHistoryIds: array<string>=[],
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
-  let statusOptions: array<domainStagingEntryStatus> = [
-    Pending,
-    Processed,
-    Void,
-    NeedsManualReview(NoRulesFound),
-    NeedsManualReview(CurrencyMismatch),
-    NeedsManualReview(MissingSearchIdentifierValue),
-    NeedsManualReview(DuplicateEntry),
-    NeedsManualReview(NoExpectationEntryFound),
-    NeedsManualReview(MultipleExpectedEntriesFound),
-    NeedsManualReview(MissingMatchField),
-    NeedsManualReview(MissingUniqueField),
-    NeedsManualReview(MissingGroupingField),
-    NeedsManualReview(InternalError),
-  ]
   let detailedStatuses =
     statusFilter->isEmptyArray
-      ? statusOptions
-      : statusFilter->Array.map(value => getStagingEntryStatusFromValue(value, statusOptions))
+      ? allStagingEntryStatuses
+      : statusFilter->Array.map(value =>
+          getStagingEntryStatusFromValue(value, allStagingEntryStatuses)
+        )
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let accountIdFilter = filterValueJson->getStrArrayFromDict("account_ids", [])
@@ -77,56 +64,41 @@ let buildProcessingEntriesV2Body = (
 
   let startTime = filterValueJson->getString("startTime", "")->toReconTimeString
   let endTime = filterValueJson->getString("endTime", "")->toReconTimeString
-  let hasTimeRange = startTime->isNonEmptyString && endTime->isNonEmptyString
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set(
-    "detailed_status",
-    detailedStatuses->getStagingEntryStatusPayload->JSON.Encode.array,
+  let detailedStatusPayload = detailedStatuses->getStagingEntryStatusPayload
+
+  filtersDict->setOptionArray("detailed_status", detailedStatusPayload->getNonEmptyArray)
+  filtersDict->setOptionArray(
+    "entry_type",
+    entryTypeFilter->Array.map(JSON.Encode.string)->getNonEmptyArray,
   )
-
-  if entryTypeFilter->isNonEmptyArray {
-    filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
-  }
-
-  if accountIdFilter->isNonEmptyArray {
-    filtersDict->Dict.set("account_ids", accountIdFilter->getJsonFromArrayOfString)
-  }
-
-  if transformationConfigIdFilter->isNonEmptyArray {
-    filtersDict->Dict.set(
-      "transformation_config_ids",
-      transformationConfigIdFilter->getJsonFromArrayOfString,
-    )
-  }
-
-  if searchText->isNonEmptyString {
-    filtersDict->Dict.set((searchType :> string), searchText->String.trim->JSON.Encode.string)
-  }
-
-  if transformationHistoryIds->isNonEmptyArray {
-    filtersDict->Dict.set(
-      "transformation_history_ids",
-      transformationHistoryIds->getJsonFromArrayOfString,
-    )
-  }
-
-  if transformationConfigIdFilter->isNonEmptyArray {
-    filtersDict->Dict.set(
-      "transformation_config_ids",
-      transformationConfigIdFilter->getJsonFromArrayOfString,
-    )
-  }
-
-  if hasTimeRange {
-    filtersDict->Dict.set(
-      "time_range",
-      [
-        ("start_time", startTime->JSON.Encode.string),
-        ("end_time", endTime->JSON.Encode.string),
-      ]->getJsonFromArrayOfJson,
-    )
-  }
+  filtersDict->setOptionArray(
+    "account_ids",
+    accountIdFilter->Array.map(JSON.Encode.string)->getNonEmptyArray,
+  )
+  filtersDict->setOptionArray(
+    "transformation_config_ids",
+    transformationConfigIdFilter->Array.map(JSON.Encode.string)->getNonEmptyArray,
+  )
+  filtersDict->setOptionArray(
+    "transformation_history_ids",
+    transformationHistoryIds->Array.map(JSON.Encode.string)->getNonEmptyArray,
+  )
+  filtersDict->setOptionString((searchType :> string), searchText->String.trim->getNonEmptyString)
+  filtersDict->setOptionDict(
+    "time_range",
+    switch (startTime->getNonEmptyString, endTime->getNonEmptyString) {
+    | (Some(startValue), Some(endValue)) =>
+      Some(
+        Dict.fromArray([
+          ("start_time", startValue->JSON.Encode.string),
+          ("end_time", endValue->JSON.Encode.string),
+        ]),
+      )
+    | _ => None
+    },
+  )
 
   [
     ("filters", filtersDict->JSON.Encode.object),
@@ -194,34 +166,9 @@ let getTotalEntries = (accountsOverview: array<accountStagingEntriesOverview>): 
 
 let getViewStatusFilter = (view: transformedEntriesViewType): string => {
   switch view {
-  | AllViewType => [
-      Pending,
-      Processed,
-      Void,
-      NeedsManualReview(NoRulesFound),
-      NeedsManualReview(CurrencyMismatch),
-      NeedsManualReview(MissingSearchIdentifierValue),
-      NeedsManualReview(DuplicateEntry),
-      NeedsManualReview(NoExpectationEntryFound),
-      NeedsManualReview(MultipleExpectedEntriesFound),
-      NeedsManualReview(MissingMatchField),
-      NeedsManualReview(MissingUniqueField),
-      NeedsManualReview(MissingGroupingField),
-      NeedsManualReview(InternalError),
-    ]
+  | AllViewType => allStagingEntryStatuses
   | ProcessedViewType => [Processed]
-  | NeedsManualReviewViewType => [
-      NeedsManualReview(NoRulesFound),
-      NeedsManualReview(CurrencyMismatch),
-      NeedsManualReview(MissingSearchIdentifierValue),
-      NeedsManualReview(DuplicateEntry),
-      NeedsManualReview(NoExpectationEntryFound),
-      NeedsManualReview(MultipleExpectedEntriesFound),
-      NeedsManualReview(MissingMatchField),
-      NeedsManualReview(MissingUniqueField),
-      NeedsManualReview(MissingGroupingField),
-      NeedsManualReview(InternalError),
-    ]
+  | NeedsManualReviewViewType => allStagingEntryManualReviewStatuses
   | UnknownTransformedEntriesViewType => []
   }
   ->getStagingEntryStatusValueFromStatusList
@@ -315,21 +262,7 @@ let initialDisplayFilters = (~transformationConfigOptions, ~accountOptions) => {
     {label: "Debit", value: "debit"},
   ]
 
-  let statusOptions = getGroupedStagingEntryStatusOptions([
-    Pending,
-    Processed,
-    Void,
-    NeedsManualReview(NoRulesFound),
-    NeedsManualReview(CurrencyMismatch),
-    NeedsManualReview(MissingSearchIdentifierValue),
-    NeedsManualReview(DuplicateEntry),
-    NeedsManualReview(NoExpectationEntryFound),
-    NeedsManualReview(MultipleExpectedEntriesFound),
-    NeedsManualReview(MissingMatchField),
-    NeedsManualReview(MissingUniqueField),
-    NeedsManualReview(MissingGroupingField),
-    NeedsManualReview(InternalError),
-  ])
+  let statusOptions = getGroupedStagingEntryStatusOptions(allStagingEntryStatuses)
 
   [
     (

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineData/ReconEngineDataTransformedEntries/ReconEngineDataTransformedEntriesUtils.res
@@ -50,10 +50,10 @@ let buildProcessingEntriesV2Body = (
   ~transformationHistoryIds: array<string>=[],
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
-  let statusValues =
+  let detailedStatuses =
     statusFilter->isEmptyArray
-      ? getProcessingEntryStatusValueFromStatusList([Pending, Processed, NeedsManualReview, Void])
-      : statusFilter
+      ? [Pending, Processed, Void, NeedsManualReview(UnknownStagingEntryManualReviewData)]
+      : statusFilter->Array.map(getStagingEntryDetailedStatusFromValue)
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let accountIdFilter = filterValueJson->getStrArrayFromDict("account_ids", [])
@@ -65,7 +65,7 @@ let buildProcessingEntriesV2Body = (
   let hasTimeRange = startTime->isNonEmptyString && endTime->isNonEmptyString
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set("status", statusValues->getJsonFromArrayOfString)
+  filtersDict->Dict.set("detailed_status", detailedStatuses->getStagingEntryDetailedStatusPayload)
 
   if entryTypeFilter->isNonEmptyArray {
     filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
@@ -131,7 +131,7 @@ let getProcessingEntryPayloadFromDict = dict => {
 
 let sumStagingOverviewStatusCount = (
   accountsOverview: array<accountStagingEntriesOverview>,
-  ~matchesStatus: processingEntryStatus => bool,
+  ~matchesStatus: domainStagingEntryStatus => bool,
 ): float => {
   accountsOverview
   ->Array.reduce(0, (acc, account) => {
@@ -146,7 +146,14 @@ let getTotalNeedsManualReviewEntries = (
   accountsOverview: array<accountStagingEntriesOverview>,
 ): float => {
   accountsOverview->sumStagingOverviewStatusCount(~matchesStatus=status =>
-    status == NeedsManualReview
+    switch status {
+    | NeedsManualReview(_) => true
+    | Pending
+    | Processed
+    | Void
+    | Archived
+    | UnknownDomainStagingEntryStatus => false
+    }
   )
 }
 
@@ -256,7 +263,9 @@ let initialDisplayFilters = (~accountOptions) => {
     {label: "Debit", value: "debit"},
   ]
 
-  let statusOptions = getStagingEntryStatusOptions([Processed, Pending, NeedsManualReview, Void])
+  let statusOptions = getGroupedStagingEntryDetailedStatusOptions(
+    stagingEntryDetailedStatusFilterOptions,
+  )
 
   [
     (

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionEntity.res
@@ -1,6 +1,5 @@
 open ReconEngineTypes
 open LogicUtils
-open ReconEngineUtils
 
 type processingColType =
   | StagingEntryId
@@ -50,14 +49,25 @@ let getProcessingHeading = colType => {
   }
 }
 
-let getStatusLabel = (status: processingEntryStatus): Table.cell => {
+let getDomainStagingEntryStatusString = (status: domainStagingEntryStatus) => {
+  switch status {
+  | Pending => "Pending"
+  | Processed => "Processed"
+  | Void => "Void"
+  | Archived => "Archived"
+  | NeedsManualReview(_) => "Needs Manual Review"
+  | UnknownDomainStagingEntryStatus => "Unknown"
+  }
+}
+
+let getStatusLabel = (status: domainStagingEntryStatus): Table.cell => {
   Label({
-    title: (status :> string)->String.toUpperCase,
+    title: status->getDomainStagingEntryStatusString->String.toUpperCase,
     color: switch status {
     | Pending => LabelBlue
     | Processed => LabelGreen
-    | NeedsManualReview => LabelOrange
-    | Archived | Void | UnknownProcessingEntryStatus => LabelGray
+    | NeedsManualReview(_) => LabelOrange
+    | Archived | Void | UnknownDomainStagingEntryStatus => LabelGray
     },
   })
 }
@@ -102,7 +112,7 @@ let getProcessingCell = (data: processingEntryType, colType): Table.cell => {
   | Currency => Text(data.currency)
   | Status =>
     switch data.discarded_status {
-    | Some(status) => getStatusLabel(status->getProcessingEntryStatusVariantFromString)
+    | Some(status) => getStatusLabel(status)
     | None => getStatusLabel(data.status)
     }
   | EffectiveAt => Date(data.effective_at)
@@ -123,7 +133,18 @@ let getProcessingCell = (data: processingEntryType, colType): Table.cell => {
       "",
     )
   | Actions => CustomCell(<ReconEngineDataTransformedEntriesActions processingEntry=data />, "")
-  | ExceptionType => EllipsisText((data.data.needs_manual_review_type :> string)->snakeToTitle, "")
+  | ExceptionType =>
+    EllipsisText(
+      switch data.status {
+      | NeedsManualReview(reason) => (reason :> string)->snakeToTitle
+      | Pending
+      | Processed
+      | Void
+      | Archived
+      | UnknownDomainStagingEntryStatus => "N/A"
+      },
+      "",
+    )
   | TransformationConfigName =>
     EllipsisText(
       data.transformation_config.transformation_config_name->getNonEmptyString->Option.getOr("N/A"),

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -172,8 +172,8 @@ let getSumOfAmountWithCurrency = (
 }
 
 let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntryType => {
-  let discardedDataDict =
-    dict->getDictfromDict("discarded_data")->processingEntryDiscardedDataItemToObjMapper
+  let discardedDataDict = dict->getDictfromDict("discarded_data")
+  let discardedStatusDict = dict->getDictfromDict("detailed_discarded_status")
   {
     id: dict->getString("id", ""),
     staging_entry_id: dict->getString("staging_entry_id", ""),
@@ -184,21 +184,19 @@ let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntry
     effective_at: dict->getString("effective_at", ""),
     metadata: dict->getJsonObjectFromDict("metadata"),
     processing_mode: dict->getString("processing_mode", ""),
-    status: dict
-    ->getString("status", "")
-    ->camelToSnake
-    ->getProcessingEntryStatusVariantFromString,
+    status: dict->getDictfromDict("detailed_status")->getDomainStagingEntryStatus,
     transformation_config: dict
     ->getDictfromDict("transformation_config")
     ->transformationConfigRefTypeMapper,
     transformation_history_id: dict->getString("transformation_history_id", ""),
     order_id: dict->getString("order_id", ""),
     version: dict->getInt("version", 0),
-    discarded_status: dict->getOptionString("discarded_status"),
-    data: dict->getDictfromDict("data")->processingEntryDataItemToObjMapper,
-    discarded_data: discardedDataDict.status != UnknownProcessingEntryStatus
-      ? Some(discardedDataDict)
-      : None,
+    discarded_status: discardedStatusDict->isEmptyDict
+      ? None
+      : Some(discardedStatusDict->getDomainStagingEntryStatus),
+    discarded_data: discardedDataDict->isEmptyDict
+      ? None
+      : Some(discardedDataDict->processingEntryDiscardedDataItemToObjMapper),
   }
 }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -174,6 +174,7 @@ let getSumOfAmountWithCurrency = (
 let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntryType => {
   let discardedDataDict = dict->getDictfromDict("discarded_data")
   let discardedStatusDict = dict->getDictfromDict("detailed_discarded_status")
+  let statusDict = dict->getDictfromDict("detailed_status")
   {
     id: dict->getString("id", ""),
     staging_entry_id: dict->getString("staging_entry_id", ""),
@@ -184,7 +185,7 @@ let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntry
     effective_at: dict->getString("effective_at", ""),
     metadata: dict->getJsonObjectFromDict("metadata"),
     processing_mode: dict->getString("processing_mode", ""),
-    status: dict->getDictfromDict("detailed_status")->getDomainStagingEntryStatus,
+    status: statusDict->getString("status", "")->getDomainStagingEntryStatus(statusDict),
     transformation_config: dict
     ->getDictfromDict("transformation_config")
     ->transformationConfigRefTypeMapper,
@@ -193,7 +194,11 @@ let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntry
     version: dict->getInt("version", 0),
     discarded_status: discardedStatusDict->isEmptyDict
       ? None
-      : Some(discardedStatusDict->getDomainStagingEntryStatus),
+      : Some(
+          discardedStatusDict
+          ->getString("status", "")
+          ->getDomainStagingEntryStatus(discardedStatusDict),
+        ),
     discarded_data: discardedDataDict->isEmptyDict
       ? None
       : Some(discardedDataDict->processingEntryDiscardedDataItemToObjMapper),

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
@@ -52,18 +52,7 @@ let make = (~accountId: string) => {
     if statusFilter->isEmptyArray {
       enhancedFilterValueJson->Dict.set(
         "status",
-        [
-          NeedsManualReview(NoRulesFound),
-          NeedsManualReview(CurrencyMismatch),
-          NeedsManualReview(MissingSearchIdentifierValue),
-          NeedsManualReview(DuplicateEntry),
-          NeedsManualReview(NoExpectationEntryFound),
-          NeedsManualReview(MultipleExpectedEntriesFound),
-          NeedsManualReview(MissingMatchField),
-          NeedsManualReview(MissingUniqueField),
-          NeedsManualReview(MissingGroupingField),
-          NeedsManualReview(InternalError),
-        ]
+        allStagingEntryManualReviewStatuses
         ->getStagingEntryStatusValueFromStatusList
         ->getJsonFromArrayOfString,
       )

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
@@ -50,10 +50,10 @@ let make = (~accountId: string) => {
     let statusFilter = filterValueJsonWithGlobalDate->getArrayFromDict("status", [])
     enhancedFilterValueJson->Dict.set("account_ids", [accountId]->getJsonFromArrayOfString)
     if statusFilter->isEmptyArray {
-      enhancedFilterValueJson->Dict.set(
-        "status",
-        getProcessingEntryStatusValueFromStatusList([NeedsManualReview])->getJsonFromArrayOfString,
+      let (manualReviewValue, _, _) = getStagingEntryDetailedStatusGroupedValueAndLabel(
+        NeedsManualReview(UnknownStagingEntryManualReviewData),
       )
+      enhancedFilterValueJson->Dict.set("status", [manualReviewValue]->getJsonFromArrayOfString)
     }
     getProcessingEntriesV2(
       ~body=buildProcessingEntriesV2Body(

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryContent.res
@@ -50,10 +50,23 @@ let make = (~accountId: string) => {
     let statusFilter = filterValueJsonWithGlobalDate->getArrayFromDict("status", [])
     enhancedFilterValueJson->Dict.set("account_ids", [accountId]->getJsonFromArrayOfString)
     if statusFilter->isEmptyArray {
-      let (manualReviewValue, _, _) = getStagingEntryDetailedStatusGroupedValueAndLabel(
-        NeedsManualReview(UnknownStagingEntryManualReviewData),
+      enhancedFilterValueJson->Dict.set(
+        "status",
+        [
+          NeedsManualReview(NoRulesFound),
+          NeedsManualReview(CurrencyMismatch),
+          NeedsManualReview(MissingSearchIdentifierValue),
+          NeedsManualReview(DuplicateEntry),
+          NeedsManualReview(NoExpectationEntryFound),
+          NeedsManualReview(MultipleExpectedEntriesFound),
+          NeedsManualReview(MissingMatchField),
+          NeedsManualReview(MissingUniqueField),
+          NeedsManualReview(MissingGroupingField),
+          NeedsManualReview(InternalError),
+        ]
+        ->getStagingEntryStatusValueFromStatusList
+        ->getJsonFromArrayOfString,
       )
-      enhancedFilterValueJson->Dict.set("status", [manualReviewValue]->getJsonFromArrayOfString)
     }
     getProcessingEntriesV2(
       ~body=buildProcessingEntriesV2Body(

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsHelper.res
@@ -273,13 +273,13 @@ module CustomToastElement = {
         `exceptions/transformed-entries/${processingEntry.staging_entry_id}`,
         "See Entry",
       )
-    | NeedsManualReview => (
+    | NeedsManualReview(_) => (
         "Transformed entry marked for manual review",
         "Please review the entry in the transformed entry exceptions page",
         `exceptions/transformed-entries/${processingEntry.staging_entry_id}`,
         "See Entry",
       )
-    | Archived | UnknownProcessingEntryStatus => (
+    | Archived | UnknownDomainStagingEntryStatus => (
         "Transformed entry processed successfully",
         "The entry has been moved to transformation entry page",
         `transformed-entries/ingestion-history/${ingestionHistoryId}?transformationHistoryId=${processingEntry.transformation_history_id}&stagingEntryId=${processingEntry.staging_entry_id}`,
@@ -449,44 +449,53 @@ module AuditTrail = {
 module ExceptionDataDisplay = {
   @react.component
   let make = (~currentTransformedEntryDetails: ReconEngineTypes.processingEntryType) => {
-    let (
-      heading,
-      subHeading,
-    ) = switch currentTransformedEntryDetails.data.needs_manual_review_type {
-    | NoRulesFound => ("No Rules Found", "The transformed entry did not match any existing rules.")
-    | StagingEntryCurrencyMismatch => (
+    let (heading, subHeading) = switch currentTransformedEntryDetails.status {
+    | NeedsManualReview(NoRulesFound) => (
+        "No Rules Found",
+        "The transformed entry did not match any existing rules.",
+      )
+    | NeedsManualReview(CurrencyMismatch) => (
         "Currency Mismatch",
         "The currency of the transformed entry does not match the expected currency.",
       )
-    | MissingSearchIdentifierValue => (
+    | NeedsManualReview(MissingSearchIdentifierValue) => (
         "Missing Search Identifier Value",
         "The transformed entry is missing a required search identifier value.",
       )
-    | DuplicateEntry => (
+    | NeedsManualReview(DuplicateEntry) => (
         "Duplicate Entry",
         "The transformed entry is identified as a duplicate of an existing entry.",
       )
-    | NoExpectationEntryFound => (
+    | NeedsManualReview(NoExpectationEntryFound) => (
         "No Expectation Entry Found",
         "No corresponding expectation entry was found for the transformed entry.",
       )
-    | MultipleExpectedEntriesFound => (
+    | NeedsManualReview(MultipleExpectedEntriesFound) => (
         "Multiple Expected Entries Found",
         "Multiple expected entries were found for the transformed entry.",
       )
-    | MissingMatchField => (
+    | NeedsManualReview(MissingMatchField) => (
         "Missing Match Field",
         "The transformed entry is missing a required match field.",
       )
-    | MissingUniqueField => (
+    | NeedsManualReview(MissingUniqueField) => (
         "Missing Unique Field",
         "The transformed entry is missing a unique field required for processing.",
       )
-    | MissingGroupingField => (
+    | NeedsManualReview(MissingGroupingField) => (
         "Missing Grouping Field",
         "The transformed entry is missing a required grouping field.",
       )
-    | UnknownNeedsManualReviewType => (
+    | NeedsManualReview(InternalError) => (
+        "Internal Error",
+        "The transformed entry could not be processed because of an internal error.",
+      )
+    | NeedsManualReview(UnknownStagingEntryManualReviewData)
+    | Pending
+    | Processed
+    | Void
+    | Archived
+    | UnknownDomainStagingEntryStatus => (
         "Unknown",
         "Please review the details and take necessary actions.",
       )

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
@@ -309,7 +309,6 @@ let getUpdatedEntry = (~entryDetails: processingEntryType, ~formData): processin
     order_id: formData->getString("order_id", ""),
     discarded_status: entryDetails.discarded_status,
     version: entryDetails.version,
-    data: entryDetails.data,
     discarded_data: entryDetails.discarded_data,
   }
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineTransformedEntryExceptions/ReconEngineTransformedEntryExceptionsUtils.res
@@ -1,5 +1,6 @@
 open ReconEngineTypes
 open LogicUtils
+open ReconEngineFilterUtils
 open ReconEngineTransformedEntryExceptionsTypes
 open ReconEngineExceptionsUtils
 open ReconEngineTransactionsUtils
@@ -116,6 +117,8 @@ let initialDisplayFilters = () => {
     {label: "Debit", value: "debit"},
   ]
 
+  let statusOptions = getGroupedStagingEntryStatusOptions(allStagingEntryManualReviewStatuses)
+
   [
     (
       {
@@ -125,6 +128,26 @@ let initialDisplayFilters = () => {
           ~customInput=InputFields.filterMultiSelectInput(
             ~options=entryTypeOptions,
             ~buttonText="Select Entry Type",
+            ~showSelectionAsChips=false,
+            ~searchable=true,
+            ~showToolTip=true,
+            ~showNameAsToolTip=true,
+            ~customButtonStyle="bg-none",
+            ~fixedDropDownDirection=BottomRight,
+            (),
+          ),
+        ),
+        localFilter: Some((_, _) => []->Array.map(Nullable.make)),
+      }: EntityType.initialFilters<'t>
+    ),
+    (
+      {
+        field: FormRenderer.makeFieldInfo(
+          ~label="status",
+          ~name="status",
+          ~customInput=InputFields.filterMultiSelectInput(
+            ~options=statusOptions,
+            ~buttonText="Select Status",
             ~showSelectionAsChips=false,
             ~searchable=true,
             ~showToolTip=true,

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -1,5 +1,6 @@
 open ReconEngineTypes
 open LogicUtils
+open ReconEngineFilterUtils
 open ReconEnginePipelinesTypes
 
 let getIngestionCounts = (ingestionHistory: array<ingestionHistoryType>) =>
@@ -20,8 +21,8 @@ let getStagingOverviewCounts = (stagingOverviewData: array<accountStagingEntries
       statusAmount,
     ) =>
       switch statusAmount.status {
-      | Archived | Void | UnknownProcessingEntryStatus => (total, needsManualReview)
-      | NeedsManualReview => (total + statusAmount.count, needsManualReview + statusAmount.count)
+      | Archived | Void | UnknownDomainStagingEntryStatus => (total, needsManualReview)
+      | NeedsManualReview(_) => (total + statusAmount.count, needsManualReview + statusAmount.count)
       | Pending | Processed => (total + statusAmount.count, needsManualReview)
       }
     )
@@ -51,13 +52,9 @@ let getPipelineStatCards = (
     )->CurrencyFormatUtils.valueFormatter(Rate)
 
   let processedStatusValue =
-    ReconEngineFilterUtils.getIngestionTransformationHistoryStatusValueFromStatusList([
-      Processed,
-    ])->Array.joinWith(",")
+    getIngestionTransformationHistoryStatusValueFromStatusList([Processed])->Array.joinWith(",")
   let failedStatusValue =
-    ReconEngineFilterUtils.getIngestionTransformationHistoryStatusValueFromStatusList([
-      Failed,
-    ])->Array.joinWith(",")
+    getIngestionTransformationHistoryStatusValueFromStatusList([Failed])->Array.joinWith(",")
 
   [
     {
@@ -185,22 +182,17 @@ let buildStagingEntriesV2Body = (
   ~limit=10,
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
-  let statusValues =
+  let detailedStatuses =
     statusFilter->isEmptyArray
-      ? ReconEngineFilterUtils.getProcessingEntryStatusValueFromStatusList([
-          Pending,
-          Processed,
-          NeedsManualReview,
-          Void,
-        ])
-      : statusFilter
+      ? [Pending, Processed, Void, NeedsManualReview(UnknownStagingEntryManualReviewData)]
+      : statusFilter->Array.map(getStagingEntryDetailedStatusFromValue)
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let transformationHistoryIds =
     filterValueJson->getStrArrayFromDict("transformation_history_ids", [])
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set("status", statusValues->getJsonFromArrayOfString)
+  filtersDict->Dict.set("detailed_status", detailedStatuses->getStagingEntryDetailedStatusPayload)
 
   if entryTypeFilter->isNonEmptyArray {
     filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
@@ -278,12 +270,9 @@ let initialStagingEntriesFilters = (
     {label: "Credit", value: "credit"},
     {label: "Debit", value: "debit"},
   ]
-  let statusOptions = ReconEngineFilterUtils.getStagingEntryStatusOptions([
-    Processed,
-    Pending,
-    NeedsManualReview,
-    Void,
-  ])
+  let statusOptions = getGroupedStagingEntryDetailedStatusOptions(
+    stagingEntryDetailedStatusFilterOptions,
+  )
 
   [
     (

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -182,50 +182,30 @@ let buildStagingEntriesV2Body = (
   ~limit=10,
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
-  let statusOptions: array<domainStagingEntryStatus> = [
-    Pending,
-    Processed,
-    Void,
-    NeedsManualReview(NoRulesFound),
-    NeedsManualReview(CurrencyMismatch),
-    NeedsManualReview(MissingSearchIdentifierValue),
-    NeedsManualReview(DuplicateEntry),
-    NeedsManualReview(NoExpectationEntryFound),
-    NeedsManualReview(MultipleExpectedEntriesFound),
-    NeedsManualReview(MissingMatchField),
-    NeedsManualReview(MissingUniqueField),
-    NeedsManualReview(MissingGroupingField),
-    NeedsManualReview(InternalError),
-  ]
   let detailedStatuses =
     statusFilter->isEmptyArray
-      ? statusOptions
-      : statusFilter->Array.map(value => getStagingEntryStatusFromValue(value, statusOptions))
+      ? allStagingEntryStatuses
+      : statusFilter->Array.map(value =>
+          getStagingEntryStatusFromValue(value, allStagingEntryStatuses)
+        )
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let transformationHistoryIds =
     filterValueJson->getStrArrayFromDict("transformation_history_ids", [])
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set(
-    "detailed_status",
-    detailedStatuses->getStagingEntryStatusPayload->JSON.Encode.array,
+  let detailedStatusPayload = detailedStatuses->getStagingEntryStatusPayload
+
+  filtersDict->setOptionArray("detailed_status", detailedStatusPayload->getNonEmptyArray)
+  filtersDict->setOptionArray(
+    "entry_type",
+    entryTypeFilter->Array.map(JSON.Encode.string)->getNonEmptyArray,
   )
-
-  if entryTypeFilter->isNonEmptyArray {
-    filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
-  }
-
-  if transformationHistoryIds->isNonEmptyArray {
-    filtersDict->Dict.set(
-      "transformation_history_ids",
-      transformationHistoryIds->getJsonFromArrayOfString,
-    )
-  }
-
-  if searchText->isNonEmptyString {
-    filtersDict->Dict.set((searchType :> string), searchText->String.trim->JSON.Encode.string)
-  }
+  filtersDict->setOptionArray(
+    "transformation_history_ids",
+    transformationHistoryIds->Array.map(JSON.Encode.string)->getNonEmptyArray,
+  )
+  filtersDict->setOptionString((searchType :> string), searchText->String.trim->getNonEmptyString)
 
   [
     ("filters", filtersDict->JSON.Encode.object),
@@ -288,21 +268,7 @@ let initialStagingEntriesFilters = (
     {label: "Credit", value: "credit"},
     {label: "Debit", value: "debit"},
   ]
-  let statusOptions = getGroupedStagingEntryStatusOptions([
-    Pending,
-    Processed,
-    Void,
-    NeedsManualReview(NoRulesFound),
-    NeedsManualReview(CurrencyMismatch),
-    NeedsManualReview(MissingSearchIdentifierValue),
-    NeedsManualReview(DuplicateEntry),
-    NeedsManualReview(NoExpectationEntryFound),
-    NeedsManualReview(MultipleExpectedEntriesFound),
-    NeedsManualReview(MissingMatchField),
-    NeedsManualReview(MissingUniqueField),
-    NeedsManualReview(MissingGroupingField),
-    NeedsManualReview(InternalError),
-  ])
+  let statusOptions = getGroupedStagingEntryStatusOptions(allStagingEntryStatuses)
 
   [
     (

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -182,17 +182,35 @@ let buildStagingEntriesV2Body = (
   ~limit=10,
 ) => {
   let statusFilter = filterValueJson->getStrArrayFromDict("status", [])
+  let statusOptions: array<domainStagingEntryStatus> = [
+    Pending,
+    Processed,
+    Void,
+    NeedsManualReview(NoRulesFound),
+    NeedsManualReview(CurrencyMismatch),
+    NeedsManualReview(MissingSearchIdentifierValue),
+    NeedsManualReview(DuplicateEntry),
+    NeedsManualReview(NoExpectationEntryFound),
+    NeedsManualReview(MultipleExpectedEntriesFound),
+    NeedsManualReview(MissingMatchField),
+    NeedsManualReview(MissingUniqueField),
+    NeedsManualReview(MissingGroupingField),
+    NeedsManualReview(InternalError),
+  ]
   let detailedStatuses =
     statusFilter->isEmptyArray
-      ? [Pending, Processed, Void, NeedsManualReview(UnknownStagingEntryManualReviewData)]
-      : statusFilter->Array.map(getStagingEntryDetailedStatusFromValue)
+      ? statusOptions
+      : statusFilter->Array.map(value => getStagingEntryStatusFromValue(value, statusOptions))
 
   let entryTypeFilter = filterValueJson->getStrArrayFromDict("entry_type", [])
   let transformationHistoryIds =
     filterValueJson->getStrArrayFromDict("transformation_history_ids", [])
 
   let filtersDict = Dict.make()
-  filtersDict->Dict.set("detailed_status", detailedStatuses->getStagingEntryDetailedStatusPayload)
+  filtersDict->Dict.set(
+    "detailed_status",
+    detailedStatuses->getStagingEntryStatusPayload->JSON.Encode.array,
+  )
 
   if entryTypeFilter->isNonEmptyArray {
     filtersDict->Dict.set("entry_type", entryTypeFilter->getJsonFromArrayOfString)
@@ -270,9 +288,21 @@ let initialStagingEntriesFilters = (
     {label: "Credit", value: "credit"},
     {label: "Debit", value: "debit"},
   ]
-  let statusOptions = getGroupedStagingEntryDetailedStatusOptions(
-    stagingEntryDetailedStatusFilterOptions,
-  )
+  let statusOptions = getGroupedStagingEntryStatusOptions([
+    Pending,
+    Processed,
+    Void,
+    NeedsManualReview(NoRulesFound),
+    NeedsManualReview(CurrencyMismatch),
+    NeedsManualReview(MissingSearchIdentifierValue),
+    NeedsManualReview(DuplicateEntry),
+    NeedsManualReview(NoExpectationEntryFound),
+    NeedsManualReview(MultipleExpectedEntriesFound),
+    NeedsManualReview(MissingMatchField),
+    NeedsManualReview(MissingUniqueField),
+    NeedsManualReview(MissingGroupingField),
+    NeedsManualReview(InternalError),
+  ])
 
   [
     (

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -291,17 +291,11 @@ type entryType = {
   transformation_id: option<string>,
 }
 
-type processingEntryStatus =
-  | @as("pending") Pending
-  | @as("processed") Processed
-  | @as("needs_manual_review") NeedsManualReview
-  | @as("archived") Archived
-  | @as("void") Void
-  | @as("unknown") UnknownProcessingEntryStatus
+type processingEntryDiscardedDataType = {reason: string}
 
-type needsManualReviewType =
+type stagingEntryManualReviewData =
   | @as("no_rules_found") NoRulesFound
-  | @as("staging_entry_currency_mismatch") StagingEntryCurrencyMismatch
+  | @as("currency_mismatch") CurrencyMismatch
   | @as("missing_search_identifier_value") MissingSearchIdentifierValue
   | @as("duplicate_entry") DuplicateEntry
   | @as("no_expectation_entry_found") NoExpectationEntryFound
@@ -309,17 +303,16 @@ type needsManualReviewType =
   | @as("missing_match_field") MissingMatchField
   | @as("missing_unique_field") MissingUniqueField
   | @as("missing_grouping_field") MissingGroupingField
-  | @as("unknown") UnknownNeedsManualReviewType
+  | @as("internal_error") InternalError
+  | @as("unknown") UnknownStagingEntryManualReviewData
 
-type processingEntryDataType = {
-  status: processingEntryStatus,
-  needs_manual_review_type: needsManualReviewType,
-}
-
-type processingEntryDiscardedDataType = {
-  status: processingEntryStatus,
-  reason: string,
-}
+type domainStagingEntryStatus =
+  | Pending
+  | NeedsManualReview(stagingEntryManualReviewData)
+  | Processed
+  | Void
+  | Archived
+  | UnknownDomainStagingEntryStatus
 
 type processingEntryType = {
   id: string,
@@ -328,7 +321,7 @@ type processingEntryType = {
   entry_type: string,
   amount: float,
   currency: string,
-  status: processingEntryStatus,
+  status: domainStagingEntryStatus,
   processing_mode: string,
   metadata: Js.Json.t,
   transformation_config: transformationConfigRefType,
@@ -336,8 +329,7 @@ type processingEntryType = {
   effective_at: string,
   order_id: string,
   version: int,
-  discarded_status: option<string>,
-  data: processingEntryDataType,
+  discarded_status: option<domainStagingEntryStatus>,
   discarded_data: option<processingEntryDiscardedDataType>,
 }
 
@@ -580,7 +572,7 @@ type overviewRulesTimeSeriesResponse = {
 }
 
 type stagingEntryOverviewStatusAmount = {
-  status: processingEntryStatus,
+  status: domainStagingEntryStatus,
   count: int,
 }
 

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -56,14 +56,33 @@ let cursorsFromDict = (dict): cursors => {
   {next: getCursor("next_cursor"), prev: getCursor("prev_cursor")}
 }
 
-let getProcessingEntryStatusVariantFromString = (status: string): processingEntryStatus => {
-  switch status->String.toLowerCase {
+let getStagingEntryManualReviewDataFromString = (
+  subStatus: string,
+): stagingEntryManualReviewData => {
+  switch subStatus->String.toLowerCase {
+  | "no_rules_found" => NoRulesFound
+  | "currency_mismatch" => CurrencyMismatch
+  | "missing_search_identifier_value" => MissingSearchIdentifierValue
+  | "duplicate_entry" => DuplicateEntry
+  | "no_expectation_entry_found" => NoExpectationEntryFound
+  | "multiple_expected_entries_found" => MultipleExpectedEntriesFound
+  | "missing_match_field" => MissingMatchField
+  | "missing_unique_field" => MissingUniqueField
+  | "missing_grouping_field" => MissingGroupingField
+  | "internal_error" => InternalError
+  | _ => UnknownStagingEntryManualReviewData
+  }
+}
+
+let getDomainStagingEntryStatus = (dict: Dict.t<JSON.t>): domainStagingEntryStatus => {
+  let subStatus = dict->getString("sub_status", "")
+  switch dict->getString("status", "")->String.toLowerCase {
   | "pending" => Pending
+  | "needs_manual_review" => NeedsManualReview(subStatus->getStagingEntryManualReviewDataFromString)
   | "processed" => Processed
-  | "archived" => Archived
-  | "needs_manual_review" => NeedsManualReview
   | "void" => Void
-  | _ => UnknownProcessingEntryStatus
+  | "archived" => Archived
+  | _ => UnknownDomainStagingEntryStatus
   }
 }
 
@@ -74,21 +93,6 @@ let getMismatchTypeVariantFromString = (mismatchType: string): mismatchType => {
   | "currency_mismatch" => CurrencyMismatch
   | "metadata_mismatch" => MetadataMismatch
   | _ => UnknownMismatchType
-  }
-}
-
-let getNeedsManualReviewTypeVariantFromString = (reviewType: string): needsManualReviewType => {
-  switch reviewType->String.toLowerCase {
-  | "no_rules_found" => NoRulesFound
-  | "staging_entry_currency_mismatch" => StagingEntryCurrencyMismatch
-  | "missing_search_identifier_value" => MissingSearchIdentifierValue
-  | "duplicate_entry" => DuplicateEntry
-  | "no_expectation_entry_found" => NoExpectationEntryFound
-  | "multiple_expected_entries_found" => MultipleExpectedEntriesFound
-  | "missing_match_field" => MissingMatchField
-  | "missing_unique_field" => MissingUniqueField
-  | "missing_grouping_field" => MissingGroupingField
-  | _ => UnknownNeedsManualReviewType
   }
 }
 
@@ -543,19 +547,9 @@ let entryItemToObjMapper = dict => {
   }
 }
 
-let processingEntryDataItemToObjMapper = (dataDict): processingEntryDataType => {
-  {
-    status: dataDict->getString("status", "")->getProcessingEntryStatusVariantFromString,
-    needs_manual_review_type: dataDict
-    ->getString("needs_manual_review_type", "")
-    ->getNeedsManualReviewTypeVariantFromString,
-  }
-}
-
 let processingEntryDiscardedDataItemToObjMapper = (dataDict): processingEntryDiscardedDataType => {
   {
     reason: dataDict->getString("reason", ""),
-    status: dataDict->getString("status", "")->getProcessingEntryStatusVariantFromString,
   }
 }
 
@@ -567,8 +561,8 @@ let transformationConfigRefTypeMapper = (dict): transformationConfigRefType => {
 }
 
 let processingItemToObjMapper = (dict): processingEntryType => {
-  let discardedDataDict =
-    dict->getDictfromDict("discarded_data")->processingEntryDiscardedDataItemToObjMapper
+  let discardedDataDict = dict->getDictfromDict("discarded_data")
+  let discardedStatusDict = dict->getDictfromDict("detailed_discarded_status")
   {
     id: dict->getString("id", ""),
     staging_entry_id: dict->getString("staging_entry_id", ""),
@@ -578,7 +572,7 @@ let processingItemToObjMapper = (dict): processingEntryType => {
     entry_type: dict->getString("entry_type", ""),
     amount: dict->getDictfromDict("amount")->getFloat("value", 0.0),
     currency: dict->getDictfromDict("amount")->getString("currency", ""),
-    status: dict->getString("status", "")->getProcessingEntryStatusVariantFromString,
+    status: dict->getDictfromDict("detailed_status")->getDomainStagingEntryStatus,
     effective_at: dict->getString("effective_at", ""),
     processing_mode: dict->getString("processing_mode", ""),
     metadata: dict->getJsonObjectFromDict("metadata"),
@@ -588,11 +582,12 @@ let processingItemToObjMapper = (dict): processingEntryType => {
     transformation_history_id: dict->getString("transformation_history_id", ""),
     order_id: dict->getString("order_id", ""),
     version: dict->getInt("version", 0),
-    discarded_status: dict->getOptionString("discarded_status"),
-    data: dict->getDictfromDict("data")->processingEntryDataItemToObjMapper,
-    discarded_data: discardedDataDict.status != UnknownProcessingEntryStatus
-      ? Some(discardedDataDict)
-      : None,
+    discarded_status: discardedStatusDict->isEmptyDict
+      ? None
+      : Some(discardedStatusDict->getDomainStagingEntryStatus),
+    discarded_data: discardedDataDict->isEmptyDict
+      ? None
+      : Some(discardedDataDict->processingEntryDiscardedDataItemToObjMapper),
   }
 }
 
@@ -1135,7 +1130,7 @@ let stagingEntryOverviewStatusAmountMapper: Dict.t<
   JSON.t,
 > => stagingEntryOverviewStatusAmount = dict => {
   {
-    status: dict->getString("status", "")->getProcessingEntryStatusVariantFromString,
+    status: dict->getDomainStagingEntryStatus,
     count: dict->getInt("count", 0),
   }
 }
@@ -1143,7 +1138,7 @@ let stagingEntryOverviewStatusAmountMapper: Dict.t<
 let accountStagingEntriesOverviewMapper: Dict.t<JSON.t> => accountStagingEntriesOverview = dict => {
   {
     status_breakdown: dict
-    ->getArrayFromDict("status_breakdown", [])
+    ->getArrayFromDict("detailed_status_breakdown", [])
     ->Array.map(status => status->getDictFromJsonObject->stagingEntryOverviewStatusAmountMapper),
   }
 }

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -74,9 +74,12 @@ let getStagingEntryManualReviewDataFromString = (
   }
 }
 
-let getDomainStagingEntryStatus = (dict: Dict.t<JSON.t>): domainStagingEntryStatus => {
+let getDomainStagingEntryStatus = (
+  status: string,
+  dict: Js.Dict.t<Js.Json.t>,
+): domainStagingEntryStatus => {
   let subStatus = dict->getString("sub_status", "")
-  switch dict->getString("status", "")->String.toLowerCase {
+  switch status->String.toLowerCase {
   | "pending" => Pending
   | "needs_manual_review" => NeedsManualReview(subStatus->getStagingEntryManualReviewDataFromString)
   | "processed" => Processed
@@ -563,6 +566,7 @@ let transformationConfigRefTypeMapper = (dict): transformationConfigRefType => {
 let processingItemToObjMapper = (dict): processingEntryType => {
   let discardedDataDict = dict->getDictfromDict("discarded_data")
   let discardedStatusDict = dict->getDictfromDict("detailed_discarded_status")
+  let statusDict = dict->getDictfromDict("detailed_status")
   {
     id: dict->getString("id", ""),
     staging_entry_id: dict->getString("staging_entry_id", ""),
@@ -572,7 +576,7 @@ let processingItemToObjMapper = (dict): processingEntryType => {
     entry_type: dict->getString("entry_type", ""),
     amount: dict->getDictfromDict("amount")->getFloat("value", 0.0),
     currency: dict->getDictfromDict("amount")->getString("currency", ""),
-    status: dict->getDictfromDict("detailed_status")->getDomainStagingEntryStatus,
+    status: statusDict->getString("status", "")->getDomainStagingEntryStatus(statusDict),
     effective_at: dict->getString("effective_at", ""),
     processing_mode: dict->getString("processing_mode", ""),
     metadata: dict->getJsonObjectFromDict("metadata"),
@@ -584,7 +588,11 @@ let processingItemToObjMapper = (dict): processingEntryType => {
     version: dict->getInt("version", 0),
     discarded_status: discardedStatusDict->isEmptyDict
       ? None
-      : Some(discardedStatusDict->getDomainStagingEntryStatus),
+      : Some(
+          discardedStatusDict
+          ->getString("status", "")
+          ->getDomainStagingEntryStatus(discardedStatusDict),
+        ),
     discarded_data: discardedDataDict->isEmptyDict
       ? None
       : Some(discardedDataDict->processingEntryDiscardedDataItemToObjMapper),
@@ -1130,7 +1138,7 @@ let stagingEntryOverviewStatusAmountMapper: Dict.t<
   JSON.t,
 > => stagingEntryOverviewStatusAmount = dict => {
   {
-    status: dict->getDomainStagingEntryStatus,
+    status: dict->getString("status", "")->getDomainStagingEntryStatus(dict),
     count: dict->getInt("count", 0),
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- Model staging entry status as a hierarchical `domainStagingEntryStatus` variant (`NeedsManualReview(reason)`), mirroring the existing `domainTransactionStatus`, and read it from the new `detailed_status`, `detailed_discarded_status` and `detailed_status_breakdown` response fields.
- Send `filters.detailed_status` (`{status, sub_status}` objects) instead of the flat `filters.status` in the transformed entries and pipelines list calls.
- Add the ten manual review reasons to the existing status filter as a "Needs Manual Review" group, so entries can be filtered by reason. The "Entry Status" group keeps Pending, Processed and Void.
- Drive the Exception Type column and the exception detail heading off the entry status, and drop the `data` blob parsing (`processingEntryDataType`, `needsManualReviewType`) it replaces.

## Motivation and Context

Transformed entries enter manual review for ten different reasons, but only the coarse `needs_manual_review` status was filterable — the reason lived inside the `data` JSONB blob. An operator triaging one problem (say duplicate entries) had to page through every manual review row. The backend now flattens the status in the DB and exposes it as `detailed_status`, which this consumes.

## How did you test it?

- Ran `npm run re:build`
- Verified on Data → Transformed Entries: filtering by a single reason returns only those entries, the Entry Status options still work, and clearing the filter returns the full list.
- Verified the same status filter on the Pipelines staging entries table and the Transformed Entry Exceptions page.
- Verified the Status column still reads "Needs Manual Review" while the Exception Type column shows the specific reason.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL: 

This needs the backend deployed, not just merged — the frontend now reads `detailed_status` exclusively, so against an older build every status renders "Unknown" and the filter returns nothing.

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
