### PR TITLE
fix: server-side pagination for disputes list to satisfy backend limit validation

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -287,7 +287,7 @@ let useGetURL = () => {
           | None =>
             switch queryParameters {
             | Some(queryParams) => Olap(`customers/list?${queryParams}`)
-            | None => Olap(`customers/list?limit=500`)
+            | None => Olap(`customers/list?limit=100`)
             }
           }
         | _ => Default("")
@@ -509,17 +509,17 @@ let useGetURL = () => {
             switch queryParameters {
             | Some(queryParams) =>
               switch transactionEntity {
-              | #Profile => Olap(`disputes/profile/list?${queryParams}&limit=10000`)
+              | #Profile => Olap(`disputes/profile/list?${queryParams}`)
               | #Merchant
               | _ =>
-                Olap(`disputes/list?${queryParams}&limit=10000`)
+                Olap(`disputes/list?${queryParams}`)
               }
             | None =>
               switch transactionEntity {
-              | #Profile => Olap(`disputes/profile/list?limit=10000`)
+              | #Profile => Olap(`disputes/profile/list?limit=100`)
               | #Merchant
               | _ =>
-                Olap(`disputes/list?limit=10000`)
+                Olap(`disputes/list?limit=100`)
               }
             }
           }
@@ -567,7 +567,7 @@ let useGetURL = () => {
           | None =>
             switch transactionEntity {
             | #Merchant => Olap(`payouts/list?limit=100`)
-            | #Profile => Olap(`payouts/profile/list?limit=10000`)
+            | #Profile => Olap(`payouts/profile/list?limit=100`)
             | _ => Olap(`payouts/list?limit=100`)
             }
           }

--- a/src/ReconEngine/ReconEngineHooks/ReconEngineCursorPaginationButtons.res
+++ b/src/ReconEngine/ReconEngineHooks/ReconEngineCursorPaginationButtons.res
@@ -6,33 +6,12 @@ let make = (
   ~onPrev: unit => unit,
   ~onNext: unit => unit,
 ) => {
-  let getButtonState = (cursor): Button.buttonState =>
-    cursor->Option.isNone || isLoading ? Button.Disabled : Button.Normal
-
-  <RenderIf condition=hasData>
-    <div className="flex flex-row justify-end items-center gap-2 py-4">
-      <Button
-        leftIcon={FontAwesome("chevron-left")}
-        buttonType=Secondary
-        buttonSize=Small
-        buttonState={getButtonState(cursors.prev)}
-        customButtonStyle="!w-8 !px-0"
-        customIconMargin=""
-        showTooltip=true
-        tooltipText="Previous page"
-        onClick={_ => onPrev()}
-      />
-      <Button
-        leftIcon={FontAwesome("chevron-right")}
-        buttonType=Secondary
-        buttonSize=Small
-        buttonState={getButtonState(cursors.next)}
-        customButtonStyle="!w-8 !px-0"
-        customIconMargin=""
-        showTooltip=true
-        tooltipText="Next page"
-        onClick={_ => onNext()}
-      />
-    </div>
-  </RenderIf>
+  <PrevNextPaginationButtons
+    isLoading
+    hasData
+    prevDisabled={cursors.prev->Option.isNone}
+    nextDisabled={cursors.next->Option.isNone}
+    onPrev
+    onNext
+  />
 }

--- a/src/components/PrevNextPaginationButtons.res
+++ b/src/components/PrevNextPaginationButtons.res
@@ -1,0 +1,39 @@
+@react.component
+let make = (
+  ~isLoading: bool,
+  ~hasData: bool,
+  ~prevDisabled: bool,
+  ~nextDisabled: bool,
+  ~onPrev: unit => unit,
+  ~onNext: unit => unit,
+) => {
+  let getButtonState = (disabled): Button.buttonState =>
+    disabled || isLoading ? Button.Disabled : Button.Normal
+
+  <RenderIf condition=hasData>
+    <div className="flex flex-row justify-end items-center gap-2 py-4">
+      <Button
+        leftIcon={FontAwesome("chevron-left")}
+        buttonType=Secondary
+        buttonSize=Small
+        buttonState={getButtonState(prevDisabled)}
+        customButtonStyle="!w-8 !px-0"
+        customIconMargin=""
+        showTooltip=true
+        tooltipText="Previous page"
+        onClick={_ => onPrev()}
+      />
+      <Button
+        leftIcon={FontAwesome("chevron-right")}
+        buttonType=Secondary
+        buttonSize=Small
+        buttonState={getButtonState(nextDisabled)}
+        customButtonStyle="!w-8 !px-0"
+        customIconMargin=""
+        showTooltip=true
+        tooltipText="Next page"
+        onClick={_ => onNext()}
+      />
+    </div>
+  </RenderIf>
+}

