### PR TITLE
feat: support full payment method blocking config in payment settings

### DIFF
--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceTypes/BusinessProfileInterfaceTypes.res
@@ -77,7 +77,19 @@ type externalVaultConnectorDetails = {
 
 type surchargeConnectorDetails = {surcharge_connector_id: string}
 
-type paymentMethodBlockingEntry = {card_types: option<array<string>>}
+type paymentMethodBlockingEntry = {
+  card_types: option<array<string>>,
+  card_networks: option<array<string>>,
+  funding_sources: option<array<string>>,
+  card_segment_types: option<array<string>>,
+  issuing_country: option<array<string>>,
+  issuers: option<array<string>>,
+  card_subtypes: option<array<string>>,
+  block_if_bin_info_unavailable: option<bool>,
+  block_virtual_cards: option<bool>,
+  block_non_reloadable_prepaid_cards: option<bool>,
+  gambling_blocked: option<bool>,
+}
 
 type paymentMethodBlockingWallet = {
   apple_pay: option<paymentMethodBlockingEntry>,

--- a/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
+++ b/src/Interface/BusinessProfileInterface/BusinessProfileInterfaceUtils/BusinessProfileInterfaceUtils.res
@@ -194,6 +194,18 @@ let paymentLinkConfigMapper = paymentLinkConfigDict => {
 
 let paymentMethodBlockingEntryMapper: Dict.t<JSON.t> => paymentMethodBlockingEntry = entryDict => {
   card_types: entryDict->getOptionStrArrayFromDict("card_types"),
+  card_networks: entryDict->getOptionStrArrayFromDict("card_networks"),
+  funding_sources: entryDict->getOptionStrArrayFromDict("funding_sources"),
+  card_segment_types: entryDict->getOptionStrArrayFromDict("card_segment_types"),
+  issuing_country: entryDict->getOptionStrArrayFromDict("issuing_country"),
+  issuers: entryDict->getOptionStrArrayFromDict("issuers"),
+  card_subtypes: entryDict->getOptionStrArrayFromDict("card_subtypes"),
+  block_if_bin_info_unavailable: entryDict->getOptionBool("block_if_bin_info_unavailable"),
+  block_virtual_cards: entryDict->getOptionBool("block_virtual_cards"),
+  block_non_reloadable_prepaid_cards: entryDict->getOptionBool(
+    "block_non_reloadable_prepaid_cards",
+  ),
+  gambling_blocked: entryDict->getOptionBool("gambling_blocked"),
 }
 
 let paymentMethodBlockingWalletEntryMapper = (walletDict, key, legacyEntry) => {
@@ -207,9 +219,7 @@ let paymentMethodBlockingWalletMapper: Dict.t<
   let legacyEntry =
     walletDict
     ->getOptionStrArrayFromDict("card_types")
-    ->Option.map(cardTypes => {
-      card_types: Some(cardTypes),
-    })
+    ->Option.map(_ => walletDict->paymentMethodBlockingEntryMapper)
   {
     apple_pay: paymentMethodBlockingWalletEntryMapper(walletDict, "apple_pay", legacyEntry),
     google_pay: paymentMethodBlockingWalletEntryMapper(walletDict, "google_pay", legacyEntry),

--- a/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentBehaviour.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentBehaviour.res
@@ -187,90 +187,6 @@ module ClickToPaySection = {
   }
 }
 
-module PaymentMethodBlocking = {
-  @react.component
-  let make = () => {
-    open FormRenderer
-
-    let cardTypeOptions: array<SelectBox.dropdownOption> = ["credit", "debit"]->Array.map(item => {
-      SelectBox.label: item->LogicUtils.snakeToTitle,
-      value: item,
-    })
-
-    let blocklistCardTypes = makeFieldInfo(
-      ~label="Card Types",
-      ~name="payment_method_blocking.card.card_types",
-      ~customInput=InputFields.multiSelectInput(
-        ~options=cardTypeOptions,
-        ~buttonText="Select Card Types",
-        ~showSelectionAsChips=false,
-        ~customButtonStyle="!rounded-lg",
-        ~fixedDropDownDirection=BottomRight,
-        ~searchable=true,
-      ),
-    )
-
-    let makeBlocklistWalletTypes = (walletType, label) =>
-      makeFieldInfo(
-        ~label,
-        ~name=`payment_method_blocking.wallet.${walletType}.card_types`,
-        ~customInput=InputFields.multiSelectInput(
-          ~options=cardTypeOptions,
-          ~buttonText="Select Card Types",
-          ~showSelectionAsChips=false,
-          ~customButtonStyle="!rounded-lg",
-          ~fixedDropDownDirection=BottomRight,
-          ~searchable=true,
-        ),
-      )
-
-    let blocklistApplePayCardTypes = makeBlocklistWalletTypes("apple_pay", "Card Types")
-    let blocklistGooglePayCardTypes = makeBlocklistWalletTypes("google_pay", "Card Types")
-
-    <DesktopRow itemWrapperClass="mx-1">
-      <div className="w-full py-8 flex flex-col gap-6">
-        <div>
-          <p className={`${body.lg.semibold} text-nd_gray-700`}>
-            {"Payment Method Blocking"->React.string}
-          </p>
-          <p className={`${body.md.medium} text-nd_gray-400 pt-2`}>
-            {"Block specific card types for card, Apple Pay, and Google Pay payment methods"->React.string}
-          </p>
-        </div>
-        <div className="flex flex-col gap-2">
-          <p className={`${body.md.semibold} text-nd_gray-700`}> {"Card"->React.string} </p>
-          <FieldRenderer
-            field={blocklistCardTypes}
-            labelClass={`!${body.md.medium} !text-nd-gray-600`}
-            fieldWrapperClass="max-w-xl"
-          />
-        </div>
-        <div className="flex flex-col gap-2">
-          <p className={`${body.md.semibold} text-nd_gray-700`}> {"Wallet"->React.string} </p>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <p className={`${body.md.medium} text-nd_gray-600`}> {"Apple Pay"->React.string} </p>
-              <FieldRenderer
-                field={blocklistApplePayCardTypes}
-                labelClass={`!${body.md.medium} !text-nd-gray-600`}
-                fieldWrapperClass="max-w-xl"
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <p className={`${body.md.medium} text-nd_gray-600`}> {"Google Pay"->React.string} </p>
-              <FieldRenderer
-                field={blocklistGooglePayCardTypes}
-                labelClass={`!${body.md.medium} !text-nd-gray-600`}
-                fieldWrapperClass="max-w-xl"
-              />
-            </div>
-          </div>
-        </div>
-      </div>
-    </DesktopRow>
-  }
-}
-
 module WebHook = {
   @react.component
   let make = () => {
@@ -590,7 +506,7 @@ let make = () => {
       <ClickToPaySection />
       <hr />
       <RenderIfVersion visibleForVersion=V1>
-        <PaymentMethodBlocking />
+        <PaymentSettingsPaymentMethodBlocking />
         <hr />
       </RenderIfVersion>
       <ReturnUrl />

--- a/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentMethodBlocking.res
+++ b/src/screens/Developer/PaymentSettings/PaymentSettingsPaymentMethodBlocking.res
@@ -1,0 +1,218 @@
+open Typography
+
+// Values must match the backend serde spellings exactly:
+// CardType/CardSegmentType are snake_case, CardNetwork is PascalCase,
+// FundingSource is UPPERCASE (two variants contain spaces).
+let cardTypeOptions: array<SelectBox.dropdownOption> = [
+  {value: "credit", label: "Credit"},
+  {value: "debit", label: "Debit"},
+]
+
+let cardNetworkOptions: array<SelectBox.dropdownOption> = [
+  {value: "Visa", label: "Visa"},
+  {value: "Mastercard", label: "Mastercard"},
+  {value: "AmericanExpress", label: "American Express"},
+  {value: "JCB", label: "JCB"},
+  {value: "DinersClub", label: "Diners Club"},
+  {value: "Discover", label: "Discover"},
+  {value: "CartesBancaires", label: "Cartes Bancaires"},
+  {value: "UnionPay", label: "UnionPay"},
+  {value: "Interac", label: "Interac"},
+  {value: "RuPay", label: "RuPay"},
+  {value: "Maestro", label: "Maestro"},
+  {value: "Star", label: "Star"},
+  {value: "Pulse", label: "Pulse"},
+  {value: "Accel", label: "Accel"},
+  {value: "Nyce", label: "Nyce"},
+  {value: "Prop", label: "Prop"},
+  {value: "PrivateLabel", label: "Private Label"},
+  {value: "Dinacard", label: "Dinacard"},
+]
+
+let fundingSourceOptions: array<SelectBox.dropdownOption> = [
+  {value: "CREDIT", label: "Credit"},
+  {value: "DEBIT", label: "Debit"},
+  {value: "DEFERRED DEBIT", label: "Deferred Debit"},
+  {value: "PREPAID", label: "Prepaid"},
+  {value: "CHARGE CARD", label: "Charge Card"},
+]
+
+let cardSegmentTypeOptions: array<SelectBox.dropdownOption> = [
+  {value: "business", label: "Business"},
+  {value: "commercial", label: "Commercial"},
+  {value: "consumer", label: "Consumer"},
+  {value: "government", label: "Government"},
+]
+
+let issuingCountryOptions: array<SelectBox.dropdownOption> =
+  CountryUtils.countriesList->Array.map(CountryUtils.getCountryOption)
+
+module CardBlockingConfigFields = {
+  @react.component
+  let make = (~namePrefix) => {
+    open FormRenderer
+
+    let multiSelectField = (~key, ~label, ~options, ~searchable) =>
+      makeFieldInfo(
+        ~label,
+        ~name=`${namePrefix}.${key}`,
+        ~customInput=InputFields.multiSelectInput(
+          ~options,
+          ~buttonText={`Select ${label}`},
+          ~showSelectionAsChips=false,
+          ~customButtonStyle="!rounded-lg",
+          ~fixedDropDownDirection=BottomRight,
+          ~searchable,
+        ),
+      )
+
+    let toggleField = (~key, ~label, ~description) =>
+      makeFieldInfo(
+        ~name=`${namePrefix}.${key}`,
+        ~label,
+        ~customInput=InputFields.switchInput(
+          ~isDisabled=false,
+          ~boolCustomClass="rounded-lg",
+          ~toggleBorder="border-nd_primary_blue-450",
+          ~toggleEnableColor="bg-nd_primary_blue-450",
+        ),
+        ~description,
+        ~toolTipPosition=Right,
+      )
+
+    let multiSelectFields = [
+      multiSelectField(
+        ~key="card_types",
+        ~label="Card Types",
+        ~options=cardTypeOptions,
+        ~searchable=true,
+      ),
+      multiSelectField(
+        ~key="card_networks",
+        ~label="Card Networks",
+        ~options=cardNetworkOptions,
+        ~searchable=true,
+      ),
+      multiSelectField(
+        ~key="funding_sources",
+        ~label="Funding Sources",
+        ~options=fundingSourceOptions,
+        ~searchable=false,
+      ),
+      multiSelectField(
+        ~key="card_segment_types",
+        ~label="Card Segment Types",
+        ~options=cardSegmentTypeOptions,
+        ~searchable=false,
+      ),
+      multiSelectField(
+        ~key="issuing_country",
+        ~label="Issuing Countries",
+        ~options=issuingCountryOptions,
+        ~searchable=true,
+      ),
+    ]
+
+    let toggleFields = [
+      toggleField(
+        ~key="block_if_bin_info_unavailable",
+        ~label="Block If BIN Info Unavailable",
+        ~description="Block the payment when card BIN information cannot be found",
+      ),
+      toggleField(
+        ~key="block_virtual_cards",
+        ~label="Block Virtual Cards",
+        ~description="Block payments made with virtual cards",
+      ),
+      toggleField(
+        ~key="block_non_reloadable_prepaid_cards",
+        ~label="Block Non-Reloadable Prepaid Cards",
+        ~description="Block payments made with non-reloadable prepaid cards",
+      ),
+      toggleField(
+        ~key="gambling_blocked",
+        ~label="Block Gambling-Restricted Cards",
+        ~description="Block cards that are restricted from gambling usage",
+      ),
+    ]
+
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 max-w-4xl">
+        {multiSelectFields
+        ->Array.mapWithIndex((field, index) =>
+          <FieldRenderer
+            key={index->Int.toString} field labelClass={`!${body.md.medium} !text-nd-gray-600`}
+          />
+        )
+        ->React.array}
+      </div>
+      <div className="flex flex-col max-w-4xl">
+        {toggleFields
+        ->Array.mapWithIndex((field, index) =>
+          <FieldRenderer
+            key={index->Int.toString}
+            field
+            labelClass={`!${body.md.medium} !text-nd-gray-600`}
+            fieldWrapperClass="w-full flex justify-between items-center py-2"
+          />
+        )
+        ->React.array}
+      </div>
+    </div>
+  }
+}
+
+type blockingTarget = Card | ApplePay | GooglePay
+
+let blockingTargets = [Card, ApplePay, GooglePay]
+
+let targetLabel = target =>
+  switch target {
+  | Card => "Card"
+  | ApplePay => "Apple Pay"
+  | GooglePay => "Google Pay"
+  }
+
+let targetPrefix = target =>
+  switch target {
+  | Card => "payment_method_blocking.card"
+  | ApplePay => "payment_method_blocking.wallet.apple_pay"
+  | GooglePay => "payment_method_blocking.wallet.google_pay"
+  }
+
+@react.component
+let make = () => {
+  open FormRenderer
+  let (activeTarget, setActiveTarget) = React.useState(_ => Card)
+  let activePrefix = activeTarget->targetPrefix
+
+  <DesktopRow itemWrapperClass="mx-1">
+    <div className="w-full py-8 flex flex-col gap-6">
+      <div>
+        <p className={`${body.lg.semibold} text-nd_gray-700`}>
+          {"Payment Method Blocking"->React.string}
+        </p>
+        <p className={`${body.md.medium} text-nd_gray-400 pt-2`}>
+          {"Block payments by card type, network, funding source, segment type, or issuing country for card, Apple Pay, and Google Pay payment methods"->React.string}
+        </p>
+      </div>
+      <div className="flex w-fit p-1 gap-1 rounded-lg border border-nd_gray-200 bg-nd_gray-50">
+        {blockingTargets
+        ->Array.map(target => {
+          let isActive = target == activeTarget
+          <button
+            key={target->targetLabel}
+            type_="button"
+            className={`px-4 py-1.5 rounded-md ${body.md.medium} ${isActive
+                ? "bg-white text-nd_gray-700 shadow-sm"
+                : "text-nd_gray-400 hover:text-nd_gray-600"}`}
+            onClick={_ => setActiveTarget(_ => target)}>
+            {target->targetLabel->React.string}
+          </button>
+        })
+        ->React.array}
+      </div>
+      <CardBlockingConfigFields key=activePrefix namePrefix=activePrefix />
+    </div>
+  </DesktopRow>
+}


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The backend business profile `payment_method_blocking` config supports 11 blocking attributes per target (card / Apple Pay / Google Pay), but the dashboard only exposed `card_types` (credit/debit).

This PR:

- Extends the Payment Method Blocking section in Payment Settings → Payment Behaviour to expose the remaining backend-supported fields for each of Card, Apple Pay, and Google Pay:
  - Multi-selects: Card Types, Card Networks, Funding Sources, Card Segment Types, Issuing Countries
  - Toggles: Block If BIN Info Unavailable, Block Virtual Cards, Block Non-Reloadable Prepaid Cards, Block Gambling-Restricted Cards
- Uses a single reusable field set with a Card / Apple Pay / Google Pay segmented switcher instead of repeating the controls three times. Unsaved edits persist across switches (react-final-form keeps unmounted field values).
- Moves the section out of `PaymentSettingsPaymentBehaviour.res` into a new `PaymentSettingsPaymentMethodBlocking.res`.
- **Fixes a data-loss bug**: the profile update replaces the `payment_method_blocking` JSONB wholesale, but the interface mapper only round-tripped `card_types` — so saving Payment Behaviour silently wiped any other blocking fields set via the API. The mapper now round-trips all backend fields, including `issuers` and `card_subtypes` which have no UI controls yet.

All option values match the backend serde spellings exactly (`CardNetwork` PascalCase, `FundingSource` UPPERCASE incl. `DEFERRED DEBIT` / `CHARGE CARD`, `card_segment_types`/`card_types` snake_case, countries as alpha-2 codes). No extra client-side validation is required since every input is dropdown/toggle constrained.

## Motivation and Context

Closes https://github.com/juspay/hyperswitch-control-center/issues/5338

The backend (`CardBlockingConfig` in `crates/api_models/src/admin.rs`) enforces all of these attributes at payment time, but merchants could only configure credit/debit blocking from the dashboard; everything else required direct API calls — which the dashboard would then wipe on the next Payment Behaviour save.

## How did you test it?

Verified the change compiles cleanly with the ReScript build. Manual test plan (to run on sandbox):

- On a V1 profile, set blocking fields across all three targets (e.g. block `PREPAID` funding source + an issuing country on Card), save, and confirm via profile GET that the payload uses the exact backend enum spellings.
- Set `issuing_country` / `issuers` on a profile directly via the profile update API, then save Payment Behaviour from the dashboard and confirm the API-set fields are preserved (regression check for the wipe bug).
- Switch between Card / Apple Pay / Google Pay with unsaved edits and confirm values persist.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
