### PR TITLE
feat: deep-link cut-over routing to the Decision Engine with the profile's connectors

### DIFF
--- a/src/libraries/Document.res
+++ b/src/libraries/Document.res
@@ -7,8 +7,6 @@ type document = {querySelectorAll: string => array<domElement>}
 external querySelector: string => Nullable.t<domElement> = "querySelector"
 @val @scope("document")
 external activeElement: Dom.element = "activeElement"
-@val @scope("document")
-external visibilityState: string = "visibilityState"
 
 @send external click: (domElement, unit) => unit = "click"
 @get external offsetWidth: Dom.element => int = "offsetWidth"

--- a/src/libraries/Document.res
+++ b/src/libraries/Document.res
@@ -7,6 +7,8 @@ type document = {querySelectorAll: string => array<domElement>}
 external querySelector: string => Nullable.t<domElement> = "querySelector"
 @val @scope("document")
 external activeElement: Dom.element = "activeElement"
+@val @scope("document")
+external visibilityState: string = "visibilityState"
 
 @send external click: (domElement, unit) => unit = "click"
 @get external offsetWidth: Dom.element => int = "offsetWidth"

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -81,7 +81,13 @@ module ActionButtons = {
 
 module ActiveSection = {
   @react.component
-  let make = (~activeRouting, ~activeRoutingId, ~onRedirectBaseUrl, ~isCutover=false) => {
+  let make = (
+    ~activeRouting,
+    ~activeRoutingId,
+    ~onRedirectBaseUrl,
+    ~isCutover=false,
+    ~onDecisionEngineRedirect=_ => (),
+  ) => {
     open LogicUtils
     let {profileId: currentprofileId} = React.useContext(
       UserInfoProvider.defaultContext,
@@ -131,21 +137,29 @@ module ActiveSection = {
           customButtonStyle="w-4/3"
           buttonSize={Small}
           onClick={_ => {
-            switch activeRoutingType {
-            | DEFAULTFALLBACK =>
-              RescriptReactRouter.push(
-                GlobalVars.appendDashboardPath(
-                  ~url=`/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`,
-                ),
-              )
-            | _ =>
-              RescriptReactRouter.push(
-                GlobalVars.appendDashboardPath(
-                  ~url=`/${onRedirectBaseUrl}/${routingTypeName(
-                      activeRoutingType,
-                    )}?id=${activeRoutingId}&isActive=true`,
-                ),
-              )
+            let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
+
+            // Cut-over profiles manage the active rule in the Decision Engine, so deep-link there.
+            // Default Fallback has no DE page (empty target) and keeps the local Hyperswitch flow.
+            if isCutover && decisionEngineTarget->isNonEmptyString {
+              onDecisionEngineRedirect(decisionEngineTarget)
+            } else {
+              switch activeRoutingType {
+              | DEFAULTFALLBACK =>
+                RescriptReactRouter.push(
+                  GlobalVars.appendDashboardPath(
+                    ~url=`/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`,
+                  ),
+                )
+              | _ =>
+                RescriptReactRouter.push(
+                  GlobalVars.appendDashboardPath(
+                    ~url=`/${onRedirectBaseUrl}/${routingTypeName(
+                        activeRoutingType,
+                      )}?id=${activeRoutingId}&isActive=true`,
+                  ),
+                )
+              }
             }
           }}
         />
@@ -201,7 +215,7 @@ module LevelWiseRoutingSection = {
 }
 
 @react.component
-let make = (~routingType: array<JSON.t>, ~isCutover=false) => {
+let make = (~routingType: array<JSON.t>, ~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
   let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let debitRoutingValue =
     (
@@ -220,6 +234,7 @@ let make = (~routingType: array<JSON.t>, ~isCutover=false) => {
         activeRoutingId={id}
         onRedirectBaseUrl="routing"
         isCutover
+        onDecisionEngineRedirect
       />
     })
     ->React.array}

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -139,8 +139,6 @@ module ActiveSection = {
           onClick={_ => {
             let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
 
-            // Cut-over profiles manage the active rule in the Decision Engine, so deep-link there.
-            // Default Fallback has no DE page (empty target) and keeps the local Hyperswitch flow.
             if isCutover && decisionEngineTarget->isNonEmptyString {
               onDecisionEngineRedirect(decisionEngineTarget, activeRoutingId)
             } else {

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -139,8 +139,13 @@ module ActiveSection = {
           onClick={_ => {
             let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
 
+            let ruleId = switch activeRoutingType {
+            | ADVANCED | VOLUME_SPLIT => activeRoutingId
+            | _ => ""
+            }
+
             if isCutover && decisionEngineTarget->isNonEmptyString {
-              onDecisionEngineRedirect(decisionEngineTarget, activeRoutingId)
+              onDecisionEngineRedirect(decisionEngineTarget, ruleId)
             } else {
               switch activeRoutingType {
               | DEFAULTFALLBACK =>

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -107,6 +107,32 @@ module ActiveSection = {
       activeRouting->getDictFromJsonObject->getString("profile_id", "")
     }
 
+    let activeRuleTypeUrl = `/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`
+
+    let handleViewAndManage = _ => {
+      let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
+
+      let ruleId = switch activeRoutingType {
+      | ADVANCED | VOLUME_SPLIT => activeRoutingId
+      | _ => ""
+      }
+
+      if isCutover && decisionEngineTarget->isNonEmptyString {
+        onDecisionEngineRedirect(decisionEngineTarget, ruleId)
+      } else {
+        switch activeRoutingType {
+        | DEFAULTFALLBACK =>
+          RescriptReactRouter.push(GlobalVars.appendDashboardPath(~url=activeRuleTypeUrl))
+        | _ =>
+          RescriptReactRouter.push(
+            GlobalVars.appendDashboardPath(
+              ~url=`${activeRuleTypeUrl}?id=${activeRoutingId}&isActive=true`,
+            ),
+          )
+        }
+      }
+    }
+
     <div className="flex flex-1">
       <div className="relative flex flex-1 flex-col bg-white border rounded-lg p-4 pt-10 gap-8">
         <div className=" flex flex-1 flex-col gap-7">
@@ -136,35 +162,7 @@ module ActiveSection = {
           buttonType=Secondary
           customButtonStyle="w-4/3"
           buttonSize={Small}
-          onClick={_ => {
-            let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
-
-            let ruleId = switch activeRoutingType {
-            | ADVANCED | VOLUME_SPLIT => activeRoutingId
-            | _ => ""
-            }
-
-            if isCutover && decisionEngineTarget->isNonEmptyString {
-              onDecisionEngineRedirect(decisionEngineTarget, ruleId)
-            } else {
-              switch activeRoutingType {
-              | DEFAULTFALLBACK =>
-                RescriptReactRouter.push(
-                  GlobalVars.appendDashboardPath(
-                    ~url=`/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`,
-                  ),
-                )
-              | _ =>
-                RescriptReactRouter.push(
-                  GlobalVars.appendDashboardPath(
-                    ~url=`/${onRedirectBaseUrl}/${routingTypeName(
-                        activeRoutingType,
-                      )}?id=${activeRoutingId}&isActive=true`,
-                  ),
-                )
-              }
-            }
-          }}
+          onClick=handleViewAndManage
         />
       </div>
     </div>

--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -29,7 +29,7 @@ module ActionButtons = {
     ~routeType: routingType,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDecisionEngineRedirect=_ => (),
+    ~onDecisionEngineRedirect=(_, _) => (),
   ) => {
     let mixpanelEvent = MixpanelHook.useSendEvent()
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
@@ -46,7 +46,7 @@ module ActionButtons = {
         buttonSize=Small
         onClick={_ => {
           if isCutover {
-            onDecisionEngineRedirect(routeType->decisionEngineRoutingTarget)
+            onDecisionEngineRedirect(routeType->decisionEngineRoutingTarget, "")
           } else {
             RescriptReactRouter.push(
               GlobalVars.appendDashboardPath(
@@ -86,7 +86,7 @@ module ActiveSection = {
     ~activeRoutingId,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDecisionEngineRedirect=_ => (),
+    ~onDecisionEngineRedirect=(_, _) => (),
   ) => {
     open LogicUtils
     let {profileId: currentprofileId} = React.useContext(
@@ -142,7 +142,7 @@ module ActiveSection = {
             // Cut-over profiles manage the active rule in the Decision Engine, so deep-link there.
             // Default Fallback has no DE page (empty target) and keeps the local Hyperswitch flow.
             if isCutover && decisionEngineTarget->isNonEmptyString {
-              onDecisionEngineRedirect(decisionEngineTarget)
+              onDecisionEngineRedirect(decisionEngineTarget, activeRoutingId)
             } else {
               switch activeRoutingType {
               | DEFAULTFALLBACK =>
@@ -174,7 +174,7 @@ module LevelWiseRoutingSection = {
     ~types: array<routingType>,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDecisionEngineRedirect=_ => (),
+    ~onDecisionEngineRedirect=(_, _) => (),
   ) => {
     let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let renderCard = (value, key) =>
@@ -215,7 +215,11 @@ module LevelWiseRoutingSection = {
 }
 
 @react.component
-let make = (~routingType: array<JSON.t>, ~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
+let make = (
+  ~routingType: array<JSON.t>,
+  ~isCutover=false,
+  ~onDecisionEngineRedirect=(_, _) => (),
+) => {
   let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let debitRoutingValue =
     (

--- a/src/screens/Routing/DebitRouting/DebitRouting.res
+++ b/src/screens/Routing/DebitRouting/DebitRouting.res
@@ -1,5 +1,5 @@
 @react.component
-let make = (~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
+let make = (~isCutover=false, ~onDecisionEngineRedirect=(_, _) => ()) => {
   open Typography
   let (showLeastCostModal, setShowLeastCostModal) = React.useState(_ => false)
   let (showManageModal, setShowManageModal) = React.useState(_ => false)
@@ -11,7 +11,7 @@ let make = (~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
     ).is_debit_routing_enabled->Option.getOr(false)
   let handleButtonClick = _ => {
     if isCutover {
-      onDecisionEngineRedirect("debit")
+      onDecisionEngineRedirect("debit", "")
     } else if debitRoutingValue {
       setShowManageModal(_ => true)
     } else {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -7,7 +7,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let url = RescriptReactRouter.useUrl()
   let pathVar = url.path->List.toArray->Array.joinWith("/")
 
-  let refreshing = React.useRef(false)
   let (records, setRecords) = React.useState(_ => [])
   let (activeRoutingIds, setActiveRoutingIds) = React.useState(_ => [])
   let (routingType, setRoutingType) = React.useState(_ => [])
@@ -83,11 +82,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
       : baseTabs
   }, (routingType, debitRoutingValue, isCutover, connectorList, profileId))
 
-  let fetchRoutingRecords = async (activeIds, ~showLoader) => {
+  let fetchRoutingRecords = async activeIds => {
     try {
-      if showLoader {
-        setScreenState(_ => PageLoaderWrapper.Loading)
-      }
+      setScreenState(_ => PageLoaderWrapper.Loading)
       let routingUrl = `${getURL(~entityName=V1(ROUTING), ~methodType=Get)}?limit=100`
       let routingJson = await fetchDetails(routingUrl)
       let configuredRules = routingJson->RoutingUtils.getRecordsObject
@@ -121,12 +118,10 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
-  let fetchActiveRouting = async (~showLoader=true) => {
+  let fetchActiveRouting = async () => {
     open LogicUtils
     try {
-      if showLoader {
-        setScreenState(_ => PageLoaderWrapper.Loading)
-      }
+      setScreenState(_ => PageLoaderWrapper.Loading)
       let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
       let routingJson = await fetchDetails(activeRoutingUrl)
 
@@ -138,21 +133,19 @@ let make = (~remainingPath, ~previewOnly=false) => {
           let id = ele->getDictFromJsonObject->getString("id", "")
           currentActiveIds->Array.push(id)
         })
-        await fetchRoutingRecords(currentActiveIds, ~showLoader)
+        await fetchRoutingRecords(currentActiveIds)
         setActiveRoutingIds(_ => currentActiveIds)
         setRoutingType(_ => routingArr)
       } else {
-        await fetchRoutingRecords([], ~showLoader)
+        await fetchRoutingRecords([])
         let defaultFallback = [("kind", "default"->JSON.Encode.string)]->Dict.fromArray
         setRoutingType(_ => [defaultFallback->JSON.Encode.object])
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     } catch {
     | Exn.Error(e) =>
-      if showLoader {
-        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-        setScreenState(_ => PageLoaderWrapper.Error(err))
-      }
+      let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
+      setScreenState(_ => PageLoaderWrapper.Error(err))
     }
   }
 
@@ -161,23 +154,31 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
-  React.useEffect(() => {
-    let refresh = _ =>
-      if Document.visibilityState === "visible" && !refreshing.current {
-        refreshing.current = true
-        fetchActiveRouting(~showLoader=false)
-        ->Promise.finally(() => refreshing.current = false)
-        ->ignore
-      }
+  let refreshActiveRouting = async () => {
+    open LogicUtils
+    try {
+      let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
+      let routingJson = await fetchDetails(activeRoutingUrl)
+      let routingArr = routingJson->getArrayFromJson([])
 
-    Window.addEventListener("visibilitychange", refresh)
-    Window.addEventListener("focus", refresh)
-    Some(
-      () => {
-        Window.removeEventListener("visibilitychange", refresh)
-        Window.removeEventListener("focus", refresh)
-      },
-    )
+      if routingArr->Array.length > 0 {
+        setActiveRoutingIds(_ =>
+          routingArr->Array.map(ele => ele->getDictFromJsonObject->getString("id", ""))
+        )
+        setRoutingType(_ => routingArr)
+      } else {
+        let defaultFallback = [("kind", "default"->JSON.Encode.string)]->getJsonFromArrayOfJson
+        setRoutingType(_ => [defaultFallback])
+      }
+    } catch {
+    | Exn.Error(_) => ()
+    }
+  }
+
+  React.useEffect(() => {
+    let onFocus = _ => refreshActiveRouting()->ignore
+    Window.addEventListener("focus", onFocus)
+    Some(() => Window.removeEventListener("focus", onFocus))
   }, (pathVar, url.search, debitRoutingValue))
 
   let checkRoutingEntry = async () => {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -161,7 +161,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
       let routingJson = await fetchDetails(activeRoutingUrl)
       let routingArr = routingJson->getArrayFromJson([])
 
-      if routingArr->Array.length > 0 {
+      if routingArr->isNonEmptyArray {
         setActiveRoutingIds(_ =>
           routingArr->Array.map(ele => ele->getDictFromJsonObject->getString("id", ""))
         )

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -28,21 +28,18 @@ let make = (~remainingPath, ~previewOnly=false) => {
   }, [previewOnly])
 
   let connectorList = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
-  let connectorFragment = React.useMemo(
-    () => connectorList->RoutingUtils.decisionEngineConnectorFragment(~profileId),
-    (connectorList, profileId),
-  )
 
   // Hyperswitch mints the deep-link but knows nothing about what DE needs to render, so append the
   // profile's connectors ourselves before opening the tab. See RoutingUtils for why it's a fragment.
-  let openDecisionEngineRoutingPage = async target => {
+  let openDecisionEngineRoutingPage = async (target, ruleId) => {
     open LogicUtils
     try {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
       let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
       let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
       if redirectUrl->isNonEmptyString {
-        `${redirectUrl}${connectorFragment}`->Window._open
+        let handoff = connectorList->RoutingUtils.decisionEngineHandoffFragment(~profileId, ~ruleId)
+        `${redirectUrl}${handoff}`->Window._open
       }
     } catch {
     | Exn.Error(_) =>
@@ -63,7 +60,8 @@ let make = (~remainingPath, ~previewOnly=false) => {
           <ActiveRouting
             routingType
             isCutover
-            onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
+            onDecisionEngineRedirect={(target, ruleId) =>
+              openDecisionEngineRoutingPage(target, ruleId)->ignore}
           />,
       },
     ]
@@ -84,7 +82,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutover))
+    // connectorList is a dep because the Active configuration tab's redirect closure reads it to
+    // build the hand-off; without it a list that arrives late would be captured as empty.
+  }, (routingType, debitRoutingValue, isCutover, connectorList))
 
   let fetchRoutingRecords = async activeIds => {
     try {
@@ -193,7 +193,8 @@ let make = (~remainingPath, ~previewOnly=false) => {
           types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
           onRedirectBaseUrl="routing"
           isCutover
-          onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
+          onDecisionEngineRedirect={(target, ruleId) =>
+            openDecisionEngineRoutingPage(target, ruleId)->ignore}
         />
       </div>
       <RenderIf condition={!previewOnly}>

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -29,8 +29,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   let connectorList = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
 
-  // Hyperswitch mints the deep-link but knows nothing about what DE needs to render, so append the
-  // profile's connectors ourselves before opening the tab. See RoutingUtils for why it's a fragment.
   let openDecisionEngineRoutingPage = async (target, ruleId) => {
     open LogicUtils
     try {
@@ -82,8 +80,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-    // connectorList is a dep because the Active configuration tab's redirect closure reads it to
-    // build the hand-off; without it a list that arrives late would be captured as empty.
   }, (routingType, debitRoutingValue, isCutover, connectorList))
 
   let fetchRoutingRecords = async activeIds => {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -118,16 +118,19 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
+  let getActiveRoutingList = async () => {
+    let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
+    let routingJson = await fetchDetails(activeRoutingUrl)
+    routingJson->LogicUtils.getArrayFromJson([])
+  }
+
   let fetchActiveRouting = async () => {
     open LogicUtils
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-      let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
-      let routingJson = await fetchDetails(activeRoutingUrl)
+      let routingArr = await getActiveRoutingList()
 
-      let routingArr = routingJson->getArrayFromJson([])
-
-      if routingArr->Array.length > 0 {
+      if routingArr->isNonEmptyArray {
         let currentActiveIds = []
         routingArr->Array.forEach(ele => {
           let id = ele->getDictFromJsonObject->getString("id", "")
@@ -157,14 +160,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let refreshActiveRouting = async () => {
     open LogicUtils
     try {
-      let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
-      let routingJson = await fetchDetails(activeRoutingUrl)
-      let routingArr = routingJson->getArrayFromJson([])
+      let routingArr = await getActiveRoutingList()
 
       if routingArr->isNonEmptyArray {
-        setActiveRoutingIds(_ =>
-          routingArr->Array.map(ele => ele->getDictFromJsonObject->getString("id", ""))
-        )
         setRoutingType(_ => routingArr)
       } else {
         let defaultFallback = [("kind", "default"->JSON.Encode.string)]->getJsonFromArrayOfJson
@@ -176,10 +174,14 @@ let make = (~remainingPath, ~previewOnly=false) => {
   }
 
   React.useEffect(() => {
-    let onFocus = _ => refreshActiveRouting()->ignore
-    Window.addEventListener("focus", onFocus)
-    Some(() => Window.removeEventListener("focus", onFocus))
-  }, (pathVar, url.search, debitRoutingValue))
+    if isCutover && !previewOnly {
+      let onFocus = _ => refreshActiveRouting()->ignore
+      Window.addEventListener("focus", onFocus)
+      Some(() => Window.removeEventListener("focus", onFocus))
+    } else {
+      None
+    }
+  }, (isCutover, previewOnly, profileId))
 
   let checkRoutingEntry = async () => {
     open LogicUtils

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -27,13 +27,44 @@ let make = (~remainingPath, ~previewOnly=false) => {
     previewOnly ? ("w-full", "mx-auto") : ("w-full", "mx-auto ")
   }, [previewOnly])
 
+  let connectorList = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
+  let connectorFragment = React.useMemo(
+    () => connectorList->RoutingUtils.decisionEngineConnectorFragment(~profileId),
+    (connectorList, profileId),
+  )
+
+  // Hyperswitch mints the deep-link but knows nothing about what DE needs to render, so append the
+  // profile's connectors ourselves before opening the tab. See RoutingUtils for why it's a fragment.
+  let openDecisionEngineRoutingPage = async target => {
+    open LogicUtils
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
+      let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
+      if redirectUrl->isNonEmptyString {
+        `${redirectUrl}${connectorFragment}`->Window._open
+      }
+    } catch {
+    | Exn.Error(_) =>
+      showToast(
+        ~message="Failed to open Decision Engine routing. Please try again.",
+        ~toastType=ToastState.ToastError,
+      )
+    }
+  }
+
   let tabs: array<Tabs.tab> = React.useMemo(() => {
     open Tabs
     let hasWorkflowsManageAccess = userHasAccess(~groupAccess=WorkflowsManage) === Access
     let baseTabs = [
       {
         title: "Active configuration",
-        renderContent: () => <ActiveRouting routingType isCutover />,
+        renderContent: () =>
+          <ActiveRouting
+            routingType
+            isCutover
+            onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
+          />,
       },
     ]
     hasWorkflowsManageAccess
@@ -136,24 +167,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
       setCutoverStatus(_ => Some(cutover))
     } catch {
     | Exn.Error(_) => setCutoverStatus(_ => Some(false))
-    }
-  }
-
-  let openDecisionEngineRoutingPage = async target => {
-    open LogicUtils
-    try {
-      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
-      let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
-      let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
-      if redirectUrl->isNonEmptyString {
-        redirectUrl->Window._open
-      }
-    } catch {
-    | Exn.Error(_) =>
-      showToast(
-        ~message="Failed to open Decision Engine routing. Please try again.",
-        ~toastType=ToastState.ToastError,
-      )
     }
   }
 

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -161,9 +161,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
-  // A cut-over profile is managed in the Decision Engine, which opens in its own tab, so the active
-  // configuration can change while this page sits untouched. Re-read it when the tab comes back to
-  // the foreground, without the loader — the page is already showing usable data.
   React.useEffect(() => {
     let refresh = _ =>
       if Document.visibilityState === "visible" && !refreshing.current {
@@ -173,9 +170,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
         ->ignore
       }
 
-    // Two events, because the two dashboards can be either two tabs or two windows: switching tabs
-    // fires visibilitychange, while side-by-side windows stay "visible" throughout and only fire
-    // focus. The in-flight guard keeps the overlap between them to one request.
     Window.addEventListener("visibilitychange", refresh)
     Window.addEventListener("focus", refresh)
     Some(

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -7,6 +7,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
   let url = RescriptReactRouter.useUrl()
   let pathVar = url.path->List.toArray->Array.joinWith("/")
 
+  let refreshing = React.useRef(false)
   let (records, setRecords) = React.useState(_ => [])
   let (activeRoutingIds, setActiveRoutingIds) = React.useState(_ => [])
   let (routingType, setRoutingType) = React.useState(_ => [])
@@ -82,9 +83,11 @@ let make = (~remainingPath, ~previewOnly=false) => {
       : baseTabs
   }, (routingType, debitRoutingValue, isCutover, connectorList, profileId))
 
-  let fetchRoutingRecords = async activeIds => {
+  let fetchRoutingRecords = async (activeIds, ~showLoader) => {
     try {
-      setScreenState(_ => PageLoaderWrapper.Loading)
+      if showLoader {
+        setScreenState(_ => PageLoaderWrapper.Loading)
+      }
       let routingUrl = `${getURL(~entityName=V1(ROUTING), ~methodType=Get)}?limit=100`
       let routingJson = await fetchDetails(routingUrl)
       let configuredRules = routingJson->RoutingUtils.getRecordsObject
@@ -118,10 +121,12 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
-  let fetchActiveRouting = async () => {
+  let fetchActiveRouting = async (~showLoader=true) => {
     open LogicUtils
     try {
-      setScreenState(_ => PageLoaderWrapper.Loading)
+      if showLoader {
+        setScreenState(_ => PageLoaderWrapper.Loading)
+      }
       let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
       let routingJson = await fetchDetails(activeRoutingUrl)
 
@@ -133,25 +138,52 @@ let make = (~remainingPath, ~previewOnly=false) => {
           let id = ele->getDictFromJsonObject->getString("id", "")
           currentActiveIds->Array.push(id)
         })
-        await fetchRoutingRecords(currentActiveIds)
+        await fetchRoutingRecords(currentActiveIds, ~showLoader)
         setActiveRoutingIds(_ => currentActiveIds)
         setRoutingType(_ => routingArr)
       } else {
-        await fetchRoutingRecords([])
+        await fetchRoutingRecords([], ~showLoader)
         let defaultFallback = [("kind", "default"->JSON.Encode.string)]->Dict.fromArray
         setRoutingType(_ => [defaultFallback->JSON.Encode.object])
         setScreenState(_ => PageLoaderWrapper.Success)
       }
     } catch {
     | Exn.Error(e) =>
-      let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-      setScreenState(_ => PageLoaderWrapper.Error(err))
+      if showLoader {
+        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
+        setScreenState(_ => PageLoaderWrapper.Error(err))
+      }
     }
   }
 
   React.useEffect(() => {
     fetchActiveRouting()->ignore
     None
+  }, (pathVar, url.search, debitRoutingValue))
+
+  // A cut-over profile is managed in the Decision Engine, which opens in its own tab, so the active
+  // configuration can change while this page sits untouched. Re-read it when the tab comes back to
+  // the foreground, without the loader — the page is already showing usable data.
+  React.useEffect(() => {
+    let refresh = _ =>
+      if Document.visibilityState === "visible" && !refreshing.current {
+        refreshing.current = true
+        fetchActiveRouting(~showLoader=false)
+        ->Promise.finally(() => refreshing.current = false)
+        ->ignore
+      }
+
+    // Two events, because the two dashboards can be either two tabs or two windows: switching tabs
+    // fires visibilitychange, while side-by-side windows stay "visible" throughout and only fire
+    // focus. The in-flight guard keeps the overlap between them to one request.
+    Window.addEventListener("visibilitychange", refresh)
+    Window.addEventListener("focus", refresh)
+    Some(
+      () => {
+        Window.removeEventListener("visibilitychange", refresh)
+        Window.removeEventListener("focus", refresh)
+      },
+    )
   }, (pathVar, url.search, debitRoutingValue))
 
   let checkRoutingEntry = async () => {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -80,7 +80,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutover, connectorList))
+  }, (routingType, debitRoutingValue, isCutover, connectorList, profileId))
 
   let fetchRoutingRecords = async activeIds => {
     try {

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -297,7 +297,7 @@ let decisionEngineHandoffFragment = (
     )
 
   let params = []
-  if connectors->Array.length > 0 {
+  if connectors->isNonEmptyArray {
     params->Array.push((
       "connectors",
       connectors->JSON.Encode.array->JSON.stringify->encodeURIComponent,
@@ -307,10 +307,9 @@ let decisionEngineHandoffFragment = (
     params->Array.push(("rule_id", ruleId->encodeURIComponent))
   }
 
-  switch params->Array.length {
-  | 0 => ""
-  | _ => `#${params->Array.map(((key, value)) => `${key}=${value}`)->Array.joinWith("&")}`
-  }
+  params->isEmptyArray
+    ? ""
+    : `#${params->Array.map(((key, value)) => `${key}=${value}`)->Array.joinWith("&")}`
 }
 
 let filterConnectorListJson = (json, ~retainInList) => {

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -291,9 +291,7 @@ let decisionEngineHandoffFragment = (
         ("merchant_connector_id", connector.id->JSON.Encode.string),
         ("connector_name", connector.connector_name->JSON.Encode.string),
         ("connector_label", connector.connector_label->JSON.Encode.string),
-      ]
-      ->Dict.fromArray
-      ->JSON.Encode.object
+      ]->getJsonFromArrayOfJson
     )
 
   let params = []

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -273,13 +273,21 @@ let filterConnectorList = (
   )
 }
 
-// The Decision Engine dashboard has no way to read a profile's connectors: its rule builder only
-// suggests gateways already used in existing DE rules, so a freshly cut-over profile gets an empty
-// list. Hand the profile's enabled connectors over in the deep-link's URL fragment — fragments are
-// never sent to a server, so this stays out of DE's access logs and request-line limits.
-let decisionEngineConnectorFragment = (
+// Everything the Decision Engine needs about this profile but cannot look up for itself, handed
+// over in the deep link's URL fragment. A fragment is never sent to a server, so this stays out of
+// DE's access logs and request-line limits.
+//
+// `connectors`: DE's rule builder only suggests gateways already named in existing DE rules, so a
+// freshly cut-over profile would otherwise be offered the whole connector catalogue instead of the
+// handful the merchant actually has.
+// `rule_id`: Hyperswitch's redirect lands on DE's rule *list*; the id is what lets DE open the one
+// rule the merchant clicked.
+//
+// The two are independent — a profile with no connectors must still hand over its rule id.
+let decisionEngineHandoffFragment = (
   connectorList: array<ConnectorTypes.connectorPayloadCommonType>,
   ~profileId,
+  ~ruleId="",
 ) => {
   let connectors =
     connectorList
@@ -299,9 +307,20 @@ let decisionEngineConnectorFragment = (
       ->JSON.Encode.object
     )
 
-  switch connectors->Array.length {
+  let params = []
+  if connectors->Array.length > 0 {
+    params->Array.push((
+      "connectors",
+      connectors->JSON.Encode.array->JSON.stringify->encodeURIComponent,
+    ))
+  }
+  if ruleId->isNonEmptyString {
+    params->Array.push(("rule_id", ruleId->encodeURIComponent))
+  }
+
+  switch params->Array.length {
   | 0 => ""
-  | _ => `#connectors=${connectors->JSON.Encode.array->JSON.stringify->encodeURIComponent}`
+  | _ => `#${params->Array.map(((key, value)) => `${key}=${value}`)->Array.joinWith("&")}`
   }
 }
 

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -273,6 +273,38 @@ let filterConnectorList = (
   )
 }
 
+// The Decision Engine dashboard has no way to read a profile's connectors: its rule builder only
+// suggests gateways already used in existing DE rules, so a freshly cut-over profile gets an empty
+// list. Hand the profile's enabled connectors over in the deep-link's URL fragment — fragments are
+// never sent to a server, so this stays out of DE's access logs and request-line limits.
+let decisionEngineConnectorFragment = (
+  connectorList: array<ConnectorTypes.connectorPayloadCommonType>,
+  ~profileId,
+) => {
+  let connectors =
+    connectorList
+    ->filterConnectorList(~retainInList=PaymentConnector)
+    ->Array.filter(connector =>
+      connector.profile_id === profileId &&
+      !connector.disabled &&
+      connector.connector_name !== "applepay"
+    )
+    ->Array.map(connector =>
+      [
+        ("merchant_connector_id", connector.id->JSON.Encode.string),
+        ("connector_name", connector.connector_name->JSON.Encode.string),
+        ("connector_label", connector.connector_label->JSON.Encode.string),
+      ]
+      ->Dict.fromArray
+      ->JSON.Encode.object
+    )
+
+  switch connectors->Array.length {
+  | 0 => ""
+  | _ => `#connectors=${connectors->JSON.Encode.array->JSON.stringify->encodeURIComponent}`
+  }
+}
+
 let filterConnectorListJson = (json, ~retainInList) => {
   json
   ->getArrayFromJson([])

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -273,17 +273,6 @@ let filterConnectorList = (
   )
 }
 
-// Everything the Decision Engine needs about this profile but cannot look up for itself, handed
-// over in the deep link's URL fragment. A fragment is never sent to a server, so this stays out of
-// DE's access logs and request-line limits.
-//
-// `connectors`: DE's rule builder only suggests gateways already named in existing DE rules, so a
-// freshly cut-over profile would otherwise be offered the whole connector catalogue instead of the
-// handful the merchant actually has.
-// `rule_id`: Hyperswitch's redirect lands on DE's rule *list*; the id is what lets DE open the one
-// rule the merchant clicked.
-//
-// The two are independent — a profile with no connectors must still hand over its rule id.
 let decisionEngineHandoffFragment = (
   connectorList: array<ConnectorTypes.connectorPayloadCommonType>,
   ~profileId,


### PR DESCRIPTION
## What

Two gaps on a **cut-over** profile, where routing is managed in the Decision Engine rather than Hyperswitch.

**1. "View and Manage" ignored the cut-over.** The Active configuration card always pushed the local Hyperswitch route. `ActiveSection` received `isCutover` (it uses it for the card heading) but was never handed `onDecisionEngineRedirect`, so it had no way to reach DE even though the Setup cards already did.

**2. DE could not see the profile's connectors.** DE's rule builder derives its gateway dropdown from gateways already named in existing DE rules, backed by the full 139-name routable-connector catalogue. A freshly cut-over profile has no DE rules yet, so the merchant was offered 139 connectors with no way to tell which ones they actually have.

**3. The deep link landed on the rule *list*.** Hyperswitch's `redirect_url` targets `routing/rules`, so clicking a specific active rule dropped the merchant somewhere they then had to search.

## How

Hyperswitch mints the deep link, but the control centre is what calls `window.open` on it — so it can append to the URL without any router change. The profile's enabled connectors and the clicked rule's id ride along in a **URL fragment**: fragments are never sent to a server, so this stays out of DE's access logs and request-line limits, and Hyperswitch never sees it.

```
{redirect_url}#connectors=<uri-encoded JSON>&rule_id=<algorithm id>
```

`connectors` and `rule_id` are independent params. The builder's first shape bailed out with `""` for the whole fragment when the connector list was empty — which would have silently swallowed the rule id for exactly the profiles this targets: freshly cut-over ones with nothing configured yet.

The rule id is withheld for Multi Objective and Default Fallback. Their `activeRoutingId` is a Hyperswitch dynamic-routing algorithm id that DE has never seen, and neither has a per-rule page.

`connectorList` joins the `tabs` memo deps because the redirect closure now reads it at click time; a late-arriving list would otherwise be captured as empty.

## Companion PR

DE reads the fragment: juspay/decision-engine#384. Landing this alone is safe — DE ignores a fragment it does not understand.

## Trust boundary

The connector list becomes client-supplied, so DE must treat it as display hints and validate every `merchant_connector_id` before persisting a rule. DE persists through its own API, so that check belongs there regardless.

## Verified

End to end against a local stack, on a real cut-over profile (`pro_1johug2CPVOIS6qOHbnO`) with a migrated rule:

- **View and Manage** returned `http://localhost:5173/routing/rules?code=DE_…` — the DE page, not the local route.
- The fragment carried all three of the profile's connectors, matching `merchant_connector_account` exactly, and correctly dropped a disabled connector, another profile's connector, and a payout processor.
- Two `paypal_test` accounts on the profile differ only by `merchant_connector_id` — the case the id exists for.
- Non-cut-over profiles are untouched: `isCutover` false keeps every local path.

`PayoutCurrentActiveRouting` also renders `ActiveSection`; it passes no `isCutover`, so it defaults to `false` and is unaffected.


<img width="3456" height="2234" alt="Screenshot 2026-08-27 at 16 35 20" src="https://github.com/user-attachments/assets/9ce4f34e-a294-45e8-8bc1-3c6006c2eae0" />

<img width="3456" height="2234" alt="Screenshot 2026-08-27 at 16 36 09" src="https://github.com/user-attachments/assets/3c28a68f-c6c7-4074-bc59-6fa501fa49a9" />

Closes #5471
