### PR TITLE
fix: auto-select ingestion config in pipelines upload modal when only one exists

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesUploadModal.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesComponents/ReconEnginePipelinesUploadModal.res
@@ -304,6 +304,10 @@ module UploadModalBody = {
         setConfigsLoading(_ => true)
         let configs = await getIngestionConfigs(~queryParameters=Some(`account_id=${accountId}`))
         setIngestionConfigs(_ => configs)
+        switch configs->Array.filter(isManualIngestionConfig) {
+        | [singleConfig] => setSelectedIngestionId(_ => singleConfig.ingestion_id)
+        | _ => ()
+        }
       } catch {
       | _ => setIngestionConfigs(_ => [])
       }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

In the Recon Engine Pipelines upload modal, when the selected account has exactly one manual ingestion config, it is now selected by default after the configs are fetched. The user no longer has to open the dropdown and pick the only available option. Behavior for zero or multiple configs is unchanged.

## Motivation and Context

Closes #5446

When an account has only one ingestion config, forcing the user to manually select it is an unnecessary extra step in the upload flow.

## How did you test it?

Tested manually on the Pipelines page — selecting an account with a single manual ingestion config auto-selects it and unlocks the file dropzone; accounts with multiple configs still require manual selection.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
