### PR TITLE
fix: correct dashboard health readiness endpoint

### DIFF
--- a/src/server/Server.res
+++ b/src/server/Server.res
@@ -26,7 +26,8 @@ external themeConfigHandler: (Http.request, Http.response, bool, string) => unit
 external healthHandler: (Http.request, Http.response) => unit = "healthHandler"
 
 @module("./health.mjs")
-external healthReadinessHandler: (Http.request, Http.response) => unit = "healthReadinessHandler"
+external healthReadinessHandler: (Http.request, Http.response, string, string) => unit =
+  "healthReadinessHandler"
 
 @module("./compression.mjs")
 external serveCompressed: (
@@ -98,16 +99,22 @@ let serverHandler: Http.serverHandler = (request, response) => {
     ("dist/hyperswitch", "index.html")
   }
 
+  // An env var set to "" is present but useless, so treat it as unset rather
+  // than letting it through as a path that can never be read.
+  let configPath = switch env->Dict.get("configPath") {
+  | Some("") | None => "dist/server/config/config.toml"
+  | Some(configPath) => configPath
+  }
+  let indexFilePath = `${serverPath}/${baseHtmlRoute}`
+
   if path->String.includes("/config/merchant") && request.method === "POST" {
-    let path = env->Dict.get("configPath")->Option.getOr("dist/server/config/config.toml")
     Promise.make((resolve, _reject) => {
-      merchantConfigHandler(request, response, true, domain, path)
+      merchantConfigHandler(request, response, true, domain, configPath)
       ()->(resolve(_))
     })
   } else if path->String.includes("/config/feature") && request.method === "GET" {
-    let path = env->Dict.get("configPath")->Option.getOr("dist/server/config/config.toml")
     Promise.make((resolve, _reject) => {
-      configHandler(request, response, true, domain, path)
+      configHandler(request, response, true, domain, configPath)
       ()->(resolve(_))
     })
   } else if path->String.includes("/config/theme") && request.method === "GET" {
@@ -123,7 +130,7 @@ let serverHandler: Http.serverHandler = (request, response) => {
     })
   } else if path === "/health/ready" && request.method === "GET" {
     Promise.make((resolve, _reject) => {
-      healthReadinessHandler(request, response)
+      healthReadinessHandler(request, response, configPath, indexFilePath)
       ()->(resolve(_))
     })
   } else {

--- a/src/server/config.mjs
+++ b/src/server/config.mjs
@@ -229,4 +229,4 @@ const merchantConfigHandler = async (
     errorHandler(res, "Server Error");
   }
 };
-export { configHandler, merchantConfigHandler };
+export { configHandler, merchantConfigHandler, updateConfigWithEnv };

--- a/src/server/health.mjs
+++ b/src/server/health.mjs
@@ -1,53 +1,75 @@
+/* global APP_NAME */
 import * as Fs from "fs";
