### PR TITLE
fix: sync routing history on focus and hand off cut-over flows to the Decision Engine

### DIFF
--- a/src/screens/Routing/History.res
+++ b/src/screens/Routing/History.res
@@ -1,9 +1,32 @@
 open HistoryEntity
 module HistoryTable = {
   @react.component
-  let make = (~records, ~activeRoutingIds: array<string>) => {
+  let make = (
+    ~records,
+    ~activeRoutingIds: array<string>,
+    ~isCutover=false,
+    ~onDecisionEngineRedirect=(_, _) => (),
+  ) => {
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
     let (offset, setOffset) = React.useState(_ => 0)
+
+    let openRecord = (historyData: RoutingTypes.historyData) => {
+      let routingType = historyData.kind->RoutingUtils.routingTypeMapper
+      let target = routingType->RoutingUtils.decisionEngineRoutingTarget
+      if target->LogicUtils.isNonEmptyString {
+        onDecisionEngineRedirect(target, historyData.id)
+      } else {
+        RescriptReactRouter.push(
+          GlobalVars.appendDashboardPath(
+            ~url=`/routing/${routingType->RoutingUtils.routingTypeName}?id=${historyData.id}${activeRoutingIds->Array.includes(
+                historyData.id,
+              )
+                ? "&isActive=true"
+                : ""}`,
+          ),
+        )
+      }
+    }
 
     <LoadedTable
       title="History"
@@ -19,12 +42,18 @@ module HistoryTable = {
       offset
       setOffset
       currentFetchCount={records->Array.length}
+      onEntityClick=?{isCutover ? Some(openRecord) : None}
     />
   }
 }
 @react.component
-let make = (~records, ~activeRoutingIds: array<string>) => {
+let make = (
+  ~records,
+  ~activeRoutingIds: array<string>,
+  ~isCutover=false,
+  ~onDecisionEngineRedirect=(_, _) => (),
+) => {
   <div className="mt-8">
-    <HistoryTable records activeRoutingIds />
+    <HistoryTable records activeRoutingIds isCutover onDecisionEngineRedirect />
   </div>
 }

--- a/src/screens/Routing/History.res
+++ b/src/screens/Routing/History.res
@@ -1,5 +1,6 @@
 open HistoryEntity
 open RoutingUtils
+open LogicUtils
 module HistoryTable = {
   @react.component
   let make = (
@@ -15,11 +16,9 @@ module HistoryTable = {
     let openRecord = (historyData: RoutingTypes.historyData) => {
       let routingType = historyData.kind->routingTypeMapper
       let target = routingType->decisionEngineRoutingTarget
-      if target->LogicUtils.isNonEmptyString {
+      if target->isNonEmptyString {
         onDecisionEngineRedirect(target, historyData.id)
       } else {
-        // Non-Decision-Engine kinds fall back to the native page — same URL builder and access
-        // check the table's getShowLink uses, so the two can't drift.
         let link = GroupAccessUtils.linkForGetShowLinkViaAccess(
           ~authorization,
           ~url=historyRecordNativeUrl(
@@ -28,7 +27,7 @@ module HistoryTable = {
             ~activeRoutingIds,
           ),
         )
-        if link->LogicUtils.isNonEmptyString {
+        if link->isNonEmptyString {
           RescriptReactRouter.push(link)
         }
       }

--- a/src/screens/Routing/History.res
+++ b/src/screens/Routing/History.res
@@ -1,4 +1,5 @@
 open HistoryEntity
+open RoutingUtils
 module HistoryTable = {
   @react.component
   let make = (
@@ -9,22 +10,29 @@ module HistoryTable = {
   ) => {
     let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
     let (offset, setOffset) = React.useState(_ => 0)
+    let authorization = userHasAccess(~groupAccess=WorkflowsManage)
 
     let openRecord = (historyData: RoutingTypes.historyData) => {
-      let routingType = historyData.kind->RoutingUtils.routingTypeMapper
-      let target = routingType->RoutingUtils.decisionEngineRoutingTarget
+      let routingType = historyData.kind->routingTypeMapper
+      let target = routingType->decisionEngineRoutingTarget
       if target->LogicUtils.isNonEmptyString {
         onDecisionEngineRedirect(target, historyData.id)
       } else {
-        RescriptReactRouter.push(
-          GlobalVars.appendDashboardPath(
-            ~url=`/routing/${routingType->RoutingUtils.routingTypeName}?id=${historyData.id}${activeRoutingIds->Array.includes(
+        // Non-Decision-Engine kinds fall back to the native page, gated by the same access check
+        // the table's getShowLink uses.
+        let link = GroupAccessUtils.linkForGetShowLinkViaAccess(
+          ~authorization,
+          ~url=GlobalVars.appendDashboardPath(
+            ~url=`/routing/${routingType->routingTypeName}?id=${historyData.id}${activeRoutingIds->Array.includes(
                 historyData.id,
               )
                 ? "&isActive=true"
                 : ""}`,
           ),
         )
+        if link->LogicUtils.isNonEmptyString {
+          RescriptReactRouter.push(link)
+        }
       }
     }
 
@@ -32,10 +40,7 @@ module HistoryTable = {
       title="History"
       hideTitle=true
       actualData=records
-      entity={historyEntity(
-        activeRoutingIds,
-        ~authorization=userHasAccess(~groupAccess=WorkflowsManage),
-      )}
+      entity={historyEntity(activeRoutingIds, ~authorization)}
       resultsPerPage=10
       showSerialNumber=true
       totalResults={records->Array.length}

--- a/src/screens/Routing/History.res
+++ b/src/screens/Routing/History.res
@@ -18,16 +18,14 @@ module HistoryTable = {
       if target->LogicUtils.isNonEmptyString {
         onDecisionEngineRedirect(target, historyData.id)
       } else {
-        // Non-Decision-Engine kinds fall back to the native page, gated by the same access check
-        // the table's getShowLink uses.
+        // Non-Decision-Engine kinds fall back to the native page — same URL builder and access
+        // check the table's getShowLink uses, so the two can't drift.
         let link = GroupAccessUtils.linkForGetShowLinkViaAccess(
           ~authorization,
-          ~url=GlobalVars.appendDashboardPath(
-            ~url=`/routing/${routingType->routingTypeName}?id=${historyData.id}${activeRoutingIds->Array.includes(
-                historyData.id,
-              )
-                ? "&isActive=true"
-                : ""}`,
+          ~url=historyRecordNativeUrl(
+            ~kind=historyData.kind,
+            ~id=historyData.id,
+            ~activeRoutingIds,
           ),
         )
         if link->LogicUtils.isNonEmptyString {

--- a/src/screens/Routing/HistoryEntity.res
+++ b/src/screens/Routing/HistoryEntity.res
@@ -68,13 +68,7 @@ let historyEntity = (
     ~getShowLink={
       value => {
         GroupAccessUtils.linkForGetShowLinkViaAccess(
-          ~url=GlobalVars.appendDashboardPath(
-            ~url=`/routing/${value.kind
-              ->routingTypeMapper
-              ->routingTypeName}?id=${value.id}${activeRoutingIds->Array.includes(value.id)
-                ? "&isActive=true"
-                : ""}`,
-          ),
+          ~url=historyRecordNativeUrl(~kind=value.kind, ~id=value.id, ~activeRoutingIds),
           ~authorization,
         )
       }

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -5,12 +5,53 @@ let make = (~routingType) => {
   open LogicUtils
   let baseUrlForRedirection = "/routing"
   let url = RescriptReactRouter.useUrl()
+  let getURL = APIUtils.useGetURL()
+  let updateDetails = APIUtils.useUpdateMethod(~showErrorToast=false)
+  let showToast = ToastAdapter.useShowToast()
   let (currentRouting, setCurrentRouting) = React.useState(() => NO_ROUTING)
   let (id, setId) = React.useState(() => None)
   let (isActive, setIsActive) = React.useState(_ => false)
   let connectorList = ConnectorListInterface.useFilteredConnectorList(
     ~retainInList=ConnectorTypes.PaymentProcessor,
   )
+  // These routing types are configured in the Decision Engine dashboard when the
+  // profile is cut over, so their native forms must not be reachable there.
+  let isDecisionEngineManaged = switch routingType->String.toLowerCase {
+  | "volume" | "rule" | "auth-rate" => true
+  | _ => false
+  }
+  let (cutoverStatus, setCutoverStatus) = React.useState(_ =>
+    isDecisionEngineManaged ? None : Some(false)
+  )
+
+  let checkRoutingEntry = async () => {
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
+      let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
+      setCutoverStatus(_ => Some(cutover))
+    } catch {
+    | Exn.Error(_) => setCutoverStatus(_ => Some(false))
+    }
+  }
+
+  React.useEffect(() => {
+    if isDecisionEngineManaged {
+      checkRoutingEntry()->ignore
+    }
+    None
+  }, [])
+
+  React.useEffect(() => {
+    if isDecisionEngineManaged && cutoverStatus->Option.getOr(false) {
+      showToast(
+        ~message="This profile's routing is managed by the Decision Engine. Use the Smart Routing page to configure it.",
+        ~toastType=ToastState.ToastInfo,
+      )
+      RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
+    }
+    None
+  }, [cutoverStatus])
 
   React.useEffect(() => {
     let searchParams = url.search
@@ -32,37 +73,44 @@ let make = (~routingType) => {
     None
   }, [url.search])
 
-  <div className="flex flex-col gap-2">
-    <PageUtils.PageHeading title="Smart Routing Configurations" customHeadingStyle="!mb-0" />
-    <BreadCrumbNavigation
-      path=[{title: "Smart Routing Configurations", link: "/routing"}]
-      currentPageTitle={getContent(currentRouting).heading}
-    />
-    {switch currentRouting {
-    | VOLUME_SPLIT =>
-      <VolumeSplitRouting
-        routingRuleId=id isActive connectorList urlEntityName=V1(ROUTING) baseUrlForRedirection
+  let screenState = switch cutoverStatus {
+  | Some(false) => PageLoaderWrapper.Success
+  | _ => PageLoaderWrapper.Loading
+  }
+
+  <PageLoaderWrapper screenState>
+    <div className="flex flex-col gap-2">
+      <PageUtils.PageHeading title="Smart Routing Configurations" customHeadingStyle="!mb-0" />
+      <BreadCrumbNavigation
+        path=[{title: "Smart Routing Configurations", link: "/routing"}]
+        currentPageTitle={getContent(currentRouting).heading}
       />
-    | ADVANCED =>
-      <AdvancedRouting
-        routingRuleId=id
-        isActive
-        setCurrentRouting
-        connectorList
-        urlEntityName=V1(ROUTING)
-        baseUrlForRedirection
-      />
-    | AUTH_RATE_ROUTING =>
-      <AuthRateRouting
-        routingRuleId=id isActive connectorList urlEntityName=V1(ROUTING) baseUrlForRedirection
-      />
-    | DEFAULTFALLBACK =>
-      <DefaultRouting
-        urlEntityName=V1(DEFAULT_FALLBACK)
-        baseUrlForRedirection
-        connectorVariant=ConnectorTypes.PaymentProcessor
-      />
-    | _ => <> </>
-    }}
-  </div>
+      {switch currentRouting {
+      | VOLUME_SPLIT =>
+        <VolumeSplitRouting
+          routingRuleId=id isActive connectorList urlEntityName=V1(ROUTING) baseUrlForRedirection
+        />
+      | ADVANCED =>
+        <AdvancedRouting
+          routingRuleId=id
+          isActive
+          setCurrentRouting
+          connectorList
+          urlEntityName=V1(ROUTING)
+          baseUrlForRedirection
+        />
+      | AUTH_RATE_ROUTING =>
+        <AuthRateRouting
+          routingRuleId=id isActive connectorList urlEntityName=V1(ROUTING) baseUrlForRedirection
+        />
+      | DEFAULTFALLBACK =>
+        <DefaultRouting
+          urlEntityName=V1(DEFAULT_FALLBACK)
+          baseUrlForRedirection
+          connectorVariant=ConnectorTypes.PaymentProcessor
+        />
+      | _ => <> </>
+      }}
+    </div>
+  </PageLoaderWrapper>
 }

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -31,6 +31,8 @@ let make = (~routingType) => {
       let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
       setCutoverStatus(_ => Some(cutover))
     } catch {
+    // If the entry check fails, fall back to the native form rather than blocking the page —
+    // the guard is a redirect for cut-over profiles, not a hard gate.
     | Exn.Error(_) => setCutoverStatus(_ => Some(false))
     }
   }

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -23,26 +23,33 @@ let make = (~routingType) => {
   )
 
   React.useEffect(() => {
+    setCutoverStatus(_ => isDecisionEngineManaged ? None : Some(false))
     if isDecisionEngineManaged {
+      let bounceToRouting = () =>
+        RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
+
       (
         async () => {
-          let cutover = await checkRoutingEntryCutover()
-          setCutoverStatus(_ => Some(cutover))
-
+          switch await checkRoutingEntryCutover() {
           // Cut-over profiles configure these routing types in the Decision Engine dashboard, so
           // bounce back to the Smart Routing page instead of showing the native form.
-          if cutover {
+          | Some(true) =>
+            setCutoverStatus(_ => Some(true))
             showToast(
               ~message="This profile's routing is managed by the Decision Engine. Use the Smart Routing page to configure it.",
               ~toastType=ToastState.ToastInfo,
             )
-            RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
+            bounceToRouting()
+          | Some(false) => setCutoverStatus(_ => Some(false))
+          // Unknown (the probe failed): fail safe — a possibly cut-over profile must not fall
+          // through to the native form, so send the user back to the Smart Routing page.
+          | None => bounceToRouting()
           }
         }
       )()->ignore
     }
     None
-  }, [])
+  }, [routingType])
 
   React.useEffect(() => {
     let searchParams = url.search

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -31,8 +31,6 @@ let make = (~routingType) => {
       (
         async () => {
           switch await checkRoutingEntryCutover() {
-          // Cut-over profiles configure these routing types in the Decision Engine dashboard, so
-          // bounce back to the Smart Routing page instead of showing the native form.
           | Some(true) =>
             setCutoverStatus(_ => Some(true))
             showToast(
@@ -41,8 +39,6 @@ let make = (~routingType) => {
             )
             bounceToRouting()
           | Some(false) => setCutoverStatus(_ => Some(false))
-          // Unknown (the probe failed): fail safe — a possibly cut-over profile must not fall
-          // through to the native form, so send the user back to the Smart Routing page.
           | None => bounceToRouting()
           }
         }
@@ -101,7 +97,7 @@ let make = (~routingType) => {
           baseUrlForRedirection
           connectorVariant=ConnectorTypes.PaymentProcessor
         />
-      | _ => <> </>
+      | NO_ROUTING => <> </>
       }}
     </div>
   </PageLoaderWrapper>

--- a/src/screens/Routing/RoutingConfigure.res
+++ b/src/screens/Routing/RoutingConfigure.res
@@ -5,67 +5,50 @@ let make = (~routingType) => {
   open LogicUtils
   let baseUrlForRedirection = "/routing"
   let url = RescriptReactRouter.useUrl()
-  let getURL = APIUtils.useGetURL()
-  let updateDetails = APIUtils.useUpdateMethod(~showErrorToast=false)
   let showToast = ToastAdapter.useShowToast()
+  let checkRoutingEntryCutover = useCheckRoutingEntryCutover()
   let (currentRouting, setCurrentRouting) = React.useState(() => NO_ROUTING)
   let (id, setId) = React.useState(() => None)
   let (isActive, setIsActive) = React.useState(_ => false)
   let connectorList = ConnectorListInterface.useFilteredConnectorList(
     ~retainInList=ConnectorTypes.PaymentProcessor,
   )
-  // These routing types are configured in the Decision Engine dashboard when the
-  // profile is cut over, so their native forms must not be reachable there.
-  let isDecisionEngineManaged = switch routingType->String.toLowerCase {
-  | "volume" | "rule" | "auth-rate" => true
-  | _ => false
-  }
+  // Volume / rule / auth-rate are configured in the Decision Engine dashboard when the profile is
+  // cut over, so their native forms must not be reachable there — they are exactly the routing
+  // types that have a Decision Engine target.
+  let isDecisionEngineManaged =
+    routingType->routingTypeFromName->decisionEngineRoutingTarget->isNonEmptyString
   let (cutoverStatus, setCutoverStatus) = React.useState(_ =>
     isDecisionEngineManaged ? None : Some(false)
   )
 
-  let checkRoutingEntry = async () => {
-    try {
-      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
-      let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
-      let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
-      setCutoverStatus(_ => Some(cutover))
-    } catch {
-    // If the entry check fails, fall back to the native form rather than blocking the page —
-    // the guard is a redirect for cut-over profiles, not a hard gate.
-    | Exn.Error(_) => setCutoverStatus(_ => Some(false))
-    }
-  }
-
   React.useEffect(() => {
     if isDecisionEngineManaged {
-      checkRoutingEntry()->ignore
+      (
+        async () => {
+          let cutover = await checkRoutingEntryCutover()
+          setCutoverStatus(_ => Some(cutover))
+
+          // Cut-over profiles configure these routing types in the Decision Engine dashboard, so
+          // bounce back to the Smart Routing page instead of showing the native form.
+          if cutover {
+            showToast(
+              ~message="This profile's routing is managed by the Decision Engine. Use the Smart Routing page to configure it.",
+              ~toastType=ToastState.ToastInfo,
+            )
+            RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
+          }
+        }
+      )()->ignore
     }
     None
   }, [])
 
   React.useEffect(() => {
-    if isDecisionEngineManaged && cutoverStatus->Option.getOr(false) {
-      showToast(
-        ~message="This profile's routing is managed by the Decision Engine. Use the Smart Routing page to configure it.",
-        ~toastType=ToastState.ToastInfo,
-      )
-      RescriptReactRouter.replace(GlobalVars.appendDashboardPath(~url="/routing"))
-    }
-    None
-  }, [cutoverStatus])
-
-  React.useEffect(() => {
     let searchParams = url.search
     let filtersFromUrl = getDictFromUrlSearchParams(searchParams)->Dict.get("id")
     setId(_ => filtersFromUrl)
-    switch routingType->String.toLowerCase {
-    | "volume" => setCurrentRouting(_ => VOLUME_SPLIT)
-    | "rule" => setCurrentRouting(_ => ADVANCED)
-    | "default" => setCurrentRouting(_ => DEFAULTFALLBACK)
-    | "auth-rate" => setCurrentRouting(_ => AUTH_RATE_ROUTING)
-    | _ => setCurrentRouting(_ => NO_ROUTING)
-    }
+    setCurrentRouting(_ => routingType->routingTypeFromName)
     let isActive =
       getDictFromUrlSearchParams(searchParams)
       ->Dict.get("isActive")
@@ -77,7 +60,7 @@ let make = (~routingType) => {
 
   let screenState = switch cutoverStatus {
   | Some(false) => PageLoaderWrapper.Success
-  | _ => PageLoaderWrapper.Loading
+  | Some(true) | None => PageLoaderWrapper.Loading
   }
 
   <PageLoaderWrapper screenState>

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -96,46 +96,34 @@ let make = (~remainingPath, ~previewOnly=false) => {
     profileId,
   ))
 
-  let fetchRoutingRecords = async (~silent=false, activeIds) => {
-    try {
-      if !silent {
-        setScreenState(_ => PageLoaderWrapper.Loading)
-      }
-      let routingUrl = `${getURL(~entityName=V1(ROUTING), ~methodType=Get)}?limit=100`
-      let routingJson = await fetchDetails(routingUrl)
-      let configuredRules = routingJson->RoutingUtils.getRecordsObject
-      let recordsData =
-        configuredRules
-        ->Belt.Array.keepMap(JSON.Decode.object)
-        ->Array.map(HistoryEntity.itemToObjMapper)
+  // Fetch and set the history records for the given active ids. Never touches screenState,
+  // so the same code serves the initial load and the silent focus re-sync.
+  let refreshRoutingRecords = async activeIds => {
+    let routingUrl = `${getURL(~entityName=V1(ROUTING), ~methodType=Get)}?limit=100`
+    let routingJson = await fetchDetails(routingUrl)
+    let configuredRules = routingJson->RoutingUtils.getRecordsObject
+    let recordsData =
+      configuredRules
+      ->Belt.Array.keepMap(JSON.Decode.object)
+      ->Array.map(HistoryEntity.itemToObjMapper)
 
-      // To sort the data in a format that active routing always comes at top of the table
-      // For ref:https://rescript-lang.org/docs/manual/latest/api/js/array-2#sortinplacewith
+    // To sort the data in a format that active routing always comes at top of the table
+    // For ref:https://rescript-lang.org/docs/manual/latest/api/js/array-2#sortinplacewith
 
-      let sortedHistoryRecords =
-        recordsData
-        ->Array.toSorted((item1, item2) => {
-          if activeIds->Array.includes(item1.id) {
-            -1.
-          } else if activeIds->Array.includes(item2.id) {
-            1.
-          } else {
-            0.
-          }
-        })
-        ->Array.map(Nullable.make)
+    let sortedHistoryRecords =
+      recordsData
+      ->Array.toSorted((item1, item2) => {
+        if activeIds->Array.includes(item1.id) {
+          -1.
+        } else if activeIds->Array.includes(item2.id) {
+          1.
+        } else {
+          0.
+        }
+      })
+      ->Array.map(Nullable.make)
 
-      setRecords(_ => sortedHistoryRecords)
-      if !silent {
-        setScreenState(_ => PageLoaderWrapper.Success)
-      }
-    } catch {
-    | Exn.Error(e) =>
-      if !silent {
-        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-        setScreenState(_ => PageLoaderWrapper.Error(err))
-      }
-    }
+    setRecords(_ => sortedHistoryRecords)
   }
 
   let getActiveRoutingList = async () => {
@@ -144,38 +132,36 @@ let make = (~remainingPath, ~previewOnly=false) => {
     routingJson->LogicUtils.getArrayFromJson([])
   }
 
-  let fetchActiveRouting = async (~silent=false) => {
+  // Re-sync the active strategies, the configuration history and the active-id set together.
+  // Never touches screenState; may throw, so callers decide whether to surface the error.
+  let syncRoutingState = async () => {
     open LogicUtils
-    try {
-      if !silent {
-        setScreenState(_ => PageLoaderWrapper.Loading)
-      }
-      let routingArr = await getActiveRoutingList()
+    let routingArr = await getActiveRoutingList()
 
-      if routingArr->isNonEmptyArray {
-        let currentActiveIds = []
-        routingArr->Array.forEach(ele => {
-          let id = ele->getDictFromJsonObject->getString("id", "")
-          currentActiveIds->Array.push(id)
-        })
-        await fetchRoutingRecords(~silent, currentActiveIds)
-        setActiveRoutingIds(_ => currentActiveIds)
-        setRoutingType(_ => routingArr)
-      } else {
-        await fetchRoutingRecords(~silent, [])
-        setActiveRoutingIds(_ => [])
-        let defaultFallback = [("kind", "default"->JSON.Encode.string)]->Dict.fromArray
-        setRoutingType(_ => [defaultFallback->JSON.Encode.object])
-        if !silent {
-          setScreenState(_ => PageLoaderWrapper.Success)
-        }
-      }
+    if routingArr->isNonEmptyArray {
+      let currentActiveIds =
+        routingArr->Array.map(ele => ele->getDictFromJsonObject->getString("id", ""))
+      await refreshRoutingRecords(currentActiveIds)
+      setActiveRoutingIds(_ => currentActiveIds)
+      setRoutingType(_ => routingArr)
+    } else {
+      await refreshRoutingRecords([])
+      setActiveRoutingIds(_ => [])
+      let defaultFallback = [("kind", "default"->JSON.Encode.string)]->getJsonFromArrayOfJson
+      setRoutingType(_ => [defaultFallback])
+    }
+  }
+
+  // Initial load drives the page loader off the same sync.
+  let fetchActiveRouting = async () => {
+    setScreenState(_ => PageLoaderWrapper.Loading)
+    try {
+      await syncRoutingState()
+      setScreenState(_ => PageLoaderWrapper.Success)
     } catch {
     | Exn.Error(e) =>
-      if !silent {
-        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-        setScreenState(_ => PageLoaderWrapper.Error(err))
-      }
+      let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
+      setScreenState(_ => PageLoaderWrapper.Error(err))
     }
   }
 
@@ -186,9 +172,9 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
   React.useEffect(() => {
     if isCutover && !previewOnly {
-      // Rules can change in the Decision Engine dashboard tab; re-sync the active
-      // list and the configuration history whenever this tab regains focus.
-      let onFocus = _ => fetchActiveRouting(~silent=true)->ignore
+      // Rules can change in the Decision Engine dashboard tab; silently re-sync the active
+      // strategies and configuration history (no loader) when this tab regains focus.
+      let onFocus = _ => syncRoutingState()->Promise.catch(_ => Promise.resolve())->ignore
       Window.addEventListener("focus", onFocus)
       Some(() => Window.removeEventListener("focus", onFocus))
     } else {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -69,7 +69,13 @@ let make = (~remainingPath, ~previewOnly=false) => {
             title: "Configuration History",
             renderContent: () => {
               records->Array.length > 0
-                ? <History records activeRoutingIds />
+                ? <History
+                    records
+                    activeRoutingIds
+                    isCutover
+                    onDecisionEngineRedirect={(target, ruleId) =>
+                      openDecisionEngineRoutingPage(target, ruleId)->ignore}
+                  />
                 : <DefaultLandingPage
                     height="90%"
                     title="No Routing Rule Configured!"
@@ -80,11 +86,21 @@ let make = (~remainingPath, ~previewOnly=false) => {
           },
         ])
       : baseTabs
-  }, (routingType, debitRoutingValue, isCutover, connectorList, profileId))
+  }, (
+    routingType,
+    records,
+    activeRoutingIds,
+    debitRoutingValue,
+    isCutover,
+    connectorList,
+    profileId,
+  ))
 
-  let fetchRoutingRecords = async activeIds => {
+  let fetchRoutingRecords = async (~silent=false, activeIds) => {
     try {
-      setScreenState(_ => PageLoaderWrapper.Loading)
+      if !silent {
+        setScreenState(_ => PageLoaderWrapper.Loading)
+      }
       let routingUrl = `${getURL(~entityName=V1(ROUTING), ~methodType=Get)}?limit=100`
       let routingJson = await fetchDetails(routingUrl)
       let configuredRules = routingJson->RoutingUtils.getRecordsObject
@@ -110,11 +126,15 @@ let make = (~remainingPath, ~previewOnly=false) => {
         ->Array.map(Nullable.make)
 
       setRecords(_ => sortedHistoryRecords)
-      setScreenState(_ => PageLoaderWrapper.Success)
+      if !silent {
+        setScreenState(_ => PageLoaderWrapper.Success)
+      }
     } catch {
     | Exn.Error(e) =>
-      let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-      setScreenState(_ => PageLoaderWrapper.Error(err))
+      if !silent {
+        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
+        setScreenState(_ => PageLoaderWrapper.Error(err))
+      }
     }
   }
 
@@ -124,10 +144,12 @@ let make = (~remainingPath, ~previewOnly=false) => {
     routingJson->LogicUtils.getArrayFromJson([])
   }
 
-  let fetchActiveRouting = async () => {
+  let fetchActiveRouting = async (~silent=false) => {
     open LogicUtils
     try {
-      setScreenState(_ => PageLoaderWrapper.Loading)
+      if !silent {
+        setScreenState(_ => PageLoaderWrapper.Loading)
+      }
       let routingArr = await getActiveRoutingList()
 
       if routingArr->isNonEmptyArray {
@@ -136,19 +158,24 @@ let make = (~remainingPath, ~previewOnly=false) => {
           let id = ele->getDictFromJsonObject->getString("id", "")
           currentActiveIds->Array.push(id)
         })
-        await fetchRoutingRecords(currentActiveIds)
+        await fetchRoutingRecords(~silent, currentActiveIds)
         setActiveRoutingIds(_ => currentActiveIds)
         setRoutingType(_ => routingArr)
       } else {
-        await fetchRoutingRecords([])
+        await fetchRoutingRecords(~silent, [])
+        setActiveRoutingIds(_ => [])
         let defaultFallback = [("kind", "default"->JSON.Encode.string)]->Dict.fromArray
         setRoutingType(_ => [defaultFallback->JSON.Encode.object])
-        setScreenState(_ => PageLoaderWrapper.Success)
+        if !silent {
+          setScreenState(_ => PageLoaderWrapper.Success)
+        }
       }
     } catch {
     | Exn.Error(e) =>
-      let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
-      setScreenState(_ => PageLoaderWrapper.Error(err))
+      if !silent {
+        let err = Exn.message(e)->Option.getOr("Failed to Fetch!")
+        setScreenState(_ => PageLoaderWrapper.Error(err))
+      }
     }
   }
 
@@ -157,25 +184,11 @@ let make = (~remainingPath, ~previewOnly=false) => {
     None
   }, (pathVar, url.search, debitRoutingValue))
 
-  let refreshActiveRouting = async () => {
-    open LogicUtils
-    try {
-      let routingArr = await getActiveRoutingList()
-
-      if routingArr->isNonEmptyArray {
-        setRoutingType(_ => routingArr)
-      } else {
-        let defaultFallback = [("kind", "default"->JSON.Encode.string)]->getJsonFromArrayOfJson
-        setRoutingType(_ => [defaultFallback])
-      }
-    } catch {
-    | Exn.Error(_) => ()
-    }
-  }
-
   React.useEffect(() => {
     if isCutover && !previewOnly {
-      let onFocus = _ => refreshActiveRouting()->ignore
+      // Rules can change in the Decision Engine dashboard tab; re-sync the active
+      // list and the configuration history whenever this tab regains focus.
+      let onFocus = _ => fetchActiveRouting(~silent=true)->ignore
       Window.addEventListener("focus", onFocus)
       Some(() => Window.removeEventListener("focus", onFocus))
     } else {

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -104,7 +104,7 @@ let make = (~remainingPath, ~previewOnly=false) => {
     let configuredRules = routingJson->RoutingUtils.getRecordsObject
     let recordsData =
       configuredRules
-      ->Belt.Array.keepMap(JSON.Decode.object)
+      ->Array.filterMap(JSON.Decode.object)
       ->Array.map(HistoryEntity.itemToObjMapper)
 
     // To sort the data in a format that active routing always comes at top of the table
@@ -182,22 +182,18 @@ let make = (~remainingPath, ~previewOnly=false) => {
     }
   }, (isCutover, previewOnly, profileId))
 
-  let checkRoutingEntry = async () => {
-    open LogicUtils
-    try {
-      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
-      let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
-      let cutover = res->getDictFromJsonObject->getBool("is_cutover", false)
-      setCutoverStatus(_ => Some(cutover))
-    } catch {
-    | Exn.Error(_) => setCutoverStatus(_ => Some(false))
-    }
-  }
+  let checkRoutingEntryCutover = RoutingUtils.useCheckRoutingEntryCutover()
 
   React.useEffect(() => {
     if !previewOnly {
       setCutoverStatus(_ => None)
-      checkRoutingEntry()->ignore
+
+      (
+        async () => {
+          let cutover = await checkRoutingEntryCutover()
+          setCutoverStatus(_ => Some(cutover))
+        }
+      )()->ignore
     }
     None
   }, [profileId])

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -174,7 +174,13 @@ let make = (~remainingPath, ~previewOnly=false) => {
     if isCutover && !previewOnly {
       // Rules can change in the Decision Engine dashboard tab; silently re-sync the active
       // strategies and configuration history (no loader) when this tab regains focus.
-      let onFocus = _ => syncRoutingState()->Promise.catch(_ => Promise.resolve())->ignore
+      let onFocus = _ =>
+        syncRoutingState()
+        ->Promise.catch(err => {
+          Console.error2("routing focus re-sync failed:", err)
+          Promise.resolve()
+        })
+        ->ignore
       Window.addEventListener("focus", onFocus)
       Some(() => Window.removeEventListener("focus", onFocus))
     } else {
@@ -190,8 +196,10 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
       (
         async () => {
+          // The routing hub is safe for non-cutover profiles, so an unknown (failed) probe
+          // falls back to the native hub — same behaviour as before.
           let cutover = await checkRoutingEntryCutover()
-          setCutoverStatus(_ => Some(cutover))
+          setCutoverStatus(_ => Some(cutover->Option.getOr(false)))
         }
       )()->ignore
     }

--- a/src/screens/Routing/RoutingStack.res
+++ b/src/screens/Routing/RoutingStack.res
@@ -107,9 +107,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
       ->Array.filterMap(JSON.Decode.object)
       ->Array.map(HistoryEntity.itemToObjMapper)
 
-    // To sort the data in a format that active routing always comes at top of the table
-    // For ref:https://rescript-lang.org/docs/manual/latest/api/js/array-2#sortinplacewith
-
     let sortedHistoryRecords =
       recordsData
       ->Array.toSorted((item1, item2) => {
@@ -132,8 +129,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
     routingJson->LogicUtils.getArrayFromJson([])
   }
 
-  // Re-sync the active strategies, the configuration history and the active-id set together.
-  // Never touches screenState; may throw, so callers decide whether to surface the error.
   let syncRoutingState = async () => {
     open LogicUtils
     let routingArr = await getActiveRoutingList()
@@ -196,8 +191,6 @@ let make = (~remainingPath, ~previewOnly=false) => {
 
       (
         async () => {
-          // The routing hub is safe for non-cutover profiles, so an unknown (failed) probe
-          // falls back to the native hub — same behaviour as before.
           let cutover = await checkRoutingEntryCutover()
           setCutoverStatus(_ => Some(cutover->Option.getOr(false)))
         }

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -27,12 +27,39 @@ let routingTypeName = routingType => {
   }
 }
 
+let routingTypeFromName = name => {
+  switch name->String.toLowerCase {
+  | "volume" => VOLUME_SPLIT
+  | "rule" => ADVANCED
+  | "default" => DEFAULTFALLBACK
+  | "auth-rate" => AUTH_RATE_ROUTING
+  | _ => NO_ROUTING
+  }
+}
+
 let decisionEngineRoutingTarget = routingType => {
   switch routingType {
   | VOLUME_SPLIT => "volume"
   | ADVANCED => "rule"
   | AUTH_RATE_ROUTING => "multi_objective"
   | _ => ""
+  }
+}
+
+// Single source for the routing "entry" probe: POST /routing/entry and read whether the
+// profile has cut over to the Decision Engine. Shared by RoutingStack and RoutingConfigure.
+let useCheckRoutingEntryCutover = () => {
+  open APIUtils
+  let getURL = useGetURL()
+  let updateDetails = useUpdateMethod(~showErrorToast=false)
+  async () => {
+    try {
+      let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
+      let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
+      res->getDictFromJsonObject->getBool("is_cutover", false)
+    } catch {
+    | Exn.Error(_) => false
+    }
   }
 }
 

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -37,6 +37,15 @@ let routingTypeFromName = name => {
   }
 }
 
+// The native config URL for a history record. Shared by the history table's getShowLink and the
+// cut-over row override so the route format and active-flag stay in one place.
+let historyRecordNativeUrl = (~kind, ~id, ~activeRoutingIds) =>
+  GlobalVars.appendDashboardPath(
+    ~url=`/routing/${kind
+      ->routingTypeMapper
+      ->routingTypeName}?id=${id}${activeRoutingIds->Array.includes(id) ? "&isActive=true" : ""}`,
+  )
+
 let decisionEngineRoutingTarget = routingType => {
   switch routingType {
   | VOLUME_SPLIT => "volume"
@@ -48,6 +57,8 @@ let decisionEngineRoutingTarget = routingType => {
 
 // Single source for the routing "entry" probe: POST /routing/entry and read whether the
 // profile has cut over to the Decision Engine. Shared by RoutingStack and RoutingConfigure.
+// Returns Some(is_cutover) on success and None when the probe fails, so callers can tell
+// "not cut over" apart from "unknown" and fail safe instead of assuming non-cutover.
 let useCheckRoutingEntryCutover = () => {
   open APIUtils
   let getURL = useGetURL()
@@ -56,9 +67,11 @@ let useCheckRoutingEntryCutover = () => {
     try {
       let entryUrl = getURL(~entityName=V1(ROUTING), ~methodType=Get, ~id=Some("entry"))
       let res = await updateDetails(entryUrl, JSON.Encode.null, Post)
-      res->getDictFromJsonObject->getBool("is_cutover", false)
+      Some(res->getDictFromJsonObject->getBool("is_cutover", false))
     } catch {
-    | Exn.Error(_) => false
+    | Exn.Error(err) =>
+      Console.error2("checkRoutingEntry failed:", err)
+      None
     }
   }
 }

--- a/src/screens/Routing/RoutingUtils.res
+++ b/src/screens/Routing/RoutingUtils.res
@@ -37,8 +37,6 @@ let routingTypeFromName = name => {
   }
 }
 
-// The native config URL for a history record. Shared by the history table's getShowLink and the
-// cut-over row override so the route format and active-flag stay in one place.
 let historyRecordNativeUrl = (~kind, ~id, ~activeRoutingIds) =>
   GlobalVars.appendDashboardPath(
     ~url=`/routing/${kind


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Fixes two Decision Engine routing bugs reported in #5495 (items 2 and 3). Both only affect **cut-over** profiles — where `POST /routing/entry` returns `is_cutover: true` because the profile's `routing_result_source` is the Decision Engine — and both leave non-cut-over profiles byte-for-byte unchanged. The cut-over-aware cards and Active-tab hand-off already shipped in #5466; this extends the same awareness to the two places it was missing: the **Configuration History** tab and **direct config URLs**.

### 1. Configuration History goes stale until a hard refresh (#5495, item 2)

On a cut-over profile the Smart Routing page re-syncs when the tab regains focus, so activating/disabling a rule in the DE dashboard tab reflects on return. That re-sync only refreshed the *active-strategies* list, so the **Active configuration** tab updated but **Configuration History** kept its old rows and ACTIVE/INACTIVE labels until a full reload.

Root cause: the focus handler called a `refreshActiveRouting` that only wrote `routingType`. `records` and `activeRoutingIds` — which back the history table and its status labels (`HistoryEntity.res` `getTableCell`) — were only ever fetched on mount.

Fix, all in [`RoutingStack.res`](src/screens/Routing/RoutingStack.res), keeping refreshes off `screenState` rather than threading a loader flag through the fetchers:

- `refreshRoutingRecords` fetches and sets the history `records` and never touches `screenState`, so the same code serves the initial load and the silent refresh (`RoutingStack.res`).
- `syncRoutingState` re-syncs the active strategies, the history records and the active-id set together; it never touches `screenState` and may throw, so callers decide whether to surface the error. This is the "refresh both, not one" fix — previously the refresh moved `routingType` without `records`/`activeRoutingIds`.
- `fetchActiveRouting` (initial load) simply drives the page loader off `syncRoutingState` — `Loading` → `syncRoutingState()` → `Success`/`Error`.
- The focus listener calls `syncRoutingState()` directly and swallows errors (`->Promise.catch(...)`) — no loader, no flag. It stays gated on `isCutover && !previewOnly` with deps `(isCutover, previewOnly, profileId)`.
- `activeRoutingIds` resets to `[]` when the active list comes back empty, so a de-activated last rule stops rendering as ACTIVE.
- `records` and `activeRoutingIds` are added to the `tabs` `useMemo` deps so the History tab can't render from a stale closure.

### 2. History rows open the legacy flow instead of the DE dashboard (#5495, item 3)

Clicking a Configuration History row on a cut-over profile opened the native preview → *Duplicate and Edit* → *Save and Activate* flow, writing a legacy Hyperswitch config for a profile whose routing is served by the Decision Engine.

Fix:

- [`History.res`](src/screens/Routing/History.res) takes `isCutover` + `onDecisionEngineRedirect` and, when cut over, passes an `onEntityClick` override to `LoadedTable` (`History.res:45`). `openRecord` maps the row's `kind` through `routingTypeMapper → decisionEngineRoutingTarget`; a non-empty target deep-links into the DE dashboard via the entry API with the rule id in the hand-off, and an empty target (e.g. `default`) falls back to the native link (`History.res:13`).
- [`RoutingConfigure.res`](src/screens/Routing/RoutingConfigure.res) guards direct URLs. `volume` / `rule` / `auth-rate` are DE-managed; on mount it `POST`s `/routing/entry` behind the page loader, and for a cut-over profile shows a toast and `replace`s back to `/routing` (`RoutingConfigure.res:19`, `:27`, `:46`). `default` stays native by design; non-cut-over profiles resolve to the normal form with no behavior change.

```
history row click ─┐
direct /routing/volume URL ─┴─▶ POST /routing/entry ──▶ is_cutover?
                                   ├─ true  → DE dashboard deep-link (rows) / toast + redirect (URLs)
                                   └─ false → native CC flow (unchanged)
```

I confirmed against the backend that a cut-over profile's `GET /routing` returns DE-sourced records (`select_routing_result` in `hyperswitch`), so the history-row ids resolve in the DE rule editor.

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

<img width="2880" height="1800" alt="06historysyncedonfocus" src="https://github.com/user-attachments/assets/407117fc-661a-4616-92f8-f7a78bc9f340" />


https://github.com/user-attachments/assets/9d858fb1-88b3-478d-9d9e-f69736ac0308


