### PR TITLE
feat: support regex transformation rule on recon datetime fields

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -421,6 +421,8 @@ let describeDateTimeTransformationRule = (rule: dateTimeTransformationRule): str
   switch rule {
   | DateTimeTrim => "Trim"
   | DateTimeJsonExtract(pointer) => `JSON extract (${pointer})`
+  | DateTimeRegex({pattern, group}) =>
+    `Regex (${pattern}${group->mapOptionOrDefault("", g => `, group ${g->Int.toString}`)})`
   | UnknownDateTimeTransformationRule => "Unknown rule"
   }
 

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -426,6 +426,7 @@ type majorUnitTransformationRule =
 type dateTimeTransformationRule =
   | DateTimeTrim
   | DateTimeJsonExtract(string)
+  | DateTimeRegex({pattern: string, group: option<int>})
   | UnknownDateTimeTransformationRule
 
 type enumTransformationRule =

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -746,6 +746,8 @@ let dateTimeTransformationRuleMapper = (dict): dateTimeTransformationRule => {
   switch dict->getString("transformation_rule_type", "") {
   | "trim" => DateTimeTrim
   | "json_extract" => DateTimeJsonExtract(dict->getString("pointer", ""))
+  | "regex" =>
+    DateTimeRegex({pattern: dict->getString("pattern", ""), group: dict->getOptionInt("group")})
   | _ => UnknownDateTimeTransformationRule
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Teaches the control center to parse and describe the `regex` transformation rule that [juspay/hyperswitch-recon#599](https://github.com/juspay/hyperswitch-recon/pull/599) added to the `date_time` datatype in `metadata_schema`.

The rule is **pre-parse** — it lives in `transformation_rules` and slices a datetime out of a larger string (e.g. pulling `22/06/2026` out of `Totals for Payment on 22/06/2026`) before the value is parsed against the configured `date_time_format`. It slices, it does not reformat.

Because the backend's `EffectiveAtFieldConfigV2` reuses `DateTimeTransformationRule` directly, the rule is available on both the `effective_at` main field and any metadata field with `field_type: "date_time"`. Both surfaces (`fieldRulesForMainField`'s `"effective_at"` branch and `fieldRulesForMetadataField`'s `"date_time"` branch) already share `dateTimeTransformationRuleMapper`, so a single mapper branch covers both — matching how the backend handled it.

This mirrors the `StrRegex` rule that already exists on the string datatype, across all three layers:

| Layer | File | Change |
| --- | --- | --- |
| Type | `ReconEngineTypes.res` | `DateTimeRegex({pattern: string, group: option<int>})` |
| Mapper | `ReconEngineUtils.res` | `\| "regex" => DateTimeRegex({...})`, `group` decoded with `getOptionInt` so absent/`null` stays `None` |
| Display | `ReconEnginePipelinesUtils.res` | `` `Regex (${pattern}, group N)` ``, group suffix dropped when `None` |

The catch-all `UnknownDateTimeTransformationRule` branch is retained, so an unrecognised future `transformation_rule_type` still degrades to the "Unknown rule" chip rather than breaking the panel.

The control center is a read-only consumer of the metadata schema — nothing in `src/` serialises transformation rules back to the API — so there is no authoring UI and no client-side regex validation in scope. The backend rejects a malformed pattern (`RegexCompileFailed`) or an out-of-range capture group (`RegexGroupOutOfRange`) at schema-save time.

**Before:** a schema using the new rule rendered the literal chip **"Unknown rule"**.
**After:** it renders `Regex (Totals for Payment on (\d{2}/\d{2}/\d{4}), group 1)`.

## Motivation and Context

Closes #5374.

The backend shipped the rule in juspay/hyperswitch-recon#599 (merged). Until the FE knows the `regex` tag, any datetime rule it doesn't recognise falls through to `UnknownDateTimeTransformationRule` and the pipeline details schema panel displays a schema that is actually valid as **"Unknown rule"** — misleading for anyone reading the transformations row to understand how a column is being parsed.

Originating issue: juspay/hyperswitch-control-center-cloud#436.

## How did you test it?

`npm run re:build` is clean with no new ReScript warnings, and `rescript format -check` passes on all three files.

Behaviour was verified by driving the compiled output — `fieldRulesForMainField` / `fieldRulesForMetadataField` → `describeFieldRules` → the chip strings rendered by `ReconEnginePipelinesHelper.FieldRow` — with the exact wire payloads from the backend PR:

| # | Input | `transform` chips | `postParse` chips |
| --- | --- | --- | --- |
| 1 | `effective_at`, `trim` + `regex` (group 1) | `Trim`, `Regex (Totals for Payment on (\d{2}/\d{2}/\d{4}), group 1)` | — |
| 2 | metadata `date_time`, `regex` (group 1) | `Regex (Totals for Payment on (\d{2}/\d{2}/\d{4}), group 1)` | — |
| 3 | `regex`, `group` omitted | `Regex (\d{2}/\d{2}/\d{4})` | — |
| 4 | `regex`, `group: null` | `Regex (\d{4}-\d{2}-\d{2})` | — |
| 5 | `trim` + `json_extract` + all post-parse rules | `Trim`, `JSON extract (/a/b)` | `Truncate (Start Of Day)`, `Add 5 hours`, `Subtract 30 minutes` |
| 6 | unrecognised `transformation_rule_type` | `Unknown rule` | — |
| 7 | `effective_at`, long 90-char pattern | full pattern rendered, no truncation | — |

Covers every acceptance criterion on #5374: both surfaces render the rule, `group` omitted and `group: null` both drop the suffix, existing `trim` / `json_extract` / post-parse rules are unchanged, and the unknown-rule fallback still works. Case 7 confirms long patterns wrap rather than overflow — the chip already carries `break-words` (`ReconEnginePipelinesHelper.res:64`), unchanged by this PR.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

Recon Engine → Pipelines → any pipeline → details page → schema panel, on a transformation config whose `metadata_schema` uses the new rule. Requires a backend carrying juspay/hyperswitch-recon#599.

## Backend Dependency

- [x] Yes
- [ ] No

Backend PR URL: https://github.com/juspay/hyperswitch-recon/pull/599 (merged)

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): none added or changed. The affected screen already sits behind the existing `dev_recon_engine_v1` flag.

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

There is no ReScript unit-test harness in this repo and no metadata schema fixture to extend, so the mapper and display string were exercised against the compiled output as described above rather than in a committed test.

Before:

<img width="975" height="99" alt="Screenshot 2026-08-26 at 7 58 49 PM" src="https://github.com/user-attachments/assets/ce0333bf-ace8-4534-a166-c600caf2c25a" />

After:

<img width="936" height="117" alt="Screenshot 2026-08-26 at 7 59 53 PM" src="https://github.com/user-attachments/assets/6b83ed77-7c03-4105-9a8f-d7c35bc3ffeb" />

