### PR TITLE
feat: add Deutsche Bank payout connector

### DIFF
--- a/playwright-tests/support/fixtures/payoutConnectorConfig.ts
+++ b/playwright-tests/support/fixtures/payoutConnectorConfig.ts
@@ -135,6 +135,28 @@ export const payoutConnectorConfig: Record<string, ConnectorConfig> = {
     },
   },
 
+  deutschebank: {
+    label: "deutschebank",
+    fields: {
+      default: "test_value",
+      overrides: {
+        "Enter Connector label": "deutschebank_default",
+      },
+      fieldLabels: [
+        "Customer Identifier *",
+        "Key ID *",
+        "Signing Private Key (PEM) *",
+        "Client Certificate Bundle (PEM cert + key concatenated) *",
+      ],
+    },
+    paymentSections: {
+      BankTransfer: {
+        label: "Bank Transfer",
+        methods: ["sepa_bank_transfer"],
+      },
+    },
+  },
+
   ebanx: {
     label: "ebanx",
     fields: {

--- a/src/screens/Connectors/ConnectorTypes.res
+++ b/src/screens/Connectors/ConnectorTypes.res
@@ -164,6 +164,7 @@ type payoutProcessorTypes =
   | ENVOY
   | TRUSTLY
   | SANTANDER
+  | DEUTSCHEBANK
 
 type threeDsAuthenticatorTypes =
   | THREEDSECUREIO

--- a/src/screens/Connectors/ConnectorUtils.res
+++ b/src/screens/Connectors/ConnectorUtils.res
@@ -41,6 +41,7 @@ let payoutConnectorList: array<connectorTypes> = [
   PayoutProcessor(ENVOY),
   PayoutProcessor(TRUSTLY),
   PayoutProcessor(SANTANDER),
+  PayoutProcessor(DEUTSCHEBANK),
 ]
 
 let payoutConnectorListForLive: array<connectorTypes> = [
@@ -1059,6 +1060,7 @@ let getPayoutProcessorNameString = (payoutProcessor: payoutProcessorTypes) =>
   | ENVOY => "envoy"
   | TRUSTLY => "trustly"
   | SANTANDER => "santander"
+  | DEUTSCHEBANK => "deutschebank"
   }
 
 let getThreeDsAuthenticatorNameString = (threeDsAuthenticator: threeDsAuthenticatorTypes) =>
@@ -1272,6 +1274,7 @@ let getConnectorNameTypeFromString = (connector, ~connectorType=ConnectorTypes.P
     | "envoy" => PayoutProcessor(ENVOY)
     | "trustly" => PayoutProcessor(TRUSTLY)
     | "santander" => PayoutProcessor(SANTANDER)
+    | "deutschebank" => PayoutProcessor(DEUTSCHEBANK)
     | _ => UnknownConnector("Not known")
     }
   | ThreeDsAuthenticator =>
@@ -1462,6 +1465,7 @@ let getPayoutProcessorInfo = (payoutconnector: ConnectorTypes.payoutProcessorTyp
   | ENVOY => envoyInfo
   | TRUSTLY => trustlyInfo
   | SANTANDER => santanderInfo
+  | DEUTSCHEBANK => deutscheBankInfo
   }
 }
 
@@ -2461,6 +2465,7 @@ let getDisplayNameForPayoutProcessor = (payoutProcessor: ConnectorTypes.payoutPr
   | ENVOY => "Worldpay Envoy"
   | TRUSTLY => "Trustly"
   | SANTANDER => "Santander"
+  | DEUTSCHEBANK => "Deutsche Bank"
   }
 
 let getDisplayNameForThreedsAuthenticator = threeDsAuthenticator =>


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Registers Deutsche Bank as a payout processor so it shows up on the Payout Processors screen and can be onboarded from the dashboard.

- `ConnectorTypes.res` — added `DEUTSCHEBANK` to `payoutProcessorTypes`
- `ConnectorUtils.res` — wired it through the five payout paths:
  - `payoutConnectorList`
  - `getPayoutProcessorNameString` → `"deutschebank"`
  - `getConnectorNameTypeFromString` (PayoutProcessor branch)
  - `getPayoutProcessorInfo` → reuses the existing `deutscheBankInfo`
  - `getDisplayNameForPayoutProcessor` → `"Deutsche Bank"`
- `payoutConnectorConfig.ts` — added the `deutschebank` playwright fixture

No WASM update needed. `getPayoutConnectorConfig("deutschebank")` already returns a payout config in the bundled WASM:

```
connector_auth: MultiAuthKey {
  api_key:    "Customer Identifier",
  key1:       "Key ID",
  api_secret: "Signing Private Key (PEM)",
  key2:       "Client Certificate Bundle (PEM cert + key concatenated)"
}
bank_transfer: [sepa_bank_transfer]
```

The connector icon already exists at `public/hyperswitch/assets/Gateway/DEUTSCHEBANK.svg`.

Scoped to test mode only, matching how recent payout connectors were introduced (Santander #5378, Loonio, Gigadat, Nuvei). Enabling it for live is a follow-up that also needs `deutschebank` added to the `connector_list_for_live.payoutProcessors` key in the deployed env config.


https://github.com/user-attachments/assets/10cdbfae-de1e-4c60-b595-c0387ef66a0a


## Motivation and Context

Closes #5417

Deutsche Bank was already integrated as a payment processor but was not selectable as a payout processor.

## How did you test it?

- `npx rescript build` compiles clean, with no non-exhaustive-match warnings on the payout switches.
- Verified the WASM payout config by loading `public/hyperswitch/wasm/euclid_bg.wasm` and calling `getPayoutConnectorConfig("deutschebank")` — the fixture's `fieldLabels` and `paymentSections` are derived from that output, so they match what the onboarding form renders.
- Added a `deutschebank` entry to `payoutConnectorConfig.ts`; `payoutConnector.spec.ts` iterates the fixture, so the connector is covered by the existing e2e suite with no spec change. Since the auth type is `MultiAuthKey` (plain text inputs) rather than `CertificateAuth`, it does not need the `generateCerts()` special case Santander uses.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)