### PR TITLE
test(playwright): add worldpayraft connector coverage and unblock the local backend boot

### DIFF
--- a/playwright-tests/start_hyperswitch.sh
+++ b/playwright-tests/start_hyperswitch.sh
@@ -94,12 +94,13 @@ try_tag() {
   sed 's|apk add --no-cache curl jq yq && sh /seed_superposition.sh|apk add --no-cache curl jq yq bash \&\& bash /seed_superposition.sh|g' \
     docker-compose.yml > docker-compose.tmp && mv docker-compose.tmp docker-compose.yml
 
-  # The upstream migration runner installs `just` by resolving its latest release
-  # through the unauthenticated GitHub API. That request can be rate-limited (403),
-  # especially from local Docker networks. `just migrate` only delegates to the
-  # Diesel CLI here, so run the equivalent command directly.
+  # The upstream migration runner installs `just` from the unauthenticated GitHub
+  # API, which gets rate-limited (403) from local Docker networks. `just migrate`
+  # only delegates to the Diesel CLI, so run that directly — and add `rustfmt`,
+  # which the CLI's build script needs and the base image lacks.
   sed -e '/      if ! command -v just >\/dev\/null 2>\&1; then/,/      fi \&\&/d' \
       -e 's|      just migrate"|      diesel migration run --migration-dir /app/migrations --config-file /app/diesel.toml"|' \
+      -e 's|apt-get install -y curl xz-utils|apt-get install -y curl xz-utils rustfmt|' \
     docker-compose.yml > docker-compose.tmp && mv docker-compose.tmp docker-compose.yml
 
   echo "Starting docker compose..."

--- a/playwright-tests/support/fixtures/payinConnectorConfig.ts
+++ b/playwright-tests/support/fixtures/payinConnectorConfig.ts
@@ -3793,4 +3793,31 @@ export const connectorConfig: Record<string, ConnectorConfig> = {
       },
     },
   },
+
+  worldpayraft: {
+    label: "worldpayraft",
+    fields: {
+      default: "test_value",
+      overrides: {
+        "Enter Connector label": "worldpayraft_default",
+      },
+      // BodyKey auth (api_key, key1); no connector_webhook_details, so there
+      // is no "Source verification key" field on this form.
+      fieldLabels: [
+        "Worldpay License *",
+        "Worldpay Merchant ID *",
+        "Connector label *",
+      ],
+    },
+    paymentSections: {
+      Credit: {
+        label: "Credit",
+        methods: ["Visa", "Mastercard", "AmericanExpress", "DinersClub"],
+      },
+      Debit: {
+        label: "Debit",
+        methods: ["Visa", "Mastercard", "AmericanExpress", "DinersClub"],
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two independent Playwright fixes.

**Worldpay Raft connector coverage.** The `All Payin Connectors` block in `payinConnector.spec.ts` is data-driven off `connectorConfig`, so a connector with no fixture entry is silently never tested. `WORLDPAYRAFT` has been wired into the control center for a while — `connectorListForSandbox` (`ConnectorUtils.res:201`), `connectorInfo`, display name, and both name-string mappings — but had no fixture, so nothing exercised it. Adds one, derived from `crates/connector_configs/toml/development.toml`:

- BodyKey auth → `Worldpay License *` (`api_key`), `Worldpay Merchant ID *` (`key1`)
- no `connector_webhook_details`, so no `Source verification key` field on this form
- Credit and Debit over Visa, Mastercard, AmericanExpress, DinersClub

That is enough for the existing matrix to generate and run `should setup and verify worldpayraft connector` — no spec changes needed.

**`start_hyperswitch.sh` backend boot.** The script already rewrites the upstream `migration_runner` service to call the Diesel CLI directly, because upstream installs `just` by resolving its latest release through the unauthenticated GitHub API and that gets rate-limited (403) from local Docker networks.

That rewrite was not sufficient. The same compose step installs the Diesel CLI from source, and the CLI's build script shells out to `rustfmt`, which the `debian:trixie-slim` base image does not ship. The migration runner exited non-zero, `docker compose up` failed, and `try_tag` cycled through every candidate tag before giving up with `No working tag found in last 5 attempts`. Adds `rustfmt` to the same `apt-get install` line, and merges the two adjacent comments into one block now that both edits share a cause.

## Motivation and Context

Fixes #5488.

The boot script is the documented way to bring up a local backend for the Playwright suite, so the second fix blocks running the suite locally at all. The first closes a silent coverage gap — a connector that ships in the sandbox list but has no test.

## How did you test it?

Both against a local stack booted by the fixed `start_hyperswitch.sh`.

- `npx playwright test playwright-tests/e2e/4-connectors/payinConnector.spec.ts -g "worldpayraft"` → **1/1 passed**. The generated test drives the real flow: search the connector list, open the form, assert the three field labels resolve to attached inputs, fill them, assert the Credit/Debit payment method types, submit, and confirm the connector card appears on `/dashboard/connectors`.
- Dry-ran the full `sed` chain against the pristine upstream `docker-compose.yml` (`git show HEAD:docker-compose.yml`) and diffed the output. It produces exactly the intended `migration_runner` command:

  ```
  apt-get update && apt-get install -y curl xz-utils rustfmt &&
  ...
  diesel migration run --migration-dir /app/migrations --config-file /app/diesel.toml"
  ```

- `shellcheck playwright-tests/start_hyperswitch.sh` → clean.
- `npx prettier --check` on the changed fixture → clean.

No product code is touched, so there is nothing to verify in the app itself.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

Backend PR URL: N/A

The Worldpay Raft fixture mirrors `[worldpayraft]` as it already exists in `crates/connector_configs/toml`; it does not require a backend change.

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A

## Checklist

- [ ] I ran `npm run re:build`
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible

`npm run re:build` is not applicable — this PR touches only Playwright fixtures and a shell script, no ReScript.
