### PR TITLE
feat(mixpanel): track 4xx API failures

### DIFF
--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -1724,6 +1724,7 @@ let responseHandler = async (
     ~section: string=?,
     ~metadata: JSON.t=?,
   ) => unit,
+  ~methodType: Fetch.requestMethod,
   ~isEmbeddableSession=false,
 ) => {
   let json = try {
@@ -1734,15 +1735,21 @@ let responseHandler = async (
 
   let responseStatus = res->Fetch.Response.status
   let responseHeaders = res->Fetch.Response.headers
+  let errorDict = json->getDictFromJsonObject->getObj("error", Dict.make())
 
-  if responseStatus >= 500 && responseStatus < 600 {
+  if responseStatus >= 400 && responseStatus < 600 {
     let xRequestId = responseHeaders->Fetch.Headers.get("x-request-id")->Option.getOr("")
+    let statusClass = responseStatus < 500 ? "4xx" : "5xx"
     let metaData =
       [
         ("url", url->JSON.Encode.string),
-        ("response", json),
         ("status", responseStatus->JSON.Encode.int),
+        ("statusClass", statusClass->JSON.Encode.string),
+        ("method", methodType->Fetch.encodeRequestMethod->JSON.Encode.string),
         ("x-request-id", xRequestId->JSON.Encode.string),
+        ("errorCode", errorDict->getString("code", "")->JSON.Encode.string),
+        ("errorMessage", errorDict->getString("message", "")->JSON.Encode.string),
+        ("response", json),
       ]->getJsonFromArrayOfJson
     sendEvent(~eventName="API Error", ~description=Some(responseStatus), ~metadata=metaData)
   }
@@ -1753,7 +1760,6 @@ let responseHandler = async (
   | 200
   | 201 => json
   | _ => {
-      let errorDict = json->getDictFromJsonObject->getObj("error", Dict.make())
       let errorStringifiedJson = errorDict->JSON.Encode.object->JSON.stringify
 
       if isPlayground && responseStatus === 403 {
@@ -1887,6 +1893,7 @@ let useGetMethod = (~showErrorToast=true) => {
         ~popUpCallBack,
         ~handleLogout,
         ~sendEvent,
+        ~methodType=Get,
         ~isEmbeddableSession=isEmbeddableSession(),
       )
     } catch {
@@ -1965,6 +1972,7 @@ let useUpdateMethod = (~showErrorToast=true) => {
         ~popUpCallBack,
         ~handleLogout,
         ~sendEvent,
+        ~methodType=method,
         ~isEmbeddableSession=isEmbeddableSession(),
       )
     } catch {

--- a/src/APIUtils/APIUtils.res
+++ b/src/APIUtils/APIUtils.res
@@ -1708,6 +1708,27 @@ let useHandleLogout = (~eventName="user_sign_out") => {
 
 let sessionExpired = ref(false)
 
+let getApiErrorMetaData = (
+  ~url,
+  ~methodType: Fetch.requestMethod,
+  ~statusClass,
+  ~status,
+  ~xRequestId,
+  ~errorCode,
+  ~errorMessage,
+  ~response,
+) =>
+  [
+    ("url", url->JSON.Encode.string),
+    ("status", status->JSON.Encode.int),
+    ("statusClass", statusClass->JSON.Encode.string),
+    ("method", methodType->methodStr->JSON.Encode.string),
+    ("x-request-id", xRequestId->JSON.Encode.string),
+    ("errorCode", errorCode->JSON.Encode.string),
+    ("errorMessage", errorMessage->JSON.Encode.string),
+    ("response", response),
+  ]->getJsonFromArrayOfJson
+
 let responseHandler = async (
   ~url,
   ~res,
@@ -1734,25 +1755,6 @@ let responseHandler = async (
   }
 
   let responseStatus = res->Fetch.Response.status
-  let responseHeaders = res->Fetch.Response.headers
-  let errorDict = json->getDictFromJsonObject->getObj("error", Dict.make())
-
-  if responseStatus >= 400 && responseStatus < 600 {
-    let xRequestId = responseHeaders->Fetch.Headers.get("x-request-id")->Option.getOr("")
-    let statusClass = responseStatus < 500 ? "4xx" : "5xx"
-    let metaData =
-      [
-        ("url", url->JSON.Encode.string),
-        ("status", responseStatus->JSON.Encode.int),
-        ("statusClass", statusClass->JSON.Encode.string),
-        ("method", methodType->Fetch.encodeRequestMethod->JSON.Encode.string),
-        ("x-request-id", xRequestId->JSON.Encode.string),
-        ("errorCode", errorDict->getString("code", "")->JSON.Encode.string),
-        ("errorMessage", errorDict->getString("message", "")->JSON.Encode.string),
-        ("response", json),
-      ]->getJsonFromArrayOfJson
-    sendEvent(~eventName="API Error", ~description=Some(responseStatus), ~metadata=metaData)
-  }
 
   let noAccessControlText = "You do not have the required permissions to access this module. Please contact your admin."
 
@@ -1760,7 +1762,29 @@ let responseHandler = async (
   | 200
   | 201 => json
   | _ => {
+      let errorDict = json->getDictFromJsonObject->getObj("error", Dict.make())
       let errorStringifiedJson = errorDict->JSON.Encode.object->JSON.stringify
+
+      if responseStatus >= 400 && responseStatus < 600 {
+        let is4xx = responseStatus < 500
+        sendEvent(
+          ~eventName=is4xx ? "API Error 4xx" : "API Error",
+          ~description=Some(responseStatus),
+          ~metadata=getApiErrorMetaData(
+            ~url,
+            ~methodType,
+            ~statusClass=is4xx ? "4xx" : "5xx",
+            ~status=responseStatus,
+            ~xRequestId=res
+            ->Fetch.Response.headers
+            ->Fetch.Headers.get("x-request-id")
+            ->Option.getOr(""),
+            ~errorCode=errorDict->getString("code", ""),
+            ~errorMessage=errorDict->getString("message", ""),
+            ~response=json,
+          ),
+        )
+      }
 
       if isPlayground && responseStatus === 403 {
         popUpCallBack()

--- a/src/hooks/MixpanelHook.res
+++ b/src/hooks/MixpanelHook.res
@@ -84,7 +84,7 @@ let useSendEvent = () => {
       let _ = await fetchApi(
         `${getHostUrl}/mixpanel/track`,
         ~method_=Post,
-        ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
+        ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
         ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
         ~forceCookies=featureFlagDetails.forceCookies,
         ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
@@ -166,7 +166,7 @@ let usePageView = () => {
         let _ = await fetchApi(
           `${getHostUrl}/mixpanel/track`,
           ~method_=Post,
-          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
+          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
           ~forceCookies=featureFlagDetails.forceCookies,
           ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
@@ -207,7 +207,7 @@ let useSetIdentity = () => {
         let _ = await fetchApi(
           `${getHostUrl}/mixpanel/track`,
           ~method_=Post,
-          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
+          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
           ~forceCookies=featureFlagDetails.forceCookies,
           ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
@@ -215,7 +215,10 @@ let useSetIdentity = () => {
         let _ = await fetchApi(
           `${getHostUrl}/mixpanel/engage`,
           ~method_=Post,
-          ~bodyStr=`data=${peopleProperties->JSON.stringifyAny->Option.getOr("")->encodeURI}`,
+          ~bodyStr=`data=${peopleProperties
+            ->JSON.stringifyAny
+            ->Option.getOr("")
+            ->encodeURIComponent}`,
           ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
           ~forceCookies=featureFlagDetails.forceCookies,
           ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,

--- a/src/hooks/MixpanelHook.res
+++ b/src/hooks/MixpanelHook.res
@@ -1,9 +1,35 @@
 type functionType = (~eventName: string=?, ~email: string=?, ~description: option<string>=?) => unit
 
+let getMixpanelBody = body =>
+  `data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`
+
+let useMixpanelRequest = () => {
+  open GlobalVars
+  let fetchApi = AuthHooks.useApiFetcher()
+  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
+
+  async (~endpoint, ~bodyStr) => {
+    try {
+      if featureFlagDetails.mixpanel {
+        let _ = await fetchApi(
+          `${getHostUrl}/mixpanel/${endpoint}`,
+          ~method_=Post,
+          ~bodyStr,
+          ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
+          ~forceCookies=featureFlagDetails.forceCookies,
+          ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
+        )
+      }
+    } catch {
+    | _ => ()
+    }
+  }
+}
+
 let useSendEvent = () => {
   open GlobalVars
   open Window
-  let fetchApi = AuthHooks.useApiFetcher()
+  let sendMixpanelRequest = useMixpanelRequest()
   let {orgId, profileId, merchantId} = React.useContext(
     UserInfoProvider.defaultContext,
   ).getCommonSessionDetails()
@@ -80,18 +106,7 @@ let useSendEvent = () => {
       },
     }
 
-    try {
-      let _ = await fetchApi(
-        `${getHostUrl}/mixpanel/track`,
-        ~method_=Post,
-        ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
-        ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
-        ~forceCookies=featureFlagDetails.forceCookies,
-        ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
-      )
-    } catch {
-    | _ => ()
-    }
+    await sendMixpanelRequest(~endpoint="track", ~bodyStr=body->getMixpanelBody)
   }
 
   (~eventName, ~email="", ~description=None, ~section="", ~metadata=JSON.Encode.null) => {
@@ -114,7 +129,7 @@ let useSendEvent = () => {
 let usePageView = () => {
   open GlobalVars
   open Window
-  let fetchApi = AuthHooks.useApiFetcher()
+  let sendMixpanelRequest = useMixpanelRequest()
   let {orgId, profileId, merchantId} = React.useContext(
     UserInfoProvider.defaultContext,
   ).getCommonSessionDetails()
@@ -129,7 +144,6 @@ let usePageView = () => {
   | UserInfoTypes.V1 => "v1"
   | V2 => "v2"
   }
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
   async (~path) => {
     let mixpanel_token = Window.env.mixpanelToken
     let body = {
@@ -161,28 +175,13 @@ let usePageView = () => {
       },
     }
 
-    try {
-      if featureFlagDetails.mixpanel {
-        let _ = await fetchApi(
-          `${getHostUrl}/mixpanel/track`,
-          ~method_=Post,
-          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
-          ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
-          ~forceCookies=featureFlagDetails.forceCookies,
-          ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
-        )
-      }
-    } catch {
-    | _ => ()
-    }
+    await sendMixpanelRequest(~endpoint="track", ~bodyStr=body->getMixpanelBody)
   }
 }
 
 let useSetIdentity = () => {
-  open GlobalVars
-  let fetchApi = AuthHooks.useApiFetcher()
+  let sendMixpanelRequest = useMixpanelRequest()
   let mixpanel_token = Window.env.mixpanelToken
-  let featureFlagDetails = HyperswitchAtom.featureFlagAtom->Recoil.useRecoilValueFromAtom
 
   async (~distinctId) => {
     let name = distinctId->LogicUtils.getNameFromEmail
@@ -202,30 +201,7 @@ let useSetIdentity = () => {
       },
     }
 
-    try {
-      if featureFlagDetails.mixpanel {
-        let _ = await fetchApi(
-          `${getHostUrl}/mixpanel/track`,
-          ~method_=Post,
-          ~bodyStr=`data=${body->JSON.stringifyAny->Option.getOr("")->encodeURIComponent}`,
-          ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
-          ~forceCookies=featureFlagDetails.forceCookies,
-          ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
-        )
-        let _ = await fetchApi(
-          `${getHostUrl}/mixpanel/engage`,
-          ~method_=Post,
-          ~bodyStr=`data=${peopleProperties
-            ->JSON.stringifyAny
-            ->Option.getOr("")
-            ->encodeURIComponent}`,
-          ~xFeatureRoute=featureFlagDetails.xFeatureRoute,
-          ~forceCookies=featureFlagDetails.forceCookies,
-          ~sendV1DummyApiKeyHeader=featureFlagDetails.sendV1DummyApiKeyHeader,
-        )
-      }
-    } catch {
-    | _ => ()
-    }
+    await sendMixpanelRequest(~endpoint="track", ~bodyStr=body->getMixpanelBody)
+    await sendMixpanelRequest(~endpoint="engage", ~bodyStr=peopleProperties->getMixpanelBody)
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Widens Mixpanel API failure tracking to cover the `4xx` range, fixes a payload encoding bug that would have corrupted the resulting events, and removes some duplication in the Mixpanel hook while in there.

**1. Track `4xx` alongside `5xx` (`src/APIUtils/APIUtils.res`)**

The condition in `responseHandler` moves from `responseStatus >= 500 && < 600` to `>= 400 && < 600`, and the two ranges are reported under separate event names:

| Range | Event name |
| --- | --- |
| `5xx` | `"API Error"` — unchanged, so existing dashboards and alerts keep their current meaning |
| `4xx` | `"API Error 4xx"` |

Nothing outside `4xx`/`5xx` emits. `200`/`201` return before the block, and the range guard excludes the other statuses that fall through the same `_` branch.

The emission now lives inside the error branch of the `switch` rather than above it, so it reuses the `errorDict` that branch already parses instead of decoding the response a second time. The payload itself is built by a new `getApiErrorMetaData` helper, keeping the property list in one place:

| Property | Status |
| --- | --- |
| `url`, `status`, `x-request-id`, `response` | existing |
| `statusClass` (`"4xx"` / `"5xx"`) | new — allows a combined breakdown across both events |
| `method` | new — resolved via `LogicUtils.methodStr` |
| `errorCode`, `errorMessage` | new — promoted out of the nested `error` object |

`response` is emitted last so the small scalar properties are not lost to Mixpanel's string property truncation on large bodies.

Supporting change: `responseHandler` takes a new `~methodType: Fetch.requestMethod` parameter, passed as `Get` from `useGetMethod` and as the caller's `method` from `useUpdateMethod`.

**2. Fix Mixpanel payload encoding (`src/hooks/MixpanelHook.res`)**

Mixpanel requests are sent as `application/x-www-form-urlencoded` (`getHeaders` in `src/hooks/AuthHooks.res` special-cases any URI containing `mixpanel`) with a body of `data=<json>`, but the JSON was escaped with `encodeURI`, which by design leaves `&`, `=`, `+` and `#` unescaped. Any payload containing those characters had its form body split and truncated server-side.

This is a pre-existing bug — `$current_url` is already affected for any dashboard URL carrying a query string — but it becomes unavoidable here, since the failing API `url` and its query string are now part of the metadata. Every call site now uses `encodeURIComponent`, which correctly escapes `+` as `%2B` and space as `%20`.

**3. Deduplicate the Mixpanel request path (`src/hooks/MixpanelHook.res`)**

`useSendEvent`, `usePageView` and `useSetIdentity` each carried their own copy of the same fetch call, feature-flag check and swallow-everything `try/catch` — four blocks in total. These are extracted into a shared `useMixpanelRequest` hook plus a `getMixpanelBody` helper, which is also what keeps the encoding fix above from having to be applied in four places.

No behaviour change: `useSendEvent` already gated on `featureFlagDetails.mixpanel` at its call site, so the gate inside the extracted hook is equivalent.

## Motivation and Context

Closes #5506.

Only `5xx` failures were reaching Mixpanel, which left the entire client-side error surface invisible: `400` validation failures including the `HE_02` / `UR_33` redirect sub-codes, `403` access-control failures on permission-gated modules, and `404` responses on resources the dashboard expected to exist. These are the failures that most directly shape user experience, and we had no way to quantify their frequency or attribute them to a screen or endpoint.

On the volume question raised earlier in review: `4xx` is considerably more frequent than `5xx`, and a number of call sites pass `~showErrorToast=false` because they treat certain `4xx` responses as expected. Splitting the event name is what addresses this — existing `"api error"` dashboards continue to mean `5xx` only and need no filter change, and `4xx` can be onboarded deliberately. `statusClass` is retained on both events so a combined view is still one breakdown away.

Two things reviewers should still weigh in on:

- **Payload contents.** `4xx` responses echo request input far more often than `5xx` do, so the full `response` body carries a wider PII surface, and `url` carries resource identifiers. Now that `errorCode` and `errorMessage` are top-level properties, dropping `response` from the `4xx` branch specifically is a reasonable option if reviewers prefer it.
- **`401` handling.** A `401` triggers `handleLogout` and `redirectToLogin` from `useApiFetcher` before the event is sent, so the payload is assembled after `clearLocalStorage` and while the page is navigating away — those events are reported inconsistently. `sessionExpired` also dedupes the toast but not the event, so N concurrent requests on an expired session emit N events. Excluding `401` entirely is defensible, since it is a session-lifecycle signal rather than an API health signal.

## How did you test it?

- `rescript clean` followed by a full rebuild: all 4025 modules compile with no warnings or errors.
- `npm run re:format:check` passes.
- Verified against the compiled output (`APIUtils.res.js`) that only the two intended event names are emitted, that the range guard excludes everything outside `4xx`/`5xx`, and that `encodeURIComponent` reaches every Mixpanel call site with no `encodeURI` remaining anywhere in `src/`.
- Verified by inspection that there is no recursion risk: the Mixpanel request path calls `fetchApi` directly with its own `try/catch` and never routes through `responseHandler`, so a failing `/mixpanel/track` request cannot loop.
- Verified the non-JSON failure path degrades cleanly: when a `4xx` returns a non-JSON body, `json` falls back to `JSON.Encode.null`, `errorDict` to an empty dict, and the new properties are emitted as empty strings rather than throwing.

Not yet exercised against a live Mixpanel project — worth confirming on INTEG that `"API Error 4xx"` events land with `statusClass`, `method`, `errorCode` and `errorMessage` populated, that `"API Error"` still fires for `5xx`, and that a URL containing `&` in its query string now arrives intact.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

Backend PR URL: N/A

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): N/A — gated by the existing `mixpanel` feature flag, unchanged.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