--- a/src/screens/Transaction/Disputes/Disputes.res
+++ b/src/screens/Transaction/Disputes/Disputes.res
@@ -10,6 +10,7 @@ let make = () => {
   let {filterValueJson, updateExistingKeys} = React.useContext(FilterContext.filterContext)
   let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
   let (disputesData, setDisputesData) = React.useState(_ => [])
+  let (hasNext, setHasNext) = React.useState(_ => false)
   let (searchText, setSearchText) = React.useState(_ => "")
   let (offset, setOffset) = React.useState(_ => 0)
   let (filters, setFilters) = React.useState(_ => None)
@@ -57,6 +58,9 @@ let make = () => {
           `${key}=${value}`
         })
         ->Array.joinWith("&")
+      let paginationParams = `limit=${disputesFetchLimit->Int.toString}&offset=${offset->Int.toString}`
+      let queryParam =
+        queryParam->isNonEmptyString ? `${queryParam}&${paginationParams}` : paginationParams
       let disputesUrl = getURL(
         ~entityName=V1(DISPUTES),
         ~methodType=Get,
@@ -64,8 +68,16 @@ let make = () => {
       )
       let response = await fetchDetails(disputesUrl)
       let disputesValue = response->getArrayDataFromJson(DisputesEntity.itemToObjMapper)
-      if disputesValue->Array.length > 0 {
-        setDisputesData(_ => disputesValue)
+      let dataLen = disputesValue->Array.length
+      if dataLen == 0 && offset > 0 {
+        // Landed past the end of the list - step back to the previous page
+        setHasNext(_ => false)
+        setOffset(_ => Js.Math.max_int(0, offset - disputesFetchLimit))
+      } else if dataLen > 0 {
+        let padding = Array.make(~length=offset, Dict.make()->DisputesEntity.itemToObjMapper)
+        setDisputesData(_ => padding->Array.concat(disputesValue))
+        // The list response has no total_count - a full page means more rows may exist
+        setHasNext(_ => dataLen == disputesFetchLimit)
         setScreenState(_ => Success)
       } else {
         setScreenState(_ => Custom)
@@ -85,7 +97,7 @@ let make = () => {
       getDisputesList()->ignore
     }
     None
-  }, (filters, searchText))
+  }, (offset, filters, searchText))
 
   let customUI =
     <NoDataFound
