### PR TITLE
feat: group merchant switcher dropdown by product type

### DIFF
--- a/src/components/SelectBox.res
+++ b/src/components/SelectBox.res
@@ -1315,28 +1315,44 @@ let getHashMappedOptionValues = (options: array<dropdownOptionWithoutOptional>) 
   hashMappedOptions
 }
 
-let getSortedKeys = (hashMappedOptions, ~reverseSort=false, ~customSortOrder=?) => {
+let getSortedKeys = (
+  hashMappedOptions,
+  ~reverseSort=false,
+  ~customSortOrder=?,
+  ~selectedGroup=?,
+) => {
   let keys = hashMappedOptions->Dict.keysToArray
+  let isSelectedGroup = key => selectedGroup->Option.mapOr(false, group => group === key)
 
   switch customSortOrder {
   | Some(order) =>
     keys->Array.toSorted((a, b) => {
-      let aIndex = order->Array.findIndex(item => item === a)
-      let bIndex = order->Array.findIndex(item => item === b)
+      switch (a->isSelectedGroup, b->isSelectedGroup) {
+      | (true, false) => -1.
+      | (false, true) => 1.
+      | (_, _) =>
+        let aIndex = order->Array.findIndex(item => item === a)
+        let bIndex = order->Array.findIndex(item => item === b)
 
-      switch (aIndex, bIndex) {
-      | (-1, -1) => String.compare(a, b)
-      | (-1, _) => 1.
-      | (_, -1) => -1.
-      | (_, _) => Float.fromInt(aIndex - bIndex)
+        switch (aIndex, bIndex) {
+        | (-1, -1) => String.compare(a, b)
+        | (-1, _) => 1.
+        | (_, -1) => -1.
+        | (_, _) => Float.fromInt(aIndex - bIndex)
+        }
       }
     })
   | None =>
     keys->Array.toSorted((a, b) => {
-      switch (a, b) {
-      | ("-", _) => 1.
-      | (_, "-") => -1.
-      | (_, _) => reverseSort ? String.compare(b, a) : String.compare(a, b)
+      switch (a->isSelectedGroup, b->isSelectedGroup) {
+      | (true, false) => -1.
+      | (false, true) => 1.
+      | (_, _) =>
+        switch (a, b) {
+        | ("-", _) => 1.
+        | (_, "-") => -1.
+        | (_, _) => reverseSort ? String.compare(b, a) : String.compare(a, b)
+        }
       }
     })
   }
@@ -1399,8 +1415,22 @@ module BaseRadio = {
     let isNonGrouped =
       hashMappedOptions->Dict.get("-")->Option.getOr([])->Array.length === options->Array.length
 
+    let selectedGroup = if shouldDisplaySelectedOnTop {
+      value
+      ->JSON.Decode.string
+      ->Option.flatMap(str => options->Array.find(option => option.value === str))
+      ->Option.map(option => option.optGroup)
+    } else {
+      None
+    }
+
     let (optgroupKeys, setOptgroupKeys) = React.useState(_ =>
-      getSortedKeys(hashMappedOptions, ~reverseSort=reverseSortGroupKeys, ~customSortOrder?)
+      getSortedKeys(
+        hashMappedOptions,
+        ~reverseSort=reverseSortGroupKeys,
+        ~customSortOrder?,
+        ~selectedGroup?,
+      )
     )
 
     let (searchString, setSearchString) = React.useState(() => "")
@@ -1513,13 +1543,19 @@ module BaseRadio = {
             hashMappedSearchedOptions,
             ~reverseSort=reverseSortGroupKeys,
             ~customSortOrder?,
+            ~selectedGroup?,
           )
           setOptgroupKeys(_ => optgroupKeysForSearch)
           options
         }
       } else {
         setOptgroupKeys(_ =>
-          getSortedKeys(hashMappedOptions, ~reverseSort=reverseSortGroupKeys, ~customSortOrder?)
+          getSortedKeys(
+            hashMappedOptions,
+            ~reverseSort=reverseSortGroupKeys,
+            ~customSortOrder?,
+            ~selectedGroup?,
+          )
         )
         options
       }

--- a/src/components/SelectBox.res
+++ b/src/components/SelectBox.res
@@ -1134,6 +1134,29 @@ module BaseSelectButton = {
   }
 }
 
+let selectBoxScrollbarCss = `
+  @supports (-webkit-appearance: none) {
+    .selectbox-scrollbar {
+     scrollbar-width: auto;
+      scrollbar-color: #CACFD8;
+    }
+    .selectbox-scrollbar::-webkit-scrollbar {
+      display: block;
+      overflow: scroll;
+      height: 5px;
+      width: 5px;
+    }
+    .selectbox-scrollbar::-webkit-scrollbar-thumb {
+      background-color: #CACFD8;
+      border-radius: 3px;
+    }
+
+    .selectbox-scrollbar::-webkit-scrollbar-track {
+      display: none;
+    }
+  }
+`
+
 module RenderListItemInBaseRadio = {
   @react.component
   let make = (
@@ -1249,28 +1272,6 @@ module RenderListItemInBaseRadio = {
       })
       ->React.array
 
-    let selectBoxScrollbarCss = `
-      @supports (-webkit-appearance: none) {
-        .selectbox-scrollbar {
-         scrollbar-width: auto;
-          scrollbar-color: #CACFD8;
-        }
-        .selectbox-scrollbar::-webkit-scrollbar {
-          display: block;
-          overflow: scroll;
-          height: 5px;
-          width: 5px;
-        }
-        .selectbox-scrollbar::-webkit-scrollbar-thumb {
-          background-color: #CACFD8;
-          border-radius: 3px;
-        }
-
-        .selectbox-scrollbar::-webkit-scrollbar-track {
-          display: none;
-        }
-      }
-    `
     let (className, styleElement) = switch (customScrollStyle, isHorizontal) {
     | (None, false) => ("", React.null)
     | (Some(style), false) => (
@@ -1590,8 +1591,8 @@ module BaseRadio = {
             customSelectionIcon
           />
         } else {
-          <>
-            {optgroupKeys
+          let groupedList =
+            optgroupKeys
             ->Array.mapWithIndex((ele, index) => {
               <React.Fragment key={index->Int.toString}>
                 <h2 className="py-1.5 pl-3 font-semibold text-nd_gray-400 text-xs leading-14">
@@ -1619,12 +1620,20 @@ module BaseRadio = {
                   textEllipsisForDropDownOptions
                   isHorizontal
                   customMarginStyleOfListItem="ml-8 mx-3 py-2 gap-2"
-                  ?customScrollStyle
                   shouldDisplaySelectedOnTop
                 />
               </React.Fragment>
             })
-            ->React.array}
+            ->React.array
+          <>
+            {switch customScrollStyle {
+            | Some(style) =>
+              <div className={`${style} selectbox-scrollbar`}>
+                <style> {React.string(selectBoxScrollbarCss)} </style>
+                groupedList
+              </div>
+            | None => groupedList
+            }}
             <div className="sticky bottom-0">
               <span> {bottomComponent} </span>
             </div>

--- a/src/components/SelectBox.resi
+++ b/src/components/SelectBox.resi
@@ -204,6 +204,7 @@ let getSortedKeys: (
   RescriptCore.Dict.t<'a>,
   ~reverseSort: bool=?,
   ~customSortOrder: array<string>=?,
+  ~selectedGroup: string=?,
 ) => array<string>
 module BaseRadio: {
   @react.component

--- a/src/entryPoints/OMPSwitch/MerchantSwitch.res
+++ b/src/entryPoints/OMPSwitch/MerchantSwitch.res
@@ -246,6 +246,7 @@ let make = () => {
       deselectDisable=true
       options={updatedMerchantList->generateDropdownOptionsCustomComponent(
         ~isPlatformOrg=isCurrentOrganizationPlatform,
+        ~groupByProduct=true,
       )}
       marginTop={`mt-16 ${borderColor} shadow-generic_shadow ml-2`}
       hideMultiSelectButtons=true
@@ -270,9 +271,23 @@ let make = () => {
       customSearchStyle={`${backgroundColor.sidebarSecondary} ${secondaryTextColor} ${borderColor}`}
       searchInputPlaceHolder="Search Merchant Account or ID"
       placeholderCss={`text-fs-13 ${backgroundColor.sidebarSecondary}`}
-      customSortOrder={[#platform, #connected, #standard]->Array.map(ompType =>
-        ompType->OMPSwitchUtils.ompTypeHeading->String.toUpperCase
-      )}
+      customSortOrder={isCurrentOrganizationPlatform
+        ? [#platform, #connected, #standard]->Array.map(ompType =>
+            ompType->OMPSwitchUtils.ompTypeHeading->String.toUpperCase
+          )
+        : {
+            open ProductTypes
+            [
+              Orchestration(V1),
+              Orchestration(V2),
+              Recon(V1),
+              Recon(V2),
+              Recovery,
+              Vault,
+              CostObservability,
+              DynamicRouting,
+            ]->Array.map(product => product->ProductUtils.getProductDisplayName->String.toUpperCase)
+          }}
     />
     <NewMerchantCreationModal setShowModal showModal />
     <LoaderModal

--- a/src/entryPoints/OMPSwitch/MerchantSwitch.res
+++ b/src/entryPoints/OMPSwitch/MerchantSwitch.res
@@ -206,6 +206,13 @@ let make = () => {
   let addItemBtnStyle = `w-full ${borderColor} border-t-0`
   let customScrollStyle = `max-h-72 overflow-scroll px-1 pt-1 ${borderColor}`
   let dropdownContainerStyle = `${roundedClass} border border-1 ${borderColor} ${widthClass}`
+  let customSortOrder = isCurrentOrganizationPlatform
+    ? [#platform, #connected, #standard]->Array.map(ompType =>
+        ompType->OMPSwitchUtils.ompTypeHeading->String.toUpperCase
+      )
+    : ProductUtils.productSortOrder->Array.map(product =>
+        product->ProductUtils.getProductDisplayName->String.toUpperCase
+      )
 
   let subHeading = {currentOMPName(merchantList, merchantId)}
 
@@ -246,7 +253,7 @@ let make = () => {
       deselectDisable=true
       options={updatedMerchantList->generateDropdownOptionsCustomComponent(
         ~isPlatformOrg=isCurrentOrganizationPlatform,
-        ~groupByProduct=true,
+        ~groupByProduct={!isCurrentOrganizationPlatform},
       )}
       marginTop={`mt-16 ${borderColor} shadow-generic_shadow ml-2`}
       hideMultiSelectButtons=true
@@ -271,23 +278,7 @@ let make = () => {
       customSearchStyle={`${backgroundColor.sidebarSecondary} ${secondaryTextColor} ${borderColor}`}
       searchInputPlaceHolder="Search Merchant Account or ID"
       placeholderCss={`text-fs-13 ${backgroundColor.sidebarSecondary}`}
-      customSortOrder={isCurrentOrganizationPlatform
-        ? [#platform, #connected, #standard]->Array.map(ompType =>
-            ompType->OMPSwitchUtils.ompTypeHeading->String.toUpperCase
-          )
-        : {
-            open ProductTypes
-            [
-              Orchestration(V1),
-              Orchestration(V2),
-              Recon(V1),
-              Recon(V2),
-              Recovery,
-              Vault,
-              CostObservability,
-              DynamicRouting,
-            ]->Array.map(product => product->ProductUtils.getProductDisplayName->String.toUpperCase)
-          }}
+      customSortOrder
     />
     <NewMerchantCreationModal setShowModal showModal />
     <LoaderModal

--- a/src/entryPoints/OMPSwitch/MerchantSwitch.res
+++ b/src/entryPoints/OMPSwitch/MerchantSwitch.res
@@ -231,6 +231,7 @@ let make = () => {
     let listItem: OMPSwitchTypes.ompListTypesCustom = {
       id: item.id,
       name: item.name,
+      productType: ?item.productType,
       type_: item.type_->Option.getOr(#standard),
       customComponent,
     }

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -661,6 +661,13 @@ let generateDropdownOptionsCustomComponent: (
           toolTipPosition=ToolTip.TopRight
         />,
       ),
+      optGroup: {
+        let displayName =
+          item.productType
+          ->Option.getOr(ProductTypes.Orchestration(UserInfoTypes.V1))
+          ->ProductUtils.getProductDisplayName
+        (displayName->isEmptyString ? "Others" : displayName)->String.toUpperCase
+      },
     }
     isPlatformOrg ? platformOptions : merchantOptions
   })

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -620,10 +620,11 @@ let generateDropdownOptions: (
   options
 }
 
-let generateDropdownOptionsCustomComponent: (
-  array<OMPSwitchTypes.ompListTypesCustom>,
-  ~isPlatformOrg: bool,
-) => array<SelectBox.dropdownOption> = (dropdownList, ~isPlatformOrg) => {
+let generateDropdownOptionsCustomComponent = (
+  dropdownList: array<OMPSwitchTypes.ompListTypesCustom>,
+  ~isPlatformOrg,
+  ~groupByProduct=false,
+): array<SelectBox.dropdownOption> => {
   let options: array<SelectBox.dropdownOption> = dropdownList->Array.map((
     item
   ): SelectBox.dropdownOption => {
@@ -661,13 +662,17 @@ let generateDropdownOptionsCustomComponent: (
           toolTipPosition=ToolTip.TopRight
         />,
       ),
-      optGroup: {
-        let displayName =
-          item.productType
-          ->Option.getOr(ProductTypes.Orchestration(UserInfoTypes.V1))
-          ->ProductUtils.getProductDisplayName
-        (displayName->isEmptyString ? "Others" : displayName)->String.toUpperCase
-      },
+      optGroup: ?(
+        if groupByProduct {
+          let displayName =
+            item.productType
+            ->Option.getOr(ProductTypes.Orchestration(UserInfoTypes.V1))
+            ->ProductUtils.getProductDisplayName
+          Some((displayName->isEmptyString ? "Others" : displayName)->String.toUpperCase)
+        } else {
+          None
+        }
+      ),
     }
     isPlatformOrg ? platformOptions : merchantOptions
   })

--- a/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
+++ b/src/entryPoints/OMPSwitch/OMPSwitchHelper.res
@@ -668,7 +668,7 @@ let generateDropdownOptionsCustomComponent = (
             item.productType
             ->Option.getOr(ProductTypes.Orchestration(UserInfoTypes.V1))
             ->ProductUtils.getProductDisplayName
-          Some((displayName->isEmptyString ? "Others" : displayName)->String.toUpperCase)
+          Some(displayName->getNonEmptyString->Option.getOr("Others")->String.toUpperCase)
         } else {
           None
         }

--- a/src/entryPoints/ProductUtils.res
+++ b/src/entryPoints/ProductUtils.res
@@ -18,6 +18,17 @@ let getProductVariantFromString = (product, ~version: UserInfoTypes.version) => 
   }
 }
 
+let productSortOrder = [
+  Orchestration(V1),
+  Orchestration(V2),
+  Recon(V1),
+  Recon(V2),
+  Recovery,
+  Vault,
+  CostObservability,
+  DynamicRouting,
+]
+
 let getProductDisplayName = product =>
   switch product {
   | Recon(V2) => "Recon"


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Groups the merchant switcher dropdown by product type (Orchestrator, Recon, Vault, etc.), so merchants belonging to the same product appear under a section header instead of one flat list.

- `MerchantSwitch.res`: carry `productType` through into the dropdown list items (it was being dropped when building `ompListTypesCustom`).
- `OMPSwitchHelper.res`: set `optGroup` on non-platform merchant options to the product display name, reusing `SelectBox`'s existing group-header machinery (the same one platform orgs already use for PLATFORM/CONNECTED/STANDARD groups). Missing `productType` falls back to Orchestration (same fallback `MerchantDropdownItem` already uses); product types with no display name (`UnknownProduct`/`OnBoarding`) bucket under OTHERS to avoid a blank header.

Platform-org grouping (PLATFORM / CONNECTED / STANDARD) is unchanged.

## Motivation and Context
Merchants across multiple products (Orchestrator, Recon, Vault, Cost Observability, ...) show up as a single flat list in the switcher; the only product signal is a small icon tooltip per row. Grouping by product makes it much faster to find the right merchant account.

<img width="350" height="496" alt="Screenshot 2026-08-19 at 11 40 56 PM" src="https://github.com/user-attachments/assets/020b0f22-4d08-4dca-80be-55a141cf4b4a" />

1. Single scroll for all products
2. Ensured profile dropdown doesn't get messed up because of this

## How did you test it?
- `npx rescript build` compiles clean.
- Verified `SelectBox` grouping logic: `optGroup` bucketing, `customSortOrder` fallback (unknown keys sort alphabetically), search and selected-on-top behavior are unaffected.

## Checklist
- [x] I formatted the code `cargo +nightly fmt --all` — n/a (frontend)
- [x] I addressed lints thrown by `cargo clippy` — n/a (frontend)
- [x] I reviewed the submitted code