### PR TITLE
feat: deep-link cut-over routing to the Decision Engine with the profile's connectors

### DIFF
--- a/src/screens/Routing/ActiveRouting.res
+++ b/src/screens/Routing/ActiveRouting.res
@@ -29,7 +29,7 @@ module ActionButtons = {
     ~routeType: routingType,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDecisionEngineRedirect=_ => (),
+    ~onDecisionEngineRedirect=(_, _) => (),
   ) => {
     let mixpanelEvent = MixpanelHook.useSendEvent()
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
@@ -46,7 +46,7 @@ module ActionButtons = {
         buttonSize=Small
         onClick={_ => {
           if isCutover {
-            onDecisionEngineRedirect(routeType->decisionEngineRoutingTarget)
+            onDecisionEngineRedirect(routeType->decisionEngineRoutingTarget, "")
           } else {
             RescriptReactRouter.push(
               GlobalVars.appendDashboardPath(
@@ -81,7 +81,13 @@ module ActionButtons = {
 
 module ActiveSection = {
   @react.component
-  let make = (~activeRouting, ~activeRoutingId, ~onRedirectBaseUrl, ~isCutover=false) => {
+  let make = (
+    ~activeRouting,
+    ~activeRoutingId,
+    ~onRedirectBaseUrl,
+    ~isCutover=false,
+    ~onDecisionEngineRedirect=(_, _) => (),
+  ) => {
     open LogicUtils
     let {profileId: currentprofileId} = React.useContext(
       UserInfoProvider.defaultContext,
@@ -99,6 +105,32 @@ module ActiveSection = {
       currentprofileId
     } else {
       activeRouting->getDictFromJsonObject->getString("profile_id", "")
+    }
+
+    let activeRuleTypeUrl = `/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`
+
+    let handleViewAndManage = _ => {
+      let decisionEngineTarget = activeRoutingType->decisionEngineRoutingTarget
+
+      let ruleId = switch activeRoutingType {
+      | ADVANCED | VOLUME_SPLIT => activeRoutingId
+      | _ => ""
+      }
+
+      if isCutover && decisionEngineTarget->isNonEmptyString {
+        onDecisionEngineRedirect(decisionEngineTarget, ruleId)
+      } else {
+        switch activeRoutingType {
+        | DEFAULTFALLBACK =>
+          RescriptReactRouter.push(GlobalVars.appendDashboardPath(~url=activeRuleTypeUrl))
+        | _ =>
+          RescriptReactRouter.push(
+            GlobalVars.appendDashboardPath(
+              ~url=`${activeRuleTypeUrl}?id=${activeRoutingId}&isActive=true`,
+            ),
+          )
+        }
+      }
     }
 
     <div className="flex flex-1">
@@ -130,24 +162,7 @@ module ActiveSection = {
           buttonType=Secondary
           customButtonStyle="w-4/3"
           buttonSize={Small}
-          onClick={_ => {
-            switch activeRoutingType {
-            | DEFAULTFALLBACK =>
-              RescriptReactRouter.push(
-                GlobalVars.appendDashboardPath(
-                  ~url=`/${onRedirectBaseUrl}/${routingTypeName(activeRoutingType)}`,
-                ),
-              )
-            | _ =>
-              RescriptReactRouter.push(
-                GlobalVars.appendDashboardPath(
-                  ~url=`/${onRedirectBaseUrl}/${routingTypeName(
-                      activeRoutingType,
-                    )}?id=${activeRoutingId}&isActive=true`,
-                ),
-              )
-            }
-          }}
+          onClick=handleViewAndManage
         />
       </div>
     </div>
@@ -160,7 +175,7 @@ module LevelWiseRoutingSection = {
     ~types: array<routingType>,
     ~onRedirectBaseUrl,
     ~isCutover=false,
-    ~onDecisionEngineRedirect=_ => (),
+    ~onDecisionEngineRedirect=(_, _) => (),
   ) => {
     let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
     let renderCard = (value, key) =>
@@ -201,7 +216,11 @@ module LevelWiseRoutingSection = {
 }
 
 @react.component
-let make = (~routingType: array<JSON.t>, ~isCutover=false) => {
+let make = (
+  ~routingType: array<JSON.t>,
+  ~isCutover=false,
+  ~onDecisionEngineRedirect=(_, _) => (),
+) => {
   let {debitRouting} = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   let debitRoutingValue =
     (
@@ -220,6 +239,7 @@ let make = (~routingType: array<JSON.t>, ~isCutover=false) => {
         activeRoutingId={id}
         onRedirectBaseUrl="routing"
         isCutover
+        onDecisionEngineRedirect
       />
     })
     ->React.array}

--- a/src/screens/Routing/DebitRouting/DebitRouting.res
+++ b/src/screens/Routing/DebitRouting/DebitRouting.res
@@ -1,5 +1,5 @@
 @react.component
-let make = (~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
+let make = (~isCutover=false, ~onDecisionEngineRedirect=(_, _) => ()) => {
   open Typography
   let (showLeastCostModal, setShowLeastCostModal) = React.useState(_ => false)
   let (showManageModal, setShowManageModal) = React.useState(_ => false)
@@ -11,7 +11,7 @@ let make = (~isCutover=false, ~onDecisionEngineRedirect=_ => ()) => {
     ).is_debit_routing_enabled->Option.getOr(false)
   let handleButtonClick = _ => {
     if isCutover {
-      onDecisionEngineRedirect("debit")
+      onDecisionEngineRedirect("debit", "")
     } else if debitRoutingValue {
       setShowManageModal(_ => true)
     } else {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -27,13 +27,40 @@ let make = (~remainingPath, ~previewOnly=false) => {
     previewOnly ? ("w-full", "mx-auto") : ("w-full", "mx-auto ")
   }, [previewOnly])
 
+  let connectorList = HyperswitchAtom.connectorListAtom->Recoil.useRecoilValueFromAtom
+
+  let openDecisionEngineRoutingPage = async (target, ruleId) => {
+    open LogicUtils
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
+      let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
+      if redirectUrl->isNonEmptyString {
+        let handoff = connectorList->RoutingUtils.decisionEngineHandoffFragment(~profileId, ~ruleId)
+        `${redirectUrl}${handoff}`->Window._open
+      }
+    } catch {
+    | Exn.Error(_) =>
+      showToast(
+        ~message="Failed to open Decision Engine routing. Please try again.",
+        ~toastType=ToastState.ToastError,
+      )
+    }
+  }
+
   let tabs: array<Tabs.tab> = React.useMemo(() => {
     open Tabs
     let hasWorkflowsManageAccess = userHasAccess(~groupAccess=WorkflowsManage) === Access
     let baseTabs = [
       {
         title: "Active configuration",
-        renderContent: () => <ActiveRouting routingType isCutover />,
+        renderContent: () =>
+          <ActiveRouting
+            routingType
+            isCutover
+            onDecisionEngineRedirect={(target, ruleId) =>
+              openDecisionEngineRoutingPage(target, ruleId)->ignore}
+          />,
       },
     ]
     hasWorkflowsManageAccess
@@ -53,7 +80,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutover))
+  }, (routingType, debitRoutingValue, isCutover, connectorList, profileId))
 
   let fetchRoutingRecords = async activeIds => {
     try {
@@ -91,16 +118,19 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }
 
+  let getActiveRoutingList = async () => {
+    let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
+    let routingJson = await fetchDetails(activeRoutingUrl)
+    routingJson->LogicUtils.getArrayFromJson([])
+  }
+
   let fetchActiveRouting = async () => {
     open LogicUtils
     try {
       setScreenState(_ => PageLoaderWrapper.Loading)
-      let activeRoutingUrl = getURL(~entityName=V1(ACTIVE_ROUTING), ~methodType=Get)
-      let routingJson = await fetchDetails(activeRoutingUrl)
+      let routingArr = await getActiveRoutingList()
 
-      let routingArr = routingJson->getArrayFromJson([])
-
-      if routingArr->Array.length > 0 {
+      if routingArr->isNonEmptyArray {
         let currentActiveIds = []
         routingArr->Array.forEach(ele => {
           let id = ele->getDictFromJsonObject->getString("id", "")
@@ -127,6 +157,32 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
+  let refreshActiveRouting = async () => {
+    open LogicUtils
+    try {
+      let routingArr = await getActiveRoutingList()
+
+      if routingArr->isNonEmptyArray {
+        setRoutingType(_ => routingArr)
+      } else {
+        let defaultFallback = [("kind", "default"->JSON.Encode.string)]->getJsonFromArrayOfJson
+        setRoutingType(_ => [defaultFallback])
+      }
+    } catch {
+    | Exn.Error(_) => ()
+    }
+  }
+
+  React.useEffect(() => {
+    if isCutover && !previewOnly {
+      let onFocus = _ => refreshActiveRouting()->ignore
+      Window.addEventListener("focus", onFocus)
+      Some(() => Window.removeEventListener("focus", onFocus))
+    } else {
+      None
+    }
+  }, (isCutover, previewOnly, profileId))
+
   let checkRoutingEntry = async () => {
     open LogicUtils
     try {
@@ -136,24 +192,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
       setCutoverStatus(_ => Some(cutover))
     } catch {
     | Exn.Error(_) => setCutoverStatus(_ => Some(false))
-    }
-  }
-
-  let openDecisionEngineRoutingPage = async target => {
-    open LogicUtils
-    try {
-      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
-      let res = await updateDetails(`${entryUrl}?target=${target}`, JSON.Encode.null, Post)
-      let redirectUrl = res->getDictFromJsonObject->getString("redirect_url", "")
-      if redirectUrl->isNonEmptyString {
-        redirectUrl->Window._open
-      }
-    } catch {
-    | Exn.Error(_) =>
-      showToast(
-        ~message="Failed to open Decision Engine routing. Please try again.",
-        ~toastType=ToastState.ToastError,
-      )
     }
   }
 
@@ -180,7 +218,8 @@ let make = (~remainingPath, ~previewOnly=false) => {
           types=[AUTH_RATE_ROUTING, ADVANCED, VOLUME_SPLIT, DEFAULTFALLBACK]
           onRedirectBaseUrl="routing"
           isCutover
-          onDecisionEngineRedirect={target => openDecisionEngineRoutingPage(target)->ignore}
+          onDecisionEngineRedirect={(target, ruleId) =>
+            openDecisionEngineRoutingPage(target, ruleId)->ignore}
         />
       </div>
       <RenderIf condition={!previewOnly}>

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -273,6 +273,43 @@ let filterConnectorList = (
   )
 }
 
+let decisionEngineHandoffFragment = (
+  connectorList: array<ConnectorTypes.connectorPayloadCommonType>,
+  ~profileId,
+  ~ruleId="",
+) => {
+  let connectors =
+    connectorList
+    ->filterConnectorList(~retainInList=PaymentConnector)
+    ->Array.filter(connector =>
+      connector.profile_id === profileId &&
+      !connector.disabled &&
+      connector.connector_name !== "applepay"
+    )
+    ->Array.map(connector =>
+      [
+        ("merchant_connector_id", connector.id->JSON.Encode.string),
+        ("connector_name", connector.connector_name->JSON.Encode.string),
+        ("connector_label", connector.connector_label->JSON.Encode.string),
+      ]->getJsonFromArrayOfJson
+    )
+
+  let params = []
+  if connectors->isNonEmptyArray {
+    params->Array.push((
+      "connectors",
+      connectors->JSON.Encode.array->JSON.stringify->encodeURIComponent,
+    ))
+  }
+  if ruleId->isNonEmptyString {
+    params->Array.push(("rule_id", ruleId->encodeURIComponent))
+  }
+
+  params->isEmptyArray
+    ? ""
+    : `#${params->Array.map(((key, value)) => `${key}=${value}`)->Array.joinWith("&")}`
+}
+
 let filterConnectorListJson = (json, ~retainInList) => {
   json
   ->getArrayFromJson([])


### PR DESCRIPTION
Hotfix port of #5466 onto the currently deployed sandbox build.

Sandbox runs `hyperswitch-control-center:2026.08.27.0`. #5466 merged to main as `36b3c4e5`, but main has since moved to `2026.08.28.0`, so it can't ship from there.

This branch is cut from the `2026.08.27.0` tag with **`36b3c4e5` cherry-picked** — one commit, exactly as squash-merged on main.

## Scope

Four files, all under `src/screens/Routing/`. Nothing else is touched.

Verified mechanically — the diff against `2026.08.27.0` is byte-identical to the commit as it landed on main:

```
diff <(git diff 2026.08.27.0..HEAD) <(git show 36b3c4e5 --format="")
→ identical
```

The two commits between the tag and where #5466 was based (`d31875ba`, `649ee0a`) are Recon Engine only — no overlap with these files — so nothing this change depends on is missing from the older base. The cherry-pick applied with no conflicts.

## What it does

On a cut-over profile, "View and Manage" on the active rule opens the Decision Engine instead of the local Hyperswitch route, carrying the profile's enabled connectors and the clicked rule's id in the deep link's URL fragment. The active configuration card also refreshes when the tab regains focus, since DE opens in its own tab.

Full description and review history: #5466 (2 approvals, 11 review comments addressed).

## Verification

`npx rescript build` clean on this base. Behaviour verified end to end against a local stack on a real cut-over profile — see #5466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5471
