### PR TITLE
test(playwright): fix visual specs that assert UI on the wrong view

### DIFF
--- a/playwright-tests/visual-testing/3-operations.spec.ts
+++ b/playwright-tests/visual-testing/3-operations.spec.ts
@@ -138,6 +138,14 @@ test.describe("Visual Testing - Payment Operations", () => {
       maxDiffPixelRatio: 0.01,
     });
 
+    // The Attempts table is its own tab on the payment details page
+    // (ShowOrder.res builds paymentDetailsTabs), so it is not in the DOM while
+    // the events-and-logs tab is selected. Select it before expanding a row.
+    const paymentAttemptsTab =
+      paymentOperations.paymentDetailsTab("Payment Attempts");
+    await paymentAttemptsTab.click();
+    await expect(paymentAttemptsTab).toHaveAttribute("aria-selected", "true");
+
     await paymentOperations.firstAttemptRowExpander.click();
     await expect(paymentOperations.connectorTransactionIdInTable).toBeVisible();
     await paymentOperations.connectorTransactionIdInTable.scrollIntoViewIfNeeded();

--- a/playwright-tests/visual-testing/6-workflow.spec.ts
+++ b/playwright-tests/visual-testing/6-workflow.spec.ts
@@ -815,9 +815,11 @@ test.describe("Visual Testing - Workflow", () => {
       await homePage.threeDSExemptionManager.click();
       await page.waitForURL(/dashboard\/3ds-exemption/, { timeout: 15000 });
 
-      // ActiveRulePreview card with the seeded rule.
+      // ActiveConfigurationCard with the seeded rule. The landing view exposes
+      // the Active badge and "View and Manage"; the delete icon belongs to
+      // ActiveRulePreview, which only mounts on the ?type=manage view.
       await expect(exemption.activeBadge).toBeVisible();
-      await expect(exemption.deleteIcon).toBeVisible();
+      await expect(exemption.viewAndManageButton).toBeVisible();
 
       await expect(page).toHaveScreenshot(
         "workflow-3ds-exemption-with-rule.png",


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two visual specs assert affordances that are not present on the view they screenshot, so they
fail deterministically on every run regardless of the change under test.

**`visual-testing/3-operations.spec.ts`** — "payment operations when payment exists" expanded the
first attempts row straight after selecting the events-and-logs tab. `Attempts` is its own entry
in `paymentDetailsTabs` (`ShowOrder.res`), so `[data-table-location="Attempts_tr1_td1"]` is never
in the DOM while events-and-logs is selected and the click times out after 30s. The spec now
selects the "Payment Attempts" tab first, the same way the e2e spec does.

**`visual-testing/6-workflow.spec.ts`** — "3ds exemption with active rule" expected the delete
icon on the `/dashboard/3ds-exemption` landing view. That view renders `ActiveConfigurationCard`
(an `Active` badge and a "View and Manage" button); the delete icon lives in `ActiveRulePreview`,
which only mounts on the `?type=manage` view. The spec now asserts the "View and Manage" button
the card actually renders, which is what the accompanying screenshot captures.

No product code changes — both are test-side corrections.

## Motivation and Context

Closes #5510

`visual-tests` currently fails with 13 failures on every pull request. These two are the only
ones caused by test code; the other 11 are snapshot pixel diffs against baselines last
regenerated on 2026-08-03 (#5264) and need a CI refresh rather than a code fix.

## How did you test it?

Both replacements are already exercised by passing e2e specs, which is where the correct
interaction sequence was taken from:

- `e2e/3-operations/paymentOperations.spec.ts:2100` clicks `paymentDetailsTab("Payment Attempts")`,
  asserts `aria-selected="true"`, then uses `attemptCell(1, 1)` — the same locator as
  `firstAttemptRowExpander`.
- `e2e/6-workflow/3dsExemptionManager.spec.ts:102` asserts `activeBadge` and `viewAndManageButton`
  on the landing view, and `3dsExemptionManager.spec.ts:121` only reaches `deleteIcon` after
  clicking "View and Manage" and waiting for `?type=manage`.

`npm run lint:tests` and `prettier --check` are clean on both files.

## Where to test it?

- [ ] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [ ] I ran `npm run re:build` — not applicable, no ReScript changed
- [x] I reviewed submitted code
- [x] I added unit tests for my changes where possible — this PR is the test change