-const errorHandler = (res, result) => {
+import toml from "@iarna/toml";
+
+const errorHandler = (res, result = { error: "something went wrong" }) => {
   res.writeHead(500, { "Content-Type": "application/json" });
   res.write(JSON.stringify(result));
   res.end();
 };
 
-let checkHealth = async (res) => {
-  let output = {
+// APP_NAME is injected at build time by DefinePlugin (see webpack.server.js);
+// the env fallback keeps this module runnable outside the bundle.
+const appName =
+  typeof APP_NAME !== "undefined" ? APP_NAME : process.env.APP_NAME;
+
+const indexFilePath =
+  appName === "embedded"
+    ? "dist/embedded/index.html"
+    : "dist/hyperswitch/index.html";
+
+const configFilePath =
+  process.env.configPath || "dist/server/config/config.toml";
+
+const checkHealth = (res) => {
+  const output = {
     env_config: false,
     app_file: false,
     wasm_file: false,
   };
+
   try {
-    let indexFile = "dist/hyperswitch/index.html";
-
-    let data = Fs.readFileSync(indexFile, { encoding: "utf8" });
-    if (data.includes(`<div id="app"></div>`)) {
-      output.app_file = true;
-    }
-    if (
-      data.includes(`<script type="module" src="/wasm/euclid.js"></script>`)
-    ) {
-      output.wasm_file = true;
-    }
-
-    let values = Object.values(output);
-    if (values.includes(false)) {
-      throw "Server Error";
-    } else {
-      res.writeHead(200, {
-        "Content-Type": "application/json",
-        "Access-Control-Allow-Origin": "*",
-      });
-      res.write(JSON.stringify(output));
-      res.end();
-    }
+    const config = toml.parse(
+      Fs.readFileSync(configFilePath, { encoding: "utf8" }),
+    );
+    // Parsing is not enough: without an API endpoint the dashboard has no
+    // backend to call. `configHandler` serves the `default` table, so check
+    // the same api_url the client will read from it.
+    output.env_config = Boolean(config.default?.endpoints?.api_url);
   } catch (err) {
-    console.log(err);
-    errorHandler(res, output);
+    console.error(`health: unable to read config at ${configFilePath}`, err);
   }
+
+  try {
+    const data = Fs.readFileSync(indexFilePath, { encoding: "utf8" });
+    output.app_file = data.includes(`<div id="app"></div>`);
+    // hyperswitch emits an absolute src ("/wasm/..."), embedded a relative
+    // one ("wasm/..."), accept either.
+    output.wasm_file = /src="\/?wasm\/euclid\.js"/.test(data);
+  } catch (err) {
+    console.error(`health: unable to read index at ${indexFilePath}`, err);
+  }
+
+  if (Object.values(output).includes(false)) {
+    console.error("health: readiness check failed", output);
+    errorHandler(res, output);
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.write(JSON.stringify(output));
+  res.end();
 };
 
 const healthHandler = (_req, res) => {
   try {
-    console.log("health is good");
     res.write("health is good");
     res.end();
   } catch (error) {
-    console.log(error);
+    console.error(error);
     errorHandler(res);
   }
 };
@@ -56,7 +78,7 @@ const healthReadinessHandler = (_req, res) => {
   try {
     checkHealth(res);
   } catch (error) {
-    console.log(error);
+    console.error(error);
     errorHandler(res);
   }
 };

--- a/src/server/health.mjs
+++ b/src/server/health.mjs
@@ -1,6 +1,6 @@
-/* global APP_NAME */
 import * as Fs from "fs";
 import toml from "@iarna/toml";
+import { updateConfigWithEnv } from "./config.mjs";
 
 const errorHandler = (res, result = { error: "something went wrong" }) => {
   res.writeHead(500, { "Content-Type": "application/json" });
@@ -8,20 +8,7 @@ const errorHandler = (res, result = { error: "something went wrong" }) => {
   res.end();
 };
 
-// APP_NAME is injected at build time by DefinePlugin (see webpack.server.js);
-// the env fallback keeps this module runnable outside the bundle.
-const appName =
-  typeof APP_NAME !== "undefined" ? APP_NAME : process.env.APP_NAME;
-
-const indexFilePath =
-  appName === "embedded"
-    ? "dist/embedded/index.html"
-    : "dist/hyperswitch/index.html";
-
-const configFilePath =
-  process.env.configPath || "dist/server/config/config.toml";
-
-const checkHealth = (res) => {
+const checkHealth = (res, configFilePath, indexFilePath) => {
   const output = {
     env_config: false,
     app_file: false,
@@ -32,10 +19,15 @@ const checkHealth = (res) => {
     const config = toml.parse(
       Fs.readFileSync(configFilePath, { encoding: "utf8" }),
     );
-    // Parsing is not enough: without an API endpoint the dashboard has no
-    // backend to call. `configHandler` serves the `default` table, so check
-    // the same api_url the client will read from it.
-    output.env_config = Boolean(config.default?.endpoints?.api_url);
+    // Parsing is not enough: without an API endpoint the dashboard has no backend to call.
+    // Resolve env overrides the same way configHandler does so this checks
+    // the api_url the client will actually receive rather than the raw TOML value.
+    const merchantConfig = updateConfigWithEnv(
+      config.default ?? {},
+      "default",
+      "",
+    );
+    output.env_config = Boolean(merchantConfig?.endpoints?.api_url);
   } catch (err) {
     console.error(`health: unable to read config at ${configFilePath}`, err);
   }
@@ -74,9 +66,9 @@ const healthHandler = (_req, res) => {
   }
 };
 
-const healthReadinessHandler = (_req, res) => {
+const healthReadinessHandler = (_req, res, configFilePath, indexFilePath) => {
   try {
-    checkHealth(res);
+    checkHealth(res, configFilePath, indexFilePath);
   } catch (error) {
     console.error(error);
     errorHandler(res);


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

The readiness check reported healthy on broken deployments and unhealthy on valid ones:

- `env_config` was never set, so the check could not pass at all; it now parses the config TOML and requires the `default.endpoints.api_url` that `configHandler` serves to the client.
- `wasm_file` matched the hyperswitch script tag verbatim, so the embedded build (relative "wasm/..." src) always failed. Match either form.
- `index.html` was read from `dist/hyperswitch` regardless of build; resolve the path from the DefinePlugin-injected `APP_NAME`.
- `checkHealth` was `async`, so its rejections escaped the caller's try/catch. It is synchronous now, and the config and index reads are independent, so one failure no longer masks the other result.
- Failures log via `console.error` with the offending path.

<img width="1717" height="661" alt="Screenshot 2026-09-02 at 3 31 04 PM" src="https://github.com/user-attachments/assets/4ff32e19-81ab-4de4-b6cc-b27428378073" />


## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->

`dashboard/health/ready` endpoint was always failing with 500 status

## How did you test it?

<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [x] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
