### PR TITLE
fix: sub-day date range presets render as "This month" on the 1st

### DIFF
--- a/patches/@juspay+blend-design-system+0.0.37.patch
+++ b/patches/@juspay+blend-design-system+0.0.37.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@juspay/blend-design-system/dist/main.js b/node_modules/@juspay/blend-design-system/dist/main.js
-index 7d7d143..912c38d 100644
+index 7d7d143..c5e7ab6 100644
 --- a/node_modules/@juspay/blend-design-system/dist/main.js
 +++ b/node_modules/@juspay/blend-design-system/dist/main.js
 @@ -23633,7 +23633,7 @@ function kao() {
@@ -20,7 +20,7 @@ index 7d7d143..912c38d 100644
      typeof Map == "function" && Map.prototype != null && typeof Map.prototype.forEach == "function" && typeof Set == "function" && Set.prototype != null && typeof Set.prototype.clear == "function" && typeof Set.prototype.forEach == "function" || console.error(
        "React depends on Map and Set built-in types. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills"
      ), _i.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = U, _i.createPortal = function(a, p) {
-@@ -88485,10 +88485,12 @@ const Yi = {
+@@ -88485,10 +88485,34 @@ const Yi = {
      return We.YESTERDAY;
    if (L0o(V))
      return We.TOMORROW;
@@ -28,16 +28,38 @@ index 7d7d143..912c38d 100644
 -    return We.THIS_MONTH;
 -  if (D0o(V))
 -    return We.LAST_MONTH;
-+  // PATCH(hyperswitch): detect the relative-time presets before THIS_MONTH/LAST_MONTH.
-+  // Upstream: https://github.com/juspay/blend-design-system/issues/1743
-+  // isThisMonth (M0o) accepts any startDate within TIMEZONE_TOLERANCE_HOURS (25h) of the 1st
-+  // at 00:00, so on the 1st of a month it swallowed Last 30 minutes / 1 hour / 6 hours / 24 hours
-+  // and the trigger rendered "This month". The relative checks below are exact (+/- 60s), so
-+  // running them first cannot steal a genuine calendar-month match.
++  // PATCH(hyperswitch): preset detection reordered. Upstream: juspay/blend-design-system#1743
++  //
++  // Shipped order ran the loose calendar checks (THIS_MONTH / LAST_MONTH) before the
++  // exact ones, and isThisMonth (M0o) accepts any startDate within TIMEZONE_TOLERANCE_HOURS
++  // (25h) of the 1st at 00:00 with an endDate merely in the current month. So on the 1st
++  // every sub-day range was labelled "This month".
++  //
++  // Both blocks below are exact -- end within +/-60s of now, span or both endpoints within
++  // +/-60s -- so neither can steal a genuine calendar-month match. Consumer-supplied
++  // customPresets go first: a preset the caller defined outranks a built-in guess, and
++  // presets with no blend equivalent (our Hour(2.0) -> "Last 2 hours" on webhooks,
++  // insights and analytics) are detectable *only* here.
++  if (l && l.length > 0) {
++    const h = $t.PRESET_DETECTION_TOLERANCE_MS;
++    for (const a of l) {
++      const p = iD(
++        a.preset
++      );
++      if (!p) continue;
++      const n = p.getDateRange();
++      if (n.startDate && n.endDate && Math.abs(
++        o.startDate.getTime() - n.startDate.getTime()
++      ) <= h && Math.abs(
++        o.endDate.getTime() - n.endDate.getTime()
++      ) <= h)
++        return a.preset;
++    }
++  }
    const i = /* @__PURE__ */ new Date(), K = Math.abs(o.endDate.getTime() - i.getTime()), q = $t.PRESET_DETECTION_TOLERANCE_MS;
    if (K <= q) {
      const h = o.endDate.getTime() - o.startDate.getTime(), a = 1800 * 1e3, p = 3600 * 1e3, n = 360 * 60 * 1e3, u = 1440 * 60 * 1e3;
-@@ -88501,6 +88503,10 @@ const Yi = {
+@@ -88501,6 +88525,10 @@ const Yi = {
      if (Math.abs(h - u) <= q)
        return We.LAST_24_HOURS;
    }
@@ -48,3 +70,26 @@ index 7d7d143..912c38d 100644
    const t = Math.round(
      (o.endDate.getTime() - o.startDate.getTime()) / (1440 * 60 * 1e3)
    );
+@@ -88544,22 +88572,6 @@ const Yi = {
+     return We.NEXT_3_MONTHS;
+   if (U && r === 12)
+     return We.NEXT_12_MONTHS;
+-  if (l && l.length > 0) {
+-    const h = $t.PRESET_DETECTION_TOLERANCE_MS;
+-    for (const a of l) {
+-      const p = iD(
+-        a.preset
+-      );
+-      if (!p) continue;
+-      const n = p.getDateRange();
+-      if (n.startDate && n.endDate && Math.abs(
+-        o.startDate.getTime() - n.startDate.getTime()
+-      ) <= h && Math.abs(
+-        o.endDate.getTime() - n.endDate.getTime()
+-      ) <= h)
+-        return a.preset;
+-    }
+-  }
+   return We.CUSTOM;
+ }, G0o = [
+   We.LAST_30_MINUTES,

--- a/patches/@juspay+blend-design-system+0.0.37.patch
+++ b/patches/@juspay+blend-design-system+0.0.37.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@juspay/blend-design-system/dist/main.js b/node_modules/@juspay/blend-design-system/dist/main.js
-index 7d7d143..1ce0ec8 100644
+index 7d7d143..912c38d 100644
 --- a/node_modules/@juspay/blend-design-system/dist/main.js
 +++ b/node_modules/@juspay/blend-design-system/dist/main.js
 @@ -23633,7 +23633,7 @@ function kao() {
@@ -20,3 +20,31 @@ index 7d7d143..1ce0ec8 100644
      typeof Map == "function" && Map.prototype != null && typeof Map.prototype.forEach == "function" && typeof Set == "function" && Set.prototype != null && typeof Set.prototype.clear == "function" && typeof Set.prototype.forEach == "function" || console.error(
        "React depends on Map and Set built-in types. Make sure that you load a polyfill in older browsers. https://reactjs.org/link/react-polyfills"
      ), _i.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE = U, _i.createPortal = function(a, p) {
+@@ -88485,10 +88485,12 @@ const Yi = {
+     return We.YESTERDAY;
+   if (L0o(V))
+     return We.TOMORROW;
+-  if (M0o(V))
+-    return We.THIS_MONTH;
+-  if (D0o(V))
+-    return We.LAST_MONTH;
++  // PATCH(hyperswitch): detect the relative-time presets before THIS_MONTH/LAST_MONTH.
++  // Upstream: https://github.com/juspay/blend-design-system/issues/1743
++  // isThisMonth (M0o) accepts any startDate within TIMEZONE_TOLERANCE_HOURS (25h) of the 1st
++  // at 00:00, so on the 1st of a month it swallowed Last 30 minutes / 1 hour / 6 hours / 24 hours
++  // and the trigger rendered "This month". The relative checks below are exact (+/- 60s), so
++  // running them first cannot steal a genuine calendar-month match.
+   const i = /* @__PURE__ */ new Date(), K = Math.abs(o.endDate.getTime() - i.getTime()), q = $t.PRESET_DETECTION_TOLERANCE_MS;
+   if (K <= q) {
+     const h = o.endDate.getTime() - o.startDate.getTime(), a = 1800 * 1e3, p = 3600 * 1e3, n = 360 * 60 * 1e3, u = 1440 * 60 * 1e3;
+@@ -88501,6 +88503,10 @@ const Yi = {
+     if (Math.abs(h - u) <= q)
+       return We.LAST_24_HOURS;
+   }
++  if (M0o(V))
++    return We.THIS_MONTH;
++  if (D0o(V))
++    return We.LAST_MONTH;
+   const t = Math.round(
+     (o.endDate.getTime() - o.startDate.getTime()) / (1440 * 60 * 1e3)
+   );

--- a/playwright-tests/e2e/3-operations/disputeOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/disputeOperations.spec.ts
@@ -13,6 +13,9 @@ import {
 } from "../../support/commands";
 
 const PLAYWRIGHT_PASSWORD = process.env.PLAYWRIGHT_PASSWORD || "Playwright00#";
+// A 1st-of-month instant — the day blend mislabels sub-day presets. Pinned
+// deliberately so the Date Selector test below stays a regression guard.
+const FIRST_OF_MONTH = "2026-09-01T12:00:00.000Z";
 
 // Disputes have no client-facing creation endpoint — production disputes
 // arrive via connector webhooks — so every scenario that needs row data
@@ -245,6 +248,15 @@ test.describe("Disputes List page", () => {
 
       await mockDisputesList(page, [sampleDispute()]);
       await goToDisputes(page, homePage);
+
+      // Pinned to the 1st on purpose. blend checks its "This month" preset before
+      // the sub-day ones and accepts any range starting within 25h of the 1st at
+      // 00:00, so on the 1st the trigger renders "This month" instead of the preset
+      // that was clicked (juspay/blend-design-system#1743). Pinning here keeps this
+      // a regression guard: it fails if the patches/@juspay+blend-design-system
+      // reorder is ever dropped, e.g. when regenerating the patch on a blend
+      // upgrade. Set here, not in beforeEach, so signup/setup run at real time.
+      await page.clock.setFixedTime(new Date(FIRST_OF_MONTH));
 
       await paymentOperations.customDateRangeButton.click();
       await page.getByRole("menuitem", { name: "Last 30 minutes" }).click();

--- a/playwright-tests/e2e/3-operations/payoutOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/payoutOperations.spec.ts
@@ -11,6 +11,9 @@ import {
 } from "../../support/commands";
 
 const PLAYWRIGHT_PASSWORD = process.env.PLAYWRIGHT_PASSWORD || "Playwright00#";
+// A 1st-of-month instant — the day blend mislabels sub-day presets. Pinned
+// deliberately so the Date Selector test below stays a regression guard.
+const FIRST_OF_MONTH = "2026-09-01T12:00:00.000Z";
 let email: string;
 
 const MOCK_PAYOUT_DETAILS = {
@@ -493,6 +496,15 @@ test.describe("Payouts Operations", () => {
         await setupPayout(page, homePage, context.request);
 
         await goToPayouts(page, homePage);
+
+        // Pinned to the 1st on purpose. blend checks its "This month" preset before
+        // the sub-day ones and accepts any range starting within 25h of the 1st at
+        // 00:00, so on the 1st the trigger renders "This month" instead of the preset
+        // that was clicked (juspay/blend-design-system#1743). Pinning here keeps this
+        // a regression guard: it fails if the patches/@juspay+blend-design-system
+        // reorder is ever dropped, e.g. when regenerating the patch on a blend
+        // upgrade. Set here, not in beforeEach, so signup/setup run at real time.
+        await page.clock.setFixedTime(new Date(FIRST_OF_MONTH));
 
         await payoutOperations.customDateRangeButton.click();
         await page.getByRole("menuitem", { name: "Last 30 minutes" }).click();

--- a/playwright-tests/e2e/3-operations/refundOperations.spec.ts
+++ b/playwright-tests/e2e/3-operations/refundOperations.spec.ts
@@ -13,6 +13,9 @@ import {
 import PaymentOperations from "../../support/pages/operations/PaymentOperations";
 
 const PLAYWRIGHT_PASSWORD = process.env.PLAYWRIGHT_PASSWORD || "Playwright00#";
+// A 1st-of-month instant — the day blend mislabels sub-day presets. Pinned
+// deliberately so the Date Selector test below stays a regression guard.
+const FIRST_OF_MONTH = "2026-09-01T12:00:00.000Z";
 const refundColumnSize = 12;
 let email: string;
 
@@ -262,6 +265,15 @@ test.describe("Refunds Operations", () => {
         await setupRefund(page, homePage, context.request);
 
         await goToRefunds(page, homePage);
+
+        // Pinned to the 1st on purpose. blend checks its "This month" preset before
+        // the sub-day ones and accepts any range starting within 25h of the 1st at
+        // 00:00, so on the 1st the trigger renders "This month" instead of the preset
+        // that was clicked (juspay/blend-design-system#1743). Pinning here keeps this
+        // a regression guard: it fails if the patches/@juspay+blend-design-system
+        // reorder is ever dropped, e.g. when regenerating the patch on a blend
+        // upgrade. Set here, not in beforeEach, so signup/setup run at real time.
+        await page.clock.setFixedTime(new Date(FIRST_OF_MONTH));
 
         await paymentOperations.customDateRangeButton.click();
         await page.getByRole("menuitem", { name: "Last 30 minutes" }).click();


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix

## Description

blend's `DateRangePicker` derives the trigger label from the selected dates instead of the clicked preset, and runs its loose calendar checks before the exact ones. `matchesThisMonthPreset` accepts any range starting within 25h of the 1st at 00:00, so on the 1st of a month every sub-day preset renders as "This month".

Two orderings are wrong, and both are patched in `dist/main.js`:

1. The four built-in sub-day presets — Last 30 minutes / 1 hour / 6 hours / 24 hours — are checked after `THIS_MONTH`.
2. The `presetConfigs` loop, the only thing that can match a consumer-supplied preset, is the **last** statement in the function. Presets with no blend built-in are therefore undetectable whenever an earlier heuristic fires. `Hour(2.0)` → "Last 2 hours" on webhooks, insights and analytics is the case that surfaced this.

New order is customPresets → built-in relative → calendar. Both hoisted blocks compare exactly (±60s), so neither can steal a genuine calendar-month match.

## Motivation and Context

Live since the picker moved to blend in #4504. Only visible on the 1st, which is why it went unnoticed — the data was always correctly scoped, only the button text was wrong.

Upstream: juspay/blend-design-system#1743. Drop the reordering hunks once that ships; the two React 18 hunks in the same patch file are unrelated and stay.

## How did you test it?

Swept every day of four months at six times of day, comparing shipped vs. patched detection against the preset set the webhooks/insights pickers actually pass: **828 mislabelled cases fixed, 0 new mismatches**. The 150 residual are pre-existing `LAST_7_DAYS` / `LAST_30_DAYS` anchoring approximations, unchanged by this.

The three Playwright Date Selector tests that assert this label are failing on main today (it's the 1st). They're pinned to a 1st-of-month clock here, so they stay a regression guard if a future blend upgrade regenerates the patch and drops the reorder.

## Where to test it?

- [x] INTEG

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

---

## Testing this branch locally

`npm i` will fail to apply the patch if your `node_modules` still holds main's version of it — patch-package can't apply a changed patch file over an already-patched copy on disk. Reinstall blend first:

```
rm -rf node_modules/@juspay/blend-design-system && npm i
```

Same command when switching back to main afterwards. CI is unaffected — it uses `npm ci`, which always patches from a clean install.
