### PR TITLE
fix: allow any 3-day window on the webhooks date filter

### DIFF
--- a/src/screens/Developer/Webhooks/WebhooksUtils.res
+++ b/src/screens/Developer/Webhooks/WebhooksUtils.res
@@ -158,17 +158,6 @@ let itemToObjectMapperAttemptsTable: dict<JSON.t> => attemptTable = dict => {
 
 let (startTimeFilterKey, endTimeFilterKey) = ("start_time", "end_time")
 
-let getAllowedDateRange = {
-  let endDate = Date.now()->Js.Date.fromFloat->DateTimeUtils.toUtc->DayJs.getDayJsForJsDate //->Date.toISOString->JSON.Encode.string
-  let startDate = endDate.subtract(3, "day")
-
-  let dateObject: Calendar.dateObj = {
-    startDate: startDate.toString(),
-    endDate: endDate.toString(),
-  }
-  dateObject
-}
-
 let initialFixedFilter = () => [
   (
     {
@@ -197,7 +186,6 @@ let initialFixedFilter = () => [
           ~numMonths=2,
           ~disableApply=false,
           ~dateRangeLimit=3,
-          ~allowedDateRange=getAllowedDateRange,
         ),
         ~inputFields=[],
         ~isRequired=false,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix

## Description

The date filter on the Webhooks page only allowed selecting within the last 3 days — every earlier date was greyed out — when the intent was a 3-day *window* placed anywhere.

`WebhooksUtils.res` was passing two different constraints to the picker:

| prop | maps to | constrains |
|---|---|---|
| `~dateRangeLimit=3` | `maxRangeDays` | the **span** — max 3 days wide |
| `~allowedDateRange=getAllowedDateRange` | `minDate` / `maxDate` | the **position** — pinned to `[today-3, today]` |

This drops the position bound and the now-unused `getAllowedDateRange` helper, leaving `dateRangeLimit=3` to do the work. `maxRangeDays` disables cells more than 3 days from whichever start date is picked, so any 3-day window is now selectable while the width cap still holds.

Net change is 12 deletions in one file. `~disableFutureDates={true}` is untouched, so dates after today remain unselectable.

https://github.com/user-attachments/assets/166b6541-e424-4ec2-b79b-eecf3fdd0f90


## Motivation and Context



## How did you test it?

Tested manually — no test files touched.

- Webhooks page → date filter: confirmed dates outside the last 3 days are now selectable, and that picking a start date disables cells more than 3 days out from it
- Confirmed future dates remain disabled
- Confirmed the preset dropdown is unchanged (presets wider than 3 days are still filtered out by `filterPresetsByLimit`)
- `npm run re:build`, `npm run re:format` and `npm run lint:hooks` all clean


## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
