### PR TITLE
fix(ci): stop image-less tags from exhausting the Playwright tag budget

### DIFF
--- a/playwright-tests/start_hyperswitch.sh
+++ b/playwright-tests/start_hyperswitch.sh
@@ -9,6 +9,14 @@ IMAGE_REPO="juspaydotin/hyperswitch-router"
 REGISTRY="docker.juspay.io"
 IMAGE="${REGISTRY}/${IMAGE_REPO}"
 MAX_TRIES=5
+# Auto-discovery walks tags newest-first. Tags with no published router image cost
+# nothing to skip, so they are not counted against MAX_TRIES; MAX_SCAN bounds how far
+# back the walk goes when a long run of tags has no image (e.g. registry outage).
+MAX_SCAN=25
+# Last tag known to boot cleanly. Tried once as a last resort when auto-discovery is
+# exhausted, so that a run of broken recent tags does not fail the suite outright.
+# Bump this when a newer tag has been verified.
+KNOWN_GOOD_TAG="${HYPERSWITCH_KNOWN_GOOD_TAG:-2026.08.21.0}"
 
 # Optional override: pin a known-good tag and skip auto-discovery.
 # Useful when all of the most-recent tags fail to boot but an older tag is known to work.
@@ -70,10 +78,11 @@ try_tag() {
   tag="$1"
   echo "==== Trying tag: $tag ===="
 
-  # Skip tags that have no published router image.
+  # Skip tags that have no published router image. Returns 2, not 1: nothing was
+  # booted, so the caller must not count this against its boot-attempt budget.
   if ! docker manifest inspect "$IMAGE:$tag" >/dev/null 2>&1; then
     echo "Docker image not available for $tag"
-    return 1
+    return 2
   fi
 
   echo "Checking out tag $tag..."
@@ -149,17 +158,37 @@ fi
 # ---------------------------------------------------------------------------
 
 attempt=0
+scanned=0
 
 for tag in $(git tag --sort=-creatordate); do
   [ "$attempt" -ge "$MAX_TRIES" ] && break
+  [ "$scanned" -ge "$MAX_SCAN" ] && break
+  scanned=$((scanned+1))
 
-  if try_tag "$tag"; then
-    exit 0
-  fi
+  status=0
+  try_tag "$tag" || status=$?
 
-  attempt=$((attempt+1))
-
+  case "$status" in
+    0) exit 0 ;;
+    # No published image: nothing was attempted, so keep the budget for tags that
+    # can actually boot. Counting these was letting a short run of image-less
+    # hotfix tags exhaust MAX_TRIES before any bootable tag was reached.
+    2) continue ;;
+    *) attempt=$((attempt+1)) ;;
+  esac
 done
 
-echo "No working tag found in last $MAX_TRIES attempts"
+echo "Auto-discovery exhausted after $attempt boot attempt(s) across $scanned tag(s)"
+
+# Last resort. Auto-discovery only ever sees the newest tags, so when those are all
+# broken it never reaches an older one that works.
+if [ -n "$KNOWN_GOOD_TAG" ]; then
+  echo "Falling back to known-good tag $KNOWN_GOOD_TAG"
+  if try_tag "$KNOWN_GOOD_TAG"; then
+    exit 0
+  fi
+  echo "Known-good tag $KNOWN_GOOD_TAG failed to boot"
+fi
+
+echo "No working tag found"
 exit 1


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [x] CI/CD

## Description

Closes #5476.

`try_tag` in `playwright-tests/start_hyperswitch.sh` returns `1` both when a tag has no published
router image and when a tag's containers fail to boot, and the auto-discovery loop counts every
non-zero return against `MAX_TRIES=5`. Tags that were never attempted therefore spend attempts
meant for tags that can actually boot.

That is what currently fails Playwright on every pull request from a fork. Forks do not receive
`vars.HYPERSWITCH_TAG`, so they take the auto-discovery path, and the five newest tags include
three hotfix tags with no image:

```
2026.08.26.1-hotfix4   no image        (attempt 1)
2026.08.26.1-hotfix3   no image        (attempt 2)
2026.08.28.0           boot failed     (attempt 3)
2026.08.26.1-hotfix2   no image        (attempt 4)
2026.08.27.0           boot failed     (attempt 5)
-> No working tag found in last 5 attempts
```

Only two tags were really tried. `2026.08.21.0` boots — it is the tag pinned for internal runs, and
it booted through auto-discovery on #5347 while it was still recent — but the walk never gets there.

**Changes**

- `try_tag` returns `2` for "no published image", so the caller can tell "nothing was attempted"
  apart from "the attempt failed".
- The loop skips `2` without spending an attempt, bounded by a new `MAX_SCAN=25` so a registry
  outage cannot walk the entire tag list.
- When auto-discovery is still exhausted, `KNOWN_GOOD_TAG` is tried once before giving up. This is
  the same escape hatch `HYPERSWITCH_TAG` already provides for internal runs, available to runs that
  cannot receive the variable. Overridable with `HYPERSWITCH_KNOWN_GOOD_TAG`.

No workflow file is touched, and behaviour is unchanged whenever `HYPERSWITCH_TAG` is set — internal
runs still skip auto-discovery entirely.

## How did you test it?

`bash -n playwright-tests/start_hyperswitch.sh` is clean.

I replayed the exact tag sequence from the failing run against both the old and new loop, with
`try_tag` stubbed to the outcomes observed in that job's log. The old logic reproduces the real
failure line for line; the new logic reaches a bootable tag:

```
=== OLD logic ===
  [2026.08.26.1-hotfix4] no image
  [2026.08.26.1-hotfix3] no image
  [2026.08.28.0] migration_runner exit 1
  [2026.08.26.1-hotfix2] no image
  [2026.08.27.0] migration_runner exit 1
RESULT: No working tag found in last 5 attempts -> exit 1

=== NEW logic ===
  ... image-less tags skipped without cost, five real boot attempts spent ...
Auto-discovery exhausted after 5 boot attempt(s) across 10 tag(s)
Falling back to known-good tag 2026.08.21.0
  [2026.08.21.0] BOOTED
RESULT: exit 0
```

The honest check on this PR is its own CI: `pull_request` runs use the script from the PR head, so
if these Playwright shards go green, the fix is demonstrated end to end on the exact case it targets.
I could not run the real Docker stack locally to confirm which older tags boot — the claim that
`2026.08.21.0` boots rests on it being the pinned internal tag and on #5347's passing run.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
