### PR TITLE
fix: exclude expected transactions from recon engine exceptions

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransaction.res
@@ -42,7 +42,6 @@ let make = (
   let sortOrder = sortDict->getMappedValueFromDict(title, Desc, getSortOrder)
 
   let exceptionStatusList = getTransactionStatusValueFromStatusList([
-    Expected,
     Missing,
     OverAmount(Mismatch),
     UnderAmount(Mismatch),

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionTransactionUtils.res
@@ -26,7 +26,6 @@ let initialDisplayFilters = () => {
     CurrencyMismatch,
     SplitMismatch,
     PartiallyReconciled,
-    Expected,
     Missing,
   ])
   [

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineOverview/ReconEngineOverviewSummary/ReconEngineOverviewSummaryUtils.res
@@ -496,7 +496,6 @@ let getOpenExceptions = (
       | CurrencyMismatch
       | SplitMismatch
       | PartiallyReconciled
-      | Expected
       | Missing =>
         statusAcc + status.count
       | Posted(Manual)
@@ -504,6 +503,7 @@ let getOpenExceptions = (
       | Matched(Manual)
       | Matched(Force)
       | Matched(WithTolerance)
+      | Expected
       | Void
       | Archived
       | UnknownDomainTransactionStatus
@@ -960,9 +960,11 @@ let getRuleActivityItems = (~overviewRules: array<overviewRulesResponse>): array
   overviewRules
   ->Array.map(rule => {
     let volume = rule.status_breakdown->Array.reduce(0, (acc, status) => acc + status.count)
-    let (matchedCount, exceptionCount, _, _) = getBreakdownCategoryCounts(rule.status_breakdown)
+    let (matchedCount, exceptionCount, _, missingCount) = getBreakdownCategoryCounts(
+      rule.status_breakdown,
+    )
     let matchRate = getPercentage(~count=matchedCount, ~total=volume)
-    {overview_rule: rule, volume, exceptions: exceptionCount, matchRate}
+    {overview_rule: rule, volume, exceptions: exceptionCount + missingCount, matchRate}
   })
   ->Array.toSorted((a, b) => Int.compare(b.exceptions, a.exceptions))
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Removes the `Expected` transaction status from the places in the Recon Engine that flag/count transactions as exceptions:

- `ReconEngineExceptionTransaction.res`: `Expected` removed from the default `exceptionStatusList` used to fetch the Exception Transactions page.
- `ReconEngineExceptionTransactionUtils.res`: `Expected` removed from the selectable status filter options on that same page.
- `ReconEngineOverviewSummaryUtils.res`:
  - `getOpenExceptions`: `Expected` no longer contributes to the "Open Exceptions" stat card count.
  - `getRuleActivityItems`: the Rules Activity "Exceptions" column now also includes `Missing` (previously excluded), so it's consistent with the other exception counts.

`OverAmount(Expected)` / `UnderAmount(Expected)` (amount-variance-but-awaiting-match statuses) are intentionally left as exceptions, matching how the Overview's exception-aging and exception-triage widgets already classified them.

## Motivation and Context

`Expected` means a transaction is just waiting on its matching counterpart — it isn't a reconciliation problem yet. Only `Missing` (expected but never arrived) and genuine mismatches should be treated as exceptions. Bundling `Expected` in with exceptions inflated exception counts and cluttered the Exceptions page with non-issues.

Fixes #5486

## How did you test it?

Manually verified the updated status lists against the domain status semantics already used elsewhere in the codebase (e.g. `getExceptionCountFromBreakdown`, `getExceptionTriageItems`), and ran `npm run re:build` to confirm the ReScript compiler's exhaustive pattern matching accepts the updated status branches.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible