### PR TITLE
fix: send profile connector list and customer list to the OLAP endpoint

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -332,7 +332,7 @@ let useGetURL = () => {
             | #Organization
             | #Merchant
             | #Profile =>
-              Default(`account/${merchantId}/profile/connectors`)
+              Olap(`account/${merchantId}/profile/connectors`)
             }
           }
         | Post | Delete =>

--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -299,8 +299,8 @@ let useGetURL = () => {
           | Some(customerId) => Default(`customers/${customerId}`)
           | None =>
             switch queryParameters {
-            | Some(queryParams) => Default(`customers/list_with_count?${queryParams}`)
-            | None => Default(`customers/list_with_count`)
+            | Some(queryParams) => Olap(`customers/list_with_count?${queryParams}`)
+            | None => Olap(`customers/list_with_count`)
             }
           }
         | _ => Default("")


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two reads that the OLAP deployment serves were still classified as `Default(...)`, so they kept resolving to the default API path. Wraps both in `Olap(...)`:

```diff
- Default(`account/${merchantId}/profile/connectors`)
+ Olap(`account/${merchantId}/profile/connectors`)

- Default(`customers/list_with_count?${queryParams}`)
- Default(`customers/list_with_count`)
+ Olap(`customers/list_with_count?${queryParams}`)
+ Olap(`customers/list_with_count`)
```

Follow-up to #5419, which introduced the `Olap`/`Default` split. While `olap_prefix` is empty (the default everywhere today) both are a no-op — the URLs are byte-identical.

## Motivation and Context

**1. Profile connector list.** The sibling route in the *same* router scope is already wrapped:

```rust
// crates/router/src/routes/app.rs
#[cfg(feature = "olap")]
impl ProfileNew {
    web::scope("/account/{account_id}/profile")
        .service(web::resource("").route(web::get().to(profiles::profiles_list_at_profile_level)))   // → Olap(`account/{mid}/profile`) ✅
        .service(web::resource("/connectors").route(web::get().to(admin::connector_list_profile)))   // → was Default(...) ❌
```

Both are `#[cfg(feature = "olap")]`-gated, both are on the allowlist, and one of them was missed. #5419 shipped 42 `Olap(...)` leaves against an intended count of 43; this is the missing one.

**2. Customers `list_with_count`.** `GET customers/list` is already `Olap(...)`, but its sibling `GET customers/list_with_count` was not — even though the two are registered in the same `#[cfg(feature = "olap")]` block of the `/customers` scope (`app.rs`, both the v1 and v2 scopes):

```rust
#[cfg(feature = "olap")]
{
    route = route
        .service(web::resource("/list").route(web::get().to(customers::customers_list)))            // → Olap(...) ✅
        .service(web::resource("/list_with_count")
            .route(web::get().to(customers::customers_list_with_count)));                           // → was Default(...) ❌
}
```

An OLTP-only build does not compile that route in at all. The practical effect today is that the two customers screens split across paths: `Customers.res` (`V1(CUSTOMERS)`) resolves through `olap_prefix`, while `CustomerV2.res` (`V1(CUSTOMERS_COUNT)`) — the paginated list that actually backs the Customers page — kept going to the default path.



## How did you test it?

`npm run re:build` (clean, 520/520) and `npx rescript format -check`. Verified via the network tab that the connectors and customers calls are unchanged with `olap_prefix` empty.

Once infra confirms the strings, the behavioural check is: set `olap_prefix`, then

- load the Connectors screen → `account/{mid}/profile/connectors` goes out under the OLAP path, while connector create/update/verify stay on the default path;
- load the Customers screen → `customers/list_with_count` goes out under the OLAP path, while opening a single customer (`customers/{id}`) stays on the default path.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

No backend code change, but see the two infra allowlist questions above.

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Bs6crYFf1KspBh7sD9qkQ
