### PR TITLE
fix: round exception entry balances to currency precision

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
@@ -530,26 +530,26 @@ let getEntriesSections = (
 
   let amountColorClass = overallBalance == 0.0 ? "text-nd_green-600" : "text-nd_red-600"
 
-  sectionData->Array.map(((_accountId, accountInfo, accountEntries, totalAmount, currency)) => {
+  sectionData->Array.map(section => {
     let accountRows =
-      accountEntries->Array.map(entry =>
+      section.accountEntries->Array.map(entry =>
         detailsFields->Array.map(
           colType => EntriesTableEntity.getCell(entry->getEntryTypeFromExceptionEntryType, colType),
         )
       )
-    let rowData = accountEntries->Array.map(entry => entry->Identity.genericTypeToJson)
+    let rowData = section.accountEntries->Array.map(entry => entry->Identity.genericTypeToJson)
 
     let titleElement =
       <div className="flex justify-between items-center mb-4">
         <p className={`text-nd_gray-700 ${body.lg.semibold}`}>
-          {accountInfo.account_info_name->React.string}
+          {section.accountInfo.account_info_name->React.string}
         </p>
         <RenderIf condition={showTotalAmount}>
           <div className={`${amountColorClass} ${body.lg.medium}`}>
             {CurrencyFormatUtils.valueFormatter(
-              totalAmount,
+              section.totalAmount,
               AmountWithSuffix,
-              ~currency,
+              ~currency=section.accountCurrency,
             )->React.string}
           </div>
         </RenderIf>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionHelper.res
@@ -547,7 +547,7 @@ let getEntriesSections = (
         <RenderIf condition={showTotalAmount}>
           <div className={`${amountColorClass} ${body.lg.medium}`}>
             {CurrencyFormatUtils.valueFormatter(
-              section.totalAmount,
+              section.accountTotalAmount,
               AmountWithSuffix,
               ~currency=section.accountCurrency,
             )->React.string}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionTypes.res
@@ -50,6 +50,6 @@ type accountSection = {
   accountId: string,
   accountInfo: accountInfo,
   accountEntries: array<exceptionResolutionEntryType>,
-  totalAmount: float,
+  accountTotalAmount: float,
   accountCurrency: string,
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionTypes.res
@@ -45,3 +45,11 @@ type exceptionResolutionEntryType = {
   ...entryType,
   entry_key: string,
 }
+
+type accountSection = {
+  accountId: string,
+  accountInfo: accountInfo,
+  accountEntries: array<exceptionResolutionEntryType>,
+  totalAmount: float,
+  accountCurrency: string,
+}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -820,7 +820,7 @@ let calculateSectionData = (
       )
     let accountEntries = groupedEntries->getValueFromDict(accountId, [])
 
-    let (totalAmount, accountCurrency) = if (
+    let (accountTotalAmount, accountCurrency) = if (
       accountInfo.account_info_type != UnknownAccountTypeVariant
     ) {
       getBalanceByAccountType(accountEntries, accountInfo.account_info_type)
@@ -828,7 +828,7 @@ let calculateSectionData = (
       getSumOfAmountWithCurrency(accountEntries)
     }
 
-    {accountId, accountInfo, accountEntries, totalAmount, accountCurrency}
+    {accountId, accountInfo, accountEntries, accountTotalAmount, accountCurrency}
   })
 }
 
@@ -840,8 +840,8 @@ let calculateOverallBalance = (
     section,
   ) => {
     switch section.accountInfo.account_info_type {
-    | Credit => (creditSum +. section.totalAmount, debitSum)
-    | Debit => (creditSum, debitSum +. section.totalAmount)
+    | Credit => (creditSum +. section.accountTotalAmount, debitSum)
+    | Debit => (creditSum, debitSum +. section.accountTotalAmount)
     | UnknownAccountTypeVariant => (creditSum, debitSum)
     }
   })

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -77,6 +77,15 @@ let exceptionTransactionEntryItemToItemMapper = (
   }
 }
 
+let roundToCurrencyPrecision = (~amount: float, ~currency: string) => {
+  open CurrencyUtils
+
+  convertCurrencyFromLowestDenomination(
+    ~amount=convertCurrencyToLowestDenomination(~amount, ~currency)->Math.round,
+    ~currency,
+  )
+}
+
 let getBalanceByAccountType = (
   entries: array<ReconEngineExceptionTransactionTypes.exceptionResolutionEntryType>,
   accountType: accountTypeVariant,
@@ -101,7 +110,7 @@ let getBalanceByAccountType = (
   let firstEntry =
     entries->getValueFromArray(0, Dict.make()->exceptionTransactionEntryItemToItemMapper)
 
-  (balance, firstEntry.currency)
+  (roundToCurrencyPrecision(~amount=balance, ~currency=firstEntry.currency), firstEntry.currency)
 }
 
 let getMismatchedFieldsFromMismatchData = (mismatchData: Js.Json.t) =>
@@ -168,7 +177,7 @@ let getSumOfAmountWithCurrency = (
 ): (float, string) => {
   let totalAmount = entries->Array.reduce(0.0, (acc, entry) => acc +. entry.amount)
   let entry = entries->getValueFromArray(0, Dict.make()->exceptionTransactionEntryItemToItemMapper)
-  (totalAmount, entry.currency)
+  (roundToCurrencyPrecision(~amount=totalAmount, ~currency=entry.currency), entry.currency)
 }
 
 let exceptionTransactionProcessingEntryItemToObjMapper = (dict): processingEntryType => {
@@ -798,7 +807,7 @@ let calculateSectionData = (
   ~accountInfoMap,
   ~getBalanceByAccountType,
   ~getSumOfAmountWithCurrency,
-) => {
+): array<ReconEngineExceptionTransactionTypes.accountSection> => {
   open ReconEngineExceptionTransactionTypes
 
   groupedEntries
@@ -811,33 +820,36 @@ let calculateSectionData = (
       )
     let accountEntries = groupedEntries->getValueFromDict(accountId, [])
 
-    let (totalAmount, currency) = if accountInfo.account_info_type != UnknownAccountTypeVariant {
+    let (totalAmount, accountCurrency) = if (
+      accountInfo.account_info_type != UnknownAccountTypeVariant
+    ) {
       getBalanceByAccountType(accountEntries, accountInfo.account_info_type)
     } else {
       getSumOfAmountWithCurrency(accountEntries)
     }
 
-    (accountId, accountInfo, accountEntries, totalAmount, currency)
+    {accountId, accountInfo, accountEntries, totalAmount, accountCurrency}
   })
 }
 
-let calculateOverallBalance = sectionData => {
-  open ReconEngineExceptionTransactionTypes
-
+let calculateOverallBalance = (
+  sectionData: array<ReconEngineExceptionTransactionTypes.accountSection>,
+) => {
   let (totalCreditAccounts, totalDebitAccounts) = sectionData->Array.reduce((0.0, 0.0), (
     (creditSum, debitSum),
-    (_, accountInfo, _, amount, _),
+    section,
   ) => {
-    if accountInfo.account_info_type == Credit {
-      (creditSum +. amount, debitSum)
-    } else if accountInfo.account_info_type == Debit {
-      (creditSum, debitSum +. amount)
-    } else {
-      (creditSum, debitSum)
+    switch section.accountInfo.account_info_type {
+    | Credit => (creditSum +. section.totalAmount, debitSum)
+    | Debit => (creditSum, debitSum +. section.totalAmount)
+    | UnknownAccountTypeVariant => (creditSum, debitSum)
     }
   })
 
-  totalCreditAccounts -. totalDebitAccounts
+  let currency =
+    sectionData->Array.map(section => section.accountCurrency)->getValueFromArray(0, "")
+
+  roundToCurrencyPrecision(~amount=totalCreditAccounts -. totalDebitAccounts, ~currency)
 }
 
 let getFixEntriesButtons = (


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Recon exception entry balances were summed as floating-point major units, so balanced transactions rendered their section totals red instead of green.

**Rounding.** Added `roundToCurrencyPrecision` in `ReconEngineExceptionTransactionUtils.res`, built from the existing `CurrencyUtils.convertCurrencyToLowestDenomination` / `convertCurrencyFromLowestDenomination` pair. It round-trips a computed total through the lowest denomination so the result lands on a clean 2/3/4-decimal value, per the currency. Applied at the three places amounts are actually summed:

- `getBalanceByAccountType` — the per-account credit/debit balance
- `getSumOfAmountWithCurrency` — the unknown-account-type fallback sum
- `calculateOverallBalance` — the cross-section total that drives the colour

Rounding happens on the final total, not per entry — rounding each operand would bias the sum. The `== 0.0` comparison in `getEntriesSections` is left as-is, because the value reaching it is now exact.

**Typing.** `calculateSectionData` returned a positional 5-tuple `(accountId, accountInfo, accountEntries, totalAmount, currency)` that both consumers destructured by position. Replaced it with an `accountSection` record in `ReconEngineExceptionTransactionTypes.res`. Its fields are account-prefixed because bare `entries` / `currency` labels trip warning 45 (error-level here) where the module is `open`ed. `calculateOverallBalance`'s `if / else if / else` also became an exhaustive `switch` on `accountTypeVariant`, so a future account type cannot silently fall into the ignore branch.

## Motivation and Context

Fixes #5409.

`324.71` and `181.51` are not exactly representable in binary, so their sum is `506.22000000000003`, not `506.22`. Subtracting the debit side left `-5.684341886080802e-14`, which is not `== 0.0`, so the totals painted red on a rounding artifact. The drift also reached the rendered value — the section header held `506.21999999999997`.

Single-entry sections happened to work, because subtracting a double from itself is exactly zero, which is why this survived. The residue grows with entry count, so the indicator became less reliable the more entries a resolution flow linked.

This colour is what an operator reads to decide whether a transaction is safe to resolve, and it is the live feedback signal in the **Link Entry** flow.

## How did you test it?

`npm run re:build` passes with no warnings.

Verified the rounding against the reported production values with a Node script driving the compiled `CurrencyUtils` output, mirroring the helper's composition (the recon module cannot be imported standalone — it pulls in recoil/react — so the helper's own wiring was confirmed against the generated JS):

| Case | Before | After |
|---|---|---|
| `324.71 + 181.51` vs `506.22` (AUD, the reported case) | `-5.68e-14` → red | `0` → green |
| Genuine one-cent gap `506.23 - 506.22` | `0.010000000000047748` | `0.01` → red, correctly |
| `100.10 + 200.20` across sections | `300.30000000000007` | `300.3` |
| `0.001 + 0.002` (BHD, three-decimal) | `0.003000000000000...` | `0.003` |
| `1.4` (JPY, zero-decimal) | `1.4` | `1` |
| 1000 × `0.01` | `9.999999999999831` | `10` |

Not yet exercised in a browser against the reported transaction — worth a reviewer confirming the section totals render `506.22` and green there.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
