### PR TITLE
chore: show truncation note when a transaction has more entries

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/HierarchicalTransactionsTableEntity.res
@@ -144,6 +144,10 @@ let getCell = (
           </React.Fragment>
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer
+          hasMoreEntries=transaction.has_more_entries
+          text={`Only ${transaction.entries->Array.length->Int.toString} entries shown`}
+        />
       </div>
     CustomCell(entryIdContent, "")
   | OrderId =>
@@ -167,6 +171,7 @@ let getCell = (
           </React.Fragment>
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(orderIdContent, "")
   | Account =>
@@ -177,6 +182,7 @@ let getCell = (
           <HierarchicalEntryRenderer fieldValue=entry.account.account_name key={entry.entry_id} />
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(accountContent, "")
   | EntryStatus =>
@@ -189,6 +195,7 @@ let getCell = (
           />
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(entryStatusContent, "")
   | Currency =>
@@ -199,6 +206,7 @@ let getCell = (
           <HierarchicalEntryRenderer fieldValue=entry.amount.currency key={entry.entry_id} />
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(currencyContent, "")
   | DebitAmount =>
@@ -213,6 +221,7 @@ let getCell = (
           <HierarchicalEntryRenderer fieldValue=amount key={entry.entry_id} />
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(debitAmountContent, "")
   | CreditAmount =>
@@ -227,6 +236,7 @@ let getCell = (
           <HierarchicalEntryRenderer fieldValue=amount key={entry.entry_id} />
         })
         ->React.array}
+        <HierarchicalMoreEntriesRenderer hasMoreEntries=transaction.has_more_entries />
       </div>
     CustomCell(creditAmountContent, "")
   }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
@@ -223,6 +223,20 @@ module HierarchicalEntryRenderer = {
   }
 }
 
+module HierarchicalMoreEntriesRenderer = {
+  @react.component
+  let make = (~hasMoreEntries: bool, ~text: string="") => {
+    <RenderIf condition={hasMoreEntries}>
+      <div className="px-8 py-3.5">
+        <div
+          className={`truncate max-w-48 whitespace-nowrap h-7 text-nd_gray-500 ${body.sm.medium}`}>
+          {text->React.string}
+        </div>
+      </div>
+    </RenderIf>
+  }
+}
+
 module AuditTrail = {
   @react.component
   let make = (~allTransactionDetails) => {

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -276,6 +276,7 @@ type transactionType = {
   data: transactionDataType,
   linked_transaction: option<linkedTransactionType>,
   modified_by: option<modifiedByType>,
+  has_more_entries: bool,
 }
 
 type entryType = {

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -537,6 +537,7 @@ let transactionItemToObjMapper = (dict): transactionType => {
     modified_by: modifiedByDict->isEmptyDict
       ? None
       : Some(modifiedByDict->modifiedByItemToObjMapper),
+    has_more_entries: dict->getBool("has_more_entries", false),
   }
 }
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


The hierarchical transactions table only renders a capped number of entries per transaction. When more exist, the row now shows a `Only <n> entries shown` note under the entry list so the truncation is visible.

- Added `has_more_entries` to `transactionType` and its mapper in `ReconEngineUtils`.
- Added `HierarchicalMoreEntriesRenderer` in `ReconEngineTransactionsHelper`, rendered at the end of every hierarchical column so row heights stay aligned (text only on the Entry ID column).

<img width="3456" height="2100" alt="image" src="https://github.com/user-attachments/assets/f3aba120-549e-4d4f-9641-4e7317ec0445" />

## Motivation and Context

Users had no way to tell that a transaction had more entries than the ones displayed, making the row look complete when it wasn't.

## How did you test it?

Tested manually on the Recon Engine transactions page — verified the note appears for transactions with `has_more_entries: true`, is absent otherwise, and that all columns stay row-aligned in both cases.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
