### PR TITLE
feat: scope x-cug-user header to webhook events APIs

### DIFF
--- a/src/hooks/AuthHooks.res
+++ b/src/hooks/AuthHooks.res
@@ -50,7 +50,10 @@ let getHeaders = (
     if xFeatureRoute {
       headersForXFeature(~headers, ~uri)
     }
-    if cugUser {
+
+    // TODO: this header is scoped to Webhook events APIs for now;
+    // remove the uri condition once webhook CUG testing is done so it applies to all APIs
+    if cugUser && uri->String.includes("/events/") {
       headers->Dict.set("x-cug-user", "true")
     }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Restrict the `x-cug-user` header (sent behind the existing `cug_user` feature flag) to Webhook events APIs only — i.e. requests whose URI contains `/events/`:

- `events/profile/list`
- `events/{merchant_id}/{event_id}/attempts`
- `events/{merchant_id}/{event_id}/retry`

Change is in `src/hooks/AuthHooks.res` (`getHeaders`): the header is now set only when `cugUser` is enabled **and** `uri` includes `/events/`. A TODO notes that the URI condition is temporary and should be removed once webhook CUG testing is complete so the header applies to all APIs again.

## Motivation and Context

CUG (closed user group) routing for webhooks is being tested in isolation. Sending `x-cug-user` on every dashboard request would route all APIs through the CUG path; scoping it to the webhook events endpoints limits the blast radius while testing.

## How did you test it?

- Ran `npm run re:build` — compiled without errors.
- Verified compiled output: header is added only when `cug_user` is enabled and the request URI contains `/events/`; other API requests do not receive the header.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s): `cug_user` (existing, behaviour scoped — no flag definition changed)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
