### PR TITLE
chore: make recon engine audit trail default to 31 days

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineAuditLogDrawer/ReconEngineAuditLogDrawer.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineAuditLogDrawer/ReconEngineAuditLogDrawer.res
@@ -114,7 +114,7 @@ module AuditTrailFilteredContent = {
               ~showTime=false,
               ~disablePastDates=false,
               ~disableFutureDates=true,
-              ~dateRangeLimit=30,
+              ~dateRangeLimit=31,
             ),
             ~inputFields=[],
           )}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

make recon engine audit trail default to 31 days

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

## How did you test it?

Locally

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
