### PR TITLE
feat: add cursor pagination in audit trail entries modal

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionsDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptionTransaction/ReconEngineExceptionsDetails.res
@@ -63,6 +63,14 @@ let make = (~id) => {
     None
   }, [])
 
+  let auditTrailAccountIds = React.useMemo(() => {
+    allExceptionDetails
+    ->Array.flatMap(transaction =>
+      transaction.entries->Array.map(entry => entry.account.account_id)
+    )
+    ->getUniqueArray
+  }, [allExceptionDetails])
+
   let tabs: array<Tabs.tab> = React.useMemo(() => {
     open Tabs
     [
@@ -77,10 +85,13 @@ let make = (~id) => {
       },
       {
         title: "Audit Trail",
-        renderContent: () => <AuditTrail allTransactionDetails={allExceptionDetails} />,
+        renderContent: () =>
+          <AuditTrail
+            allTransactionDetails={allExceptionDetails} accountIds=auditTrailAccountIds accountsData
+          />,
       },
     ]
-  }, (allExceptionDetails, entriesList, accountsData))
+  }, (allExceptionDetails, entriesList, accountsData, auditTrailAccountIds))
 
   <div>
     <div className="flex flex-col gap-4 mb-6">

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
@@ -62,7 +62,7 @@ let make = (
 
   <PageLoaderWrapper
     screenState customLoader={<Shimmer styleClass="h-40 w-full mt-6 rounded-xl" />}>
-    <div className="flex flex-col gap-6 mt-6 mb-16">
+    <div className="flex flex-col gap-6 mt-6">
       <RenderIf condition={accountIds->isEmptyArray}>
         <NoDataFound customCssClass="my-6" message="No Data Available" renderType=Painting />
       </RenderIf>

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
@@ -3,6 +3,7 @@ let make = (
   ~primaryTransactionId: string,
   ~accountIds: array<string>,
   ~accountsData: array<ReconEngineTypes.accountType>,
+  ~entriesDetailFields=EntriesTableEntity.transactionEntriesDetailFields,
 ) => {
   open APIUtils
   open LogicUtils
@@ -77,6 +78,7 @@ let make = (
             transformationNameMap
             currencyOptions
             transformationConfigOptions
+            entriesDetailFields
           />
         </FilterContext>
       )

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntriesContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntriesContent.res
@@ -8,6 +8,7 @@ let make = (
   ~transformationNameMap: Dict.t<string>,
   ~currencyOptions: array<FilterSelectBox.dropdownOption>,
   ~transformationConfigOptions: array<FilterSelectBox.dropdownOption>,
+  ~entriesDetailFields=EntriesTableEntity.transactionEntriesDetailFields,
 ) => {
   open LogicUtils
   open EntriesTableEntity
@@ -121,7 +122,7 @@ let make = (
     let sections = getEntriesSections(
       ~groupedEntries,
       ~accountInfoMap,
-      ~detailsFields=transactionEntriesDetailFields,
+      ~detailsFields=entriesDetailFields,
       ~showTotalAmount=false,
     )
     let accountIds = groupedEntries->Dict.keysToArray
@@ -146,7 +147,7 @@ let make = (
         <div className="flex flex-col">
           <ReconEngineCustomExpandableSelectionTable
             title=""
-            heading={transactionEntriesDetailFields->Array.map(getHeading)}
+            heading={entriesDetailFields->Array.map(getHeading)}
             getSectionRowDetails=sectionDetails
             showScrollBar=true
             showOptions=false

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsDetails.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsDetails.res
@@ -86,7 +86,11 @@ let make = (~id) => {
       {
         title: "Audit Trail",
         renderContent: () =>
-          <AuditTrailTab transactionId={currentTransactionDetails.transaction_id} />,
+          <AuditTrailTab
+            transactionId={currentTransactionDetails.transaction_id}
+            accountIds=ruleAccountIds
+            accountsData
+          />,
       },
     ]
   }, (currentTransactionDetails, ruleAccountIds, accountsData))

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
@@ -115,9 +115,9 @@ module EntryAuditTrailInfo = {
     ~accountIds: array<string>,
     ~accountsData: array<accountType>,
   ) => {
-    <div className="flex flex-col gap-4 px-2 my-6">
+    <div className="flex flex-col gap-4 px-2 mb-6">
       <RenderIf condition={openedTransaction.data.reason->Option.isSome}>
-        <div className="flex flex-col gap-2 p-4 border border-nd_gray-150 rounded-lg w-full">
+        <div className="flex flex-col gap-2 p-4 mt-6 border border-nd_gray-150 rounded-lg w-full">
           <div className="flex flex-row justify-between">
             <p className={`${body.lg.semibold} text-nd_gray-700`}>
               {"Resolution Remark"->React.string}

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsHelper.res
@@ -110,71 +110,11 @@ module EntryAuditTrailInfo = {
   open ReconEngineTypes
 
   @react.component
-  let make = (~openedTransaction: transactionType, ~entriesList: array<entryType>=[]) => {
-    open EntriesTableEntity
-    open ReconEngineTransactionsUtils
-    open ReconEngineUtils
-
-    let accountGroups = React.useMemo(() => {
-      let groupedByAccount = entriesList->Array.reduce(Dict.make(), (acc, entry) => {
-        let accountId = entry.account_id
-        let existing = acc->getValueFromDict(accountId, [])
-        acc->Dict.set(accountId, [...existing, entry])
-        acc
-      })
-
-      groupedByAccount
-      ->Dict.toArray
-      ->Array.map(((accountId, entries)) => {
-        let entry = entries->getValueFromArray(0, Dict.make()->entryItemToObjMapper)
-        let accountName = entry.account_name
-        ({accountId, accountName, entries}: ReconEngineTransactionsTypes.accountGroup)
-      })
-    }, [entriesList])
-
-    let heading = detailsFields->Array.map(getHeading)
-
-    let getSectionRowDetails = (sectionIndex: int, rowIndex: int) => {
-      let group = accountGroups->getValueFromArray(
-        sectionIndex,
-        (
-          {
-            accountId: "",
-            accountName: "",
-            entries: [],
-          }: ReconEngineTransactionsTypes.accountGroup
-        ),
-      )
-      let entry = group.entries->getValueFromArray(rowIndex, Dict.make()->entryItemToObjMapper)
-      let filteredEntryMetadata = entry.metadata->getFilteredMetadataFromEntries
-      let hasEntryMetadata = !(filteredEntryMetadata->isEmptyDict)
-
-      <RenderIf condition={rowIndex < group.entries->Array.length}>
-        <RenderIf condition={hasEntryMetadata}>
-          <div className="p-4">
-            <div className="w-full bg-nd_gray-50 rounded-xl overflow-y-scroll !max-h-60 py-2 px-6">
-              <PrettyPrintJson
-                jsonToDisplay={filteredEntryMetadata->JSON.Encode.object->JSON.stringify}
-              />
-            </div>
-          </div>
-        </RenderIf>
-      </RenderIf>
-    }
-
-    let sections = accountGroups->Array.map(group => {
-      open ReconEngineExceptionTransactionTypes
-      {
-        titleElement: <p className={`text-nd_gray-800 ${body.lg.semibold} mb-2`}>
-          {group.accountName->React.string}
-        </p>,
-        rows: group.entries->Array.map(entry =>
-          detailsFields->Array.map(colType => getCell(entry, colType))
-        ),
-        rowData: group.entries->Array.map(entry => entry->Identity.genericTypeToJson),
-      }
-    })
-
+  let make = (
+    ~openedTransaction: transactionType,
+    ~accountIds: array<string>,
+    ~accountsData: array<accountType>,
+  ) => {
     <div className="flex flex-col gap-4 px-2 my-6">
       <RenderIf condition={openedTransaction.data.reason->Option.isSome}>
         <div className="flex flex-col gap-2 p-4 border border-nd_gray-150 rounded-lg w-full">
@@ -188,8 +128,11 @@ module EntryAuditTrailInfo = {
           </p>
         </div>
       </RenderIf>
-      <ReconEngineCustomExpandableSelectionTable
-        title="" heading getSectionRowDetails showScrollBar=true showOptions=false sections
+      <ReconEngineTransactionEntries
+        primaryTransactionId={openedTransaction.id}
+        accountIds
+        accountsData
+        entriesDetailFields=EntriesTableEntity.detailsFields
       />
       <RenderIf condition={openedTransaction.linked_transaction->Option.isSome}>
         <div className="flex flex-col gap-4">
@@ -239,23 +182,18 @@ module HierarchicalMoreEntriesRenderer = {
 
 module AuditTrail = {
   @react.component
-  let make = (~allTransactionDetails) => {
+  let make = (
+    ~allTransactionDetails,
+    ~accountIds: array<string>,
+    ~accountsData: array<ReconEngineTypes.accountType>,
+  ) => {
     open AuditTrailStepIndicatorTypes
     open ReconEngineTransactionsUtils
-    open ReconEngineTypes
-    open APIUtils
-
-    let getURL = useGetURL()
-    let fetchDetails = useGetMethod()
 
     let (showModal, setShowModal) = React.useState(_ => false)
     let (openedTransaction, setOpenedTransaction) = React.useState(_ =>
       Dict.make()->getTransactionsPayloadFromDict
     )
-    let (entriesList, setEntriesList) = React.useState(_ => [
-      Dict.make()->transactionsEntryItemToObjMapperFromDict,
-    ])
-    let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
 
     React.useMemo(() => {
       if allTransactionDetails->Array.length > 0 {
@@ -263,66 +201,31 @@ module AuditTrail = {
       }
     }, [allTransactionDetails])
 
-    let getEntriesDetails = async _ => {
-      setScreenState(_ => PageLoaderWrapper.Loading)
-      try {
-        let url = getURL(
-          ~entityName=V1(HYPERSWITCH_RECON),
-          ~methodType=Get,
-          ~hyperswitchReconType=#PROCESSED_ENTRIES_LIST_WITH_TRANSACTION,
-          ~id=Some(openedTransaction.transaction_id),
-        )
-        let res = await fetchDetails(url)
-        let entriesList = res->getArrayDataFromJson(transactionsEntryItemToObjMapperFromDict)
-        let entriesDataArray = openedTransaction.entries->Array.map(entry => {
-          let foundEntry =
-            entriesList
-            ->Array.find(e => entry.entry_id == e.entry_id)
-            ->Option.getOr(Dict.make()->transactionsEntryItemToObjMapperFromDict)
+    let sections =
+      allTransactionDetails->Array.map((transaction: ReconEngineTypes.transactionType) => {
+        let reasonText = switch transaction.data.reason {
+        | Some(reason) if reason->isNonEmptyString => Some(reason)
+        | _ => transaction.discarded_data->Option.flatMap(discardedData => discardedData.reason)
+        }
 
-          {
-            ...foundEntry,
-            account_name: entry.account.account_name,
-          }
-        })
-        setEntriesList(_ => entriesDataArray)
-        setScreenState(_ => PageLoaderWrapper.Success)
-      } catch {
-      | _ => setScreenState(_ => PageLoaderWrapper.Error("Failed to fetch transaction details"))
-      }
-    }
-
-    let sections = allTransactionDetails->Array.map((transaction: transactionType) => {
-      let reasonText = switch transaction.data.reason {
-      | Some(reason) if reason->isNonEmptyString => Some(reason)
-      | _ => transaction.discarded_data->Option.flatMap(discardedData => discardedData.reason)
-      }
-
-      let customComponent = {
-        id: transaction.version->Int.toString,
-        customComponent: Some(
-          <TransactionDetailInfo
-            currentTransactionDetails=transaction
-            detailsFields=[Status, Variance, CreatedAt]
-            customWidthClass="w-1/3"
-          />,
-        ),
-        onClick: _ => {
-          setOpenedTransaction(_ => transaction)
-          setShowModal(_ => true)
-        },
-        reasonText,
-        modifiedBy: transaction.modified_by,
-      }
-      customComponent
-    })
-
-    React.useEffect(() => {
-      if showModal {
-        getEntriesDetails()->ignore
-      }
-      None
-    }, [showModal])
+        let customComponent = {
+          id: transaction.version->Int.toString,
+          customComponent: Some(
+            <TransactionDetailInfo
+              currentTransactionDetails=transaction
+              detailsFields=[Status, Variance, CreatedAt]
+              customWidthClass="w-1/3"
+            />,
+          ),
+          onClick: _ => {
+            setOpenedTransaction(_ => transaction)
+            setShowModal(_ => true)
+          },
+          reasonText,
+          modifiedBy: transaction.modified_by,
+        }
+        customComponent
+      })
 
     let modalHeading = {
       <div className="flex justify-between border-b">
@@ -364,35 +267,24 @@ module AuditTrail = {
         modalClass="flex flex-col justify-start h-screen w-2/5 float-right overflow-hidden !bg-white dark:!bg-jp-gray-lightgray_background"
         childClass="relative h-full"
         customModalHeading=modalHeading>
-        <PageLoaderWrapper
-          screenState
-          customLoader={<div className="h-full flex flex-col justify-center items-center">
-            <div className="animate-spin mb-1">
-              <Icon name="spinner" size=20 />
-            </div>
-          </div>}>
-          <div className="h-full relative">
-            <div className="absolute inset-0 overflow-y-auto px-2 pb-20">
-              <RenderIf condition={entriesList->Array.length > 0}>
-                <EntryAuditTrailInfo openedTransaction entriesList />
-              </RenderIf>
-              <RenderIf condition={entriesList->Array.length === 0}>
-                <div className="text-center text-nd_gray-500 py-8">
-                  {"No entries found"->React.string}
-                </div>
-              </RenderIf>
-            </div>
-            <div
-              className="absolute bottom-0 left-0 right-0 bg-white dark:bg-jp-gray-lightgray_background p-4 border-t border-nd_gray-150">
-              <Button
-                customButtonStyle="!w-full"
-                buttonType=Button.Primary
-                onClick={_ => setShowModal(_ => false)}
-                text="OK"
+        <div className="h-full relative">
+          <div className="absolute inset-0 overflow-y-auto px-2 pb-20">
+            <RenderIf condition={showModal && openedTransaction.id->isNonEmptyString}>
+              <EntryAuditTrailInfo
+                key={openedTransaction.id} openedTransaction accountIds accountsData
               />
-            </div>
+            </RenderIf>
           </div>
-        </PageLoaderWrapper>
+          <div
+            className="absolute bottom-0 left-0 right-0 bg-white dark:bg-jp-gray-lightgray_background p-4 border-t border-nd_gray-150">
+            <Button
+              customButtonStyle="!w-full"
+              buttonType=Button.Primary
+              onClick={_ => setShowModal(_ => false)}
+              text="OK"
+            />
+          </div>
+        </div>
       </Modal>
     </>
   }
@@ -400,7 +292,11 @@ module AuditTrail = {
 
 module AuditTrailTab = {
   @react.component
-  let make = (~transactionId: string) => {
+  let make = (
+    ~transactionId: string,
+    ~accountIds: array<string>,
+    ~accountsData: array<ReconEngineTypes.accountType>,
+  ) => {
     let getTransactions = ReconEngineHooks.useGetTransactions()
     let (allTransactionDetails, setAllTransactionDetails) = React.useState(_ => [])
     let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
@@ -425,7 +321,7 @@ module AuditTrailTab = {
 
     <PageLoaderWrapper
       screenState customLoader={<Shimmer styleClass="h-40 w-full mt-8 rounded-xl" />}>
-      <AuditTrail allTransactionDetails />
+      <AuditTrail allTransactionDetails accountIds accountsData />
     </PageLoaderWrapper>
   }
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsTypes.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsTypes.res
@@ -35,12 +35,6 @@ type entriesListCursorPayload = {
 
 type entriesMetadataKeysToExclude = Amount | Currency
 
-type accountGroup = {
-  accountId: string,
-  accountName: string,
-  entries: array<entryType>,
-}
-
 type lineageFieldType = {
   lineageFieldLabel: string,
   lineageFieldValue: string,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

- **Audit Trail modal** (transaction details and exception details pages): clicking a version now renders the Entries tab's `ReconEngineTransactionEntries` for that version, fetching through `POST /entries/list` per rule account with cursor pagination, filters and ID search. Previously it called `GET /transactions/{transaction_id}/entries`, which returns every version's entries unpaginated, and filtered them client-side.
- `ReconEngineTransactionEntriesContent` takes an optional `entriesDetailFields` prop (default unchanged) so the modal keeps its existing column set.
- The modal content mounts only while open and is keyed on the version `id`, so each click fetches exactly that version's entries.
- Removed the old fetch, state and effect from `AuditTrail`, and the now-unused `accountGroup` type.


https://github.com/user-attachments/assets/147a504c-6ed0-415a-9e53-2d4ed1cc5efd

https://github.com/user-attachments/assets/3354afae-909b-4341-b949-bfb4cabe3e4f



## Motivation and Context

Closes #5501.

Every version click issued the same all-versions request and did the version filtering in the browser. `/entries/list` is version-scoped, paginated, and profile-checked, and the Entries tab already uses it.

## How did you test it?

Locally, one `POST /entries/list` per account with the clicked version's `id` (changing per version), archived versions returning archived entries, pagination/filters/search inside the modal, and the Entries tab unchanged.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

<!-- If Yes, please add the related backend PR URL(s) below -->

Backend PR URL:

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

<!-- If applicable, mention the feature flag name(s) below -->

Feature flag name(s):

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible