### PR TITLE
fix: use v2 webhook url in revenue recovery screens

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorHome.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorHome.res
@@ -208,6 +208,9 @@ let make = () => {
         <ConnectorWebhookPreview
           merchantId
           connectorName=connectorInfoDict.connector_name
+          version=V2
+          profileId=connectorInfoDict.profile_id
+          connectorId=connectorInfoDict.id
           textCss="border border-nd_gray-300 font-[700] rounded-xl px-4 py-2 mb-6 mt-6  text-nd_gray-400"
           containerClass="flex flex-row items-center justify-between"
           hideLabel=true

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
@@ -239,6 +239,9 @@ let make = (
           <ConnectorWebhookPreview
             merchantId
             connectorName=connectorInfoDict.connector_name
+            version=V2
+            profileId
+            connectorId=connectorInfoDict.id
             textCss={`border border-nd_gray-400 ${body.md.medium} rounded-xl px-4 py-2 text-nd_gray-400 w-full !font-jetbrains-mono`}
             containerClass="flex flex-row items-center justify-between"
             displayTextLength=38

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryProcessorReview.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryProcessorReview.res
@@ -61,7 +61,13 @@ let make = (~connectorInfo) => {
         <div className="flex flex-col ">
           <ConnectorHelperV2.PreviewCreds connectorInfo=connectorInfodict connectorAccountFields />
         </div>
-        <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
+        <ConnectorWebhookPreview
+          merchantId
+          connectorName=connectorInfodict.connector_name
+          version=V2
+          profileId=connectorInfodict.profile_id
+          connectorId=connectorInfodict.id
+        />
       </div>
     </div>
     <ACLButton

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingConnectorsSummary.res
@@ -247,7 +247,14 @@ module BillingConnectorDetails = {
             condition={connectorName->getConnectorNameTypeFromString(
               ~connectorType=BillingProcessor,
             ) != BillingProcessor(CUSTOMBILLING)}>
-            <ConnectorWebhookPreview merchantId connectorName=connectorInfodict.connector_name />
+            <ConnectorWebhookPreview
+              merchantId
+              connectorName=connectorInfodict.connector_name
+              version=V2
+              profileId=connectorInfodict.profile_id
+              connectorId=connectorInfodict.id
+              isRecoveryWebhook=true
+            />
           </RenderIf>
         </div>
         {switch connectorName->getConnectorNameTypeFromString(~connectorType=BillingProcessor) {
@@ -448,7 +455,11 @@ module PaymentConnectorDetails = {
                   {connectorInfodict.profile_id->React.string}
                 </div>
                 <ConnectorWebhookPreview
-                  merchantId connectorName=connectorInfodict.connector_name
+                  merchantId
+                  connectorName=connectorInfodict.connector_name
+                  version=V2
+                  profileId=connectorInfodict.profile_id
+                  connectorId=connectorInfodict.id
                 />
               </div>
               <div className="flex flex-col gap-4">

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsWebhooks.res
@@ -13,6 +13,10 @@ let make = (~initialValues, ~merchantId, ~onNextClick) => {
         <ConnectorWebhookPreview
           merchantId
           connectorName=connectorInfoDict.connector_name
+          version=V2
+          profileId=connectorInfoDict.profile_id
+          connectorId=connectorInfoDict.id
+          isRecoveryWebhook=true
           textCss="border border-nd_gray-400 font-medium rounded-xl px-4 py-2 mb-6 mt-6  text-nd_gray-400 w-full !font-jetbrains-mono"
           containerClass="flex flex-row items-center justify-between"
           displayTextLength=38

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -237,6 +237,10 @@ let make = (
           <ConnectorWebhookPreview
             merchantId
             connectorName=connectorInfoDict.connector_name
+            version=V2
+            profileId=connectorInfoDict.profile_id
+            connectorId=connectorInfoDict.id
+            isRecoveryWebhook=true
             textCss="border border-nd_gray-400 font-medium rounded-xl px-4 py-2 text-nd_gray-400 w-full !font-jetbrains-mono"
             containerClass="flex flex-row items-center justify-between"
             displayTextLength=38

--- a/src/fragments/ConnectorFragments/ConnectorWebhookDetails/ConnectorWebhookPreview.res
+++ b/src/fragments/ConnectorFragments/ConnectorWebhookDetails/ConnectorWebhookPreview.res
@@ -2,6 +2,10 @@
 let make = (
   ~merchantId,
   ~connectorName,
+  ~version: UserInfoTypes.version=V1,
+  ~profileId="",
+  ~connectorId="",
+  ~isRecoveryWebhook=false,
   ~textCss="",
   ~showFullText=false,
   ~showFullCopy=false,
@@ -11,13 +15,25 @@ let make = (
   ~truncateDisplayValue=false,
 ) => {
   let showToast = ToastAdapter.useShowToast()
-  let copyValueOfWebhookEndpoint = `${Window.env.apiBaseUrl}/webhooks/${merchantId}/${connectorName}`
-  let displayValueOfWebhookEndpoint = `${Window.env.apiBaseUrl}...${connectorName}`
+  // v2 webhooks are addressed by profile and merchant connector account id, not connector name
+  let copyValueOfWebhookEndpoint = switch version {
+  | V2 =>
+    isRecoveryWebhook
+      ? `${Window.env.apiBaseUrl}/v2/webhooks/recovery/${merchantId}/${profileId}/${connectorId}`
+      : `${Window.env.apiBaseUrl}/v2/webhooks/${merchantId}/${profileId}/${connectorId}`
+  | V1 => `${Window.env.apiBaseUrl}/webhooks/${merchantId}/${connectorName}`
+  }
+  // the last path segment differs by version: connector name (v1) vs connector id (v2)
+  let webhookEndpointTail = switch version {
+  | V2 => connectorId
+  | V1 => connectorName
+  }
+  let displayValueOfWebhookEndpoint = `${Window.env.apiBaseUrl}...${webhookEndpointTail}`
   let baseurl = `${Window.env.apiBaseUrl}`
   let shortDisplayValueofWebhookEndpoint = `${baseurl->String.slice(
       ~start=0,
       ~end=9,
-    )}...${connectorName}`
+    )}...${webhookEndpointTail}`
 
   let displayValueOfWebhookEndpoint = switch displayTextLength {
   | Some(end) =>


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
ConnectorWebhookPreview always rendered the v1 endpoint shape /webhooks/{merchant_id}/{connector_name}, but the v2 route is /v2/webhooks/{merchant_id}/{profile_id}/{connector_id} (and /v2/webhooks/recovery/... for revenue recovery). The profile id was missing entirely and the connector name stood in for the merchant connector account id, so the endpoint shown to merchants was wrong.

Add optional version, profileId, connectorId and isRecoveryWebhook props that default to the existing v1 behaviour, and pass them from the Revenue Recovery screens - the billing/subscription webhooks use the recovery route, the payment processor ones the generic v2 route. The truncated display value now ends with the connector id on v2 so it agrees with what the copy button yields.


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [ ] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I ran `npm run re:build`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
