### PR TITLE
feat: enable saved views for refunds and disputes screens

### DIFF
--- a/src/screens/Transaction/Disputes/Disputes.res
+++ b/src/screens/Transaction/Disputes/Disputes.res
@@ -15,7 +15,7 @@ let make = () => {
   let (filters, setFilters) = React.useState(_ => None)
   let (transactionViewStatuses, setTransactionViewStatuses) = React.useState(_ => [])
 
-  let {generateReport, email, transactionView} =
+  let {generateReport, email, transactionView, devSavedViews} =
     HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
   let {getCommonSessionDetails, getResolvedUserInfo, checkUserEntity} = React.useContext(
@@ -113,6 +113,9 @@ let make = () => {
       customLeftView={<SearchBarFilter
         placeholder="Search for dispute ID" setSearchVal=setSearchText searchVal=searchText
       />}
+      customFilterActions={<RenderIf condition={devSavedViews}>
+        <SavedViewsComponent entity=SavedViewTypes.Dispute />
+      </RenderIf>}
       entityName=V1(DISPUTE_FILTERS)
       title="Disputes"
     />

--- a/src/screens/Transaction/Refunds/Refund.res
+++ b/src/screens/Transaction/Refunds/Refund.res
@@ -87,7 +87,7 @@ let make = () => {
     None
   }, (offset, filters, searchText))
 
-  let {generateReport, transactionView} =
+  let {generateReport, transactionView, devSavedViews} =
     HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   <ErrorBoundary>
@@ -134,6 +134,9 @@ let make = () => {
                 searchVal=searchText
               />
             </div>}
+            customFilterActions={<RenderIf condition={devSavedViews}>
+              <SavedViewsComponent entity=SavedViewTypes.Refund />
+            </RenderIf>}
             entityName=V1(REFUND_FILTERS)
             title="Refunds"
           />


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Extends the saved views feature (previously Payments-only) to the **Refunds** and **Disputes** screens.

- `Refund.res` and `Disputes.res` now pass a `customFilterActions` to their `RemoteTableFilters`, rendering `SavedViewsComponent` with `entity=Refund` / `entity=Dispute` — the same integration pattern `Orders.res` uses.
- No new saved-views code was needed: `SavedViewTypes`, `SavedViewsComponent`, `SavedViewsUtils`, and the hooks are already generic over the entity, and the `RefundViews` / `DisputeViews` user-data keys (entities `refund_views` / `dispute_views`) already exist in the frontend types.
- Rendering is gated behind the existing `dev_saved_views` feature flag, same as payments. No config changes are included in this PR.

Users get the full saved-views flow on both screens: save the current filter selection as a named view (optionally including the date range), re-apply it from the dropdown, rename inline, overwrite, delete, and automatic active-view detection when the current filters match a saved view. Views are stored per user per entity — refund views, dispute views, and payment views are fully isolated from each other.

## Motivation and Context

Closes #5442.

Merchants can save frequently used filter combinations on the payments list but must re-build the same filters manually on every visit to Refunds and Disputes. This brings those screens to parity.

## How did you test it?

Tested manually end to end against a locally running `hyperswitch` router (current main) with the corresponding backend support:

- API level: full create / fetch / update (rename + filters) / delete cycle for both `RefundViews` and `DisputeViews` via `/user/data`, filters round-trip intact (including `amount_filter` and flattened time range); validation verified — max 5 views per entity, duplicate-name rejection, empty-name rejection, entity/key mismatch rejection, unknown `view_id` 404; `PaymentViews` behavior unchanged.
- UI level: with seeded refunds (mixed statuses/currencies, full + partial) and disputes (mixed stages/statuses/currencies) — save view → switch to Default View → re-select (filters and chips restore) → rename → overwrite → delete on both screens; refund/dispute/payment views verified isolated from each other; payments saved views regression-checked.


https://github.com/user-attachments/assets/fd2fbf88-1bed-45c7-9f7b-9a6a018364df



## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

Cannot be tested on shared environments until the backend dependency below is deployed there; verified locally against `hyperswitch` main.

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [x] Yes
- [ ] No

Backend PR URL: pending — `hyperswitch` PR adding `RefundViews` / `DisputeViews` support to the `/user/data` dashboard-metadata API (will be linked here once raised).

**⚠️ Merge order: this PR must be merged only after the backend PR is merged and deployed.** Until then, enabling `dev_saved_views` on these screens would fail with `IR_06` deserialization errors on save (the backend rejects the `RefundViews` / `DisputeViews` keys).

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): `dev_saved_views` (existing, unchanged — the saved views UI on these screens renders only when it is enabled)

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