@@ -151,12 +163,22 @@ let make = () => {
           hideTitle=true
           actualData={disputesData->Array.map(Nullable.make)}
           entity={DisputesEntity.disputesEntity(merchantId, orgId)}
-          resultsPerPage=10
+          resultsPerPage=disputesFetchLimit
           showSerialNumber=true
           totalResults={disputesData->Array.length}
           offset
           setOffset
           currentFetchCount={disputesData->Array.length}
+          showPagination=false
+          showResultsPerPageSelector=false
+          bottomActions={<DisputesHelper.PrevNextPagination
+            isLoading={screenState === PageLoaderWrapper.Loading}
+            hasData={disputesData->Array.length > 0}
+            prevDisabled={offset == 0}
+            nextDisabled={!hasNext}
+            onPrev={() => setOffset(prev => Js.Math.max_int(0, prev - disputesFetchLimit))}
+            onNext={() => setOffset(prev => prev + disputesFetchLimit)}
+          />}
           defaultColumns={DisputesEntity.defaultColumns}
           customColumnMapper={TableAtoms.disputesMapDefaultCols}
           showSerialNumberInCustomizeColumns=false

--- a/src/screens/Transaction/Disputes/Disputes.res
+++ b/src/screens/Transaction/Disputes/Disputes.res
@@ -16,6 +16,11 @@ let make = () => {
   let (filters, setFilters) = React.useState(_ => None)
   let (transactionViewStatuses, setTransactionViewStatuses) = React.useState(_ => [])
 
+  let handleSearchTextChange = updater => {
+    setOffset(_ => 0)
+    setSearchText(updater)
+  }
+
   let {generateReport, email, transactionView} =
     HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let {updateTransactionEntity} = OMPSwitchHooks.useUserInfo()
@@ -72,7 +77,7 @@ let make = () => {
       if dataLen == 0 && offset > 0 {
         // Landed past the end of the list - step back to the previous page
         setHasNext(_ => false)
-        setOffset(_ => Js.Math.max_int(0, offset - disputesFetchLimit))
+        setOffset(_ => Math.Int.max(0, offset - disputesFetchLimit))
       } else if dataLen > 0 {
         let padding = Array.make(~length=offset, Dict.make()->DisputesEntity.itemToObjMapper)
         setDisputesData(_ => padding->Array.concat(disputesValue))
@@ -123,7 +128,7 @@ let make = () => {
           ->getStrArrayFromJsonArray
         )}
       customLeftView={<SearchBarFilter
-        placeholder="Search for dispute ID" setSearchVal=setSearchText searchVal=searchText
+        placeholder="Search for dispute ID" setSearchVal=handleSearchTextChange searchVal=searchText
       />}
       entityName=V1(DISPUTE_FILTERS)
       title="Disputes"
@@ -170,13 +175,12 @@ let make = () => {
           setOffset
           currentFetchCount={disputesData->Array.length}
           showPagination=false
-          showResultsPerPageSelector=false
-          bottomActions={<DisputesHelper.PrevNextPagination
+          bottomActions={<PrevNextPaginationButtons
             isLoading={screenState === PageLoaderWrapper.Loading}
             hasData={disputesData->Array.length > 0}
             prevDisabled={offset == 0}
             nextDisabled={!hasNext}
-            onPrev={() => setOffset(prev => Js.Math.max_int(0, prev - disputesFetchLimit))}
+            onPrev={() => setOffset(prev => Math.Int.max(0, prev - disputesFetchLimit))}
             onNext={() => setOffset(prev => prev + disputesFetchLimit)}
           />}
           defaultColumns={DisputesEntity.defaultColumns}

--- a/src/screens/Transaction/Disputes/DisputesHelper.res
+++ b/src/screens/Transaction/Disputes/DisputesHelper.res
@@ -1,40 +1,5 @@
 open Typography
 
-module PrevNextPagination = {
-  @react.component
-  let make = (~isLoading, ~hasData, ~prevDisabled, ~nextDisabled, ~onPrev, ~onNext) => {
-    let getButtonState = (disabled): Button.buttonState =>
-      disabled || isLoading ? Button.Disabled : Button.Normal
-
-    <RenderIf condition=hasData>
-      <div className="flex flex-row justify-end items-center gap-2 py-4">
-        <Button
-          leftIcon={FontAwesome("chevron-left")}
-          buttonType=Secondary
-          buttonSize=Small
-          buttonState={getButtonState(prevDisabled)}
-          customButtonStyle="!w-8 !px-0"
-          customIconMargin=""
-          showTooltip=true
-          tooltipText="Previous page"
-          onClick={_ => onPrev()}
-        />
-        <Button
-          leftIcon={FontAwesome("chevron-right")}
-          buttonType=Secondary
-          buttonSize=Small
-          buttonState={getButtonState(nextDisabled)}
-          customButtonStyle="!w-8 !px-0"
-          customIconMargin=""
-          showTooltip=true
-          tooltipText="Next page"
-          onClick={_ => onNext()}
-        />
-      </div>
-    </RenderIf>
-  }
-}
-
 module DualRefundsAlert = {
   @react.component
   let make = (~subText, ~customLearnMoreComponent=React.null) => {

--- a/src/screens/Transaction/Disputes/DisputesHelper.res
+++ b/src/screens/Transaction/Disputes/DisputesHelper.res
@@ -1,5 +1,40 @@
 open Typography
 
+module PrevNextPagination = {
+  @react.component
+  let make = (~isLoading, ~hasData, ~prevDisabled, ~nextDisabled, ~onPrev, ~onNext) => {
+    let getButtonState = (disabled): Button.buttonState =>
+      disabled || isLoading ? Button.Disabled : Button.Normal
+
+    <RenderIf condition=hasData>
+      <div className="flex flex-row justify-end items-center gap-2 py-4">
+        <Button
+          leftIcon={FontAwesome("chevron-left")}
+          buttonType=Secondary
+          buttonSize=Small
+          buttonState={getButtonState(prevDisabled)}
+          customButtonStyle="!w-8 !px-0"
+          customIconMargin=""
+          showTooltip=true
+          tooltipText="Previous page"
+          onClick={_ => onPrev()}
+        />
+        <Button
+          leftIcon={FontAwesome("chevron-right")}
+          buttonType=Secondary
+          buttonSize=Small
+          buttonState={getButtonState(nextDisabled)}
+          customButtonStyle="!w-8 !px-0"
+          customIconMargin=""
+          showTooltip=true
+          tooltipText="Next page"
+          onClick={_ => onNext()}
+        />
+      </div>
+    </RenderIf>
+  }
+}
+
 module DualRefundsAlert = {
   @react.component
   let make = (~subText, ~customLearnMoreComponent=React.null) => {

--- a/src/screens/Transaction/Disputes/DisputesUtils.res
+++ b/src/screens/Transaction/Disputes/DisputesUtils.res
@@ -1,5 +1,9 @@
 open DisputeTypes
 open LogicUtils
+
+// Page size for server-side pagination; backend allows limit between 1 and 100
+let disputesFetchLimit = 20
+
 let disputeStatusVariantMapper = status => {
   switch status {
   | "dispute_opened" => DisputeOpened


### PR DESCRIPTION
Closes #5444

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Backend PR [juspay/hyperswitch#13684](https://github.com/juspay/hyperswitch/pull/13684) added hard validation on list pagination params: `limit` must be 1–100 (out-of-range is a deserialization error, not a clamp) and `offset` caps at 20,000. The dashboard's Disputes screen fetched the whole list in one request with a hardcoded `limit=10000` and paginated client-side, so every load 400s against a backend containing that change.

This PR replaces the fetch-everything approach with **server-side pagination** on the Disputes screen, and cleans up the two other oversized hardcoded limits (both currently unreachable, fixed defensively).

**Exact changes:**

- `src/screens/Transaction/Disputes/Disputes.res`
  - The list fetch now appends `limit=20&offset=N` to the filter query params and refetches whenever the offset, filters, or search text change.
  - Added a `hasNext` flag: a full page (20 rows) means a next page may exist; a short page means the end was reached. No totals are fabricated — `disputes/list` returns a bare array with no `total_count`.
  - The table's built-in paginator and results-per-page selector are hidden (`showPagination=false`, `showResultsPerPageSelector=false`); instead, previous/next chevron buttons render via the table's `bottomActions` slot — the same pattern the Recon Engine screens use for cursor pagination.
  - Previous is enabled when `offset > 0`; Next when the last page was full. Both disable while loading and hide when there is no data.
  - Landing past the end of the list (e.g. clicking Next when the list ends exactly on a page boundary) steps back to the previous page automatically.
- `src/screens/Transaction/Disputes/DisputesHelper.res`
  - New `PrevNextPagination` component — a generic equivalent of `ReconEngineCursorPaginationButtons` (same button styling and tooltips) driven by `prevDisabled`/`nextDisabled` props instead of API cursors.
- `src/screens/Transaction/Disputes/DisputesUtils.res`
  - Added `disputesFetchLimit = 20` constant (backend allows 1–100).
- `src/APIUtils/APIUtils.res`
  - Disputes GET arms with query params no longer hardcode any limit — the screen supplies `limit`/`offset`. The no-query-params fallback arms went from `limit=10000` to `limit=100`.
  - `payouts/profile/list?limit=10000` → `limit=100`. Dead code — the Payouts screen already paginates server-side via POST body (`limit: 20` + `offset`) and the only GET caller passes a payout id — but fixed so it cannot 400 if a caller is ever added.
  - Unused `customers/list?limit=500` fallback → `limit=100` (both live customer screens always pass explicit `limit=20` query params).

**Not included (possible follow-up):** a `DisputeListResponse { count, total_count, data }` envelope on the backend (refunds pattern) would enable exact totals and numbered page controls; until then previous/next is the honest UX for this API shape. The `disputes/aggregate` endpoint cannot supply totals either — it only accepts a time range, so its counts ignore status/connector/currency filters.

<img width="2217" height="1368" alt="Screenshot 2026-08-21 at 6 03 38 PM" src="https://github.com/user-attachments/assets/9f17469c-8242-4e46-9ef1-8ebd4b4c9e7d" />



## Motivation and Context

Without this change, the Disputes screen is fully broken (HTTP 400 `"list limit 10000 is invalid, it must be between 1 and 100"` on every load) the moment sandbox/production deploys a router build containing juspay/hyperswitch#13684. The disputes list API has supported `limit`/`offset` since juspay/hyperswitch#5637 (Sep 2024), so no backend change is needed. As a bonus, the screen no longer pulls up to 10,000 rows on every load.

## How did you test it?

Ran the dashboard locally against a live backend during development — the paginated fetch flow (`limit=20&offset=N` in the query string) loads the Disputes list correctly.

Verification checklist:

- [x] Disputes screen loads; the list request carries `limit=20&offset=0` and returns 200.
- [ ] Next fetches the following page (`offset=20`); Previous returns to the prior page; buttons disable while a page is loading.
- [ ] Previous is disabled on the first page; Next is disabled when a short (<20 rows) page is returned.
- [ ] Changing filters / date range resets to the first page (offset reset via `RemoteTableFilters`).
- [ ] Search by dispute id works (search params combine with `limit`/`offset` in the query string).
- [ ] Payouts and Customers screens unaffected (their list flows already send limits ≤ 100).
