### PR TITLE
feat: support replace_char transformation rule on recon string fields

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -369,10 +369,7 @@ let describeStringTransformationRule = (rule: stringTransformationRule): string 
   | StrRegex({pattern, group}) =>
     `Regex (${pattern}${group->mapOptionOrDefault("", g => `, group ${g->Int.toString}`)})`
   | StrReplaceChar({fromChar, toChar, mode}) =>
-    switch toChar {
-    | Some(toChar) => `Replace "${fromChar}" with "${toChar}" (${mode->describeReplaceMode})`
-    | None => `Delete "${fromChar}" (${mode->describeReplaceMode})`
-    }
+    `Replace "${fromChar}" with "${toChar->Option.getOr("")}" (${mode->describeReplaceMode})`
   | UnknownStringTransformationRule => "Unknown rule"
   }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEnginePipelines/ReconEnginePipelinesUtils.res
@@ -368,6 +368,11 @@ let describeStringTransformationRule = (rule: stringTransformationRule): string 
   | StrJsonExtract(pointer) => `JSON extract (${pointer})`
   | StrRegex({pattern, group}) =>
     `Regex (${pattern}${group->mapOptionOrDefault("", g => `, group ${g->Int.toString}`)})`
+  | StrReplaceChar({fromChar, toChar, mode}) =>
+    switch toChar {
+    | Some(toChar) => `Replace "${fromChar}" with "${toChar}" (${mode->describeReplaceMode})`
+    | None => `Delete "${fromChar}" (${mode->describeReplaceMode})`
+    }
   | UnknownStringTransformationRule => "Unknown rule"
   }
 

--- a/src/ReconEngine/ReconEngineTypes.res
+++ b/src/ReconEngine/ReconEngineTypes.res
@@ -390,6 +390,7 @@ type stringTransformationRule =
   | StrTrim
   | StrJsonExtract(string)
   | StrRegex({pattern: string, group: option<int>})
+  | StrReplaceChar({fromChar: string, toChar: option<string>, mode: replaceMode})
   | UnknownStringTransformationRule
 
 type currencyTransformationRule =

--- a/src/ReconEngine/ReconEngineUtils.res
+++ b/src/ReconEngine/ReconEngineUtils.res
@@ -680,6 +680,12 @@ let stringTransformationRuleMapper = (dict): stringTransformationRule => {
   | "json_extract" => StrJsonExtract(dict->getString("pointer", ""))
   | "regex" =>
     StrRegex({pattern: dict->getString("pattern", ""), group: dict->getOptionInt("group")})
+  | "replace_char" =>
+    StrReplaceChar({
+      fromChar: dict->getString("from", ""),
+      toChar: dict->getOptionString("to"),
+      mode: dict->getDictfromDict("mode")->replaceModeMapper,
+    })
   | _ => UnknownStringTransformationRule
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Backend PR [juspay/hyperswitch-recon#616](https://github.com/juspay/hyperswitch-recon/pull/616) extended the shared `StringTransformationRule` enum with `replace_char`, making it valid on two things the control center already reads: the `order_id` main field (`OrderIdFieldConfigV1`) and every `string` metadata field (`FieldTypeConfig::String`).

`stringTransformationRuleMapper` had no case for it, so such a rule fell through to `UnknownStringTransformationRule` and the **Pipelines → pipeline details → Transformation run details → "Fields & rules"** modal rendered the chip as `Transform: Unknown rule`. The majorunit half of the same backend rule already rendered correctly (`MajorUnitReplaceChar`, #5238); this is the string half that was never wired.

Three edits, each mirroring the existing `MajorUnitReplaceChar` handling:

| File | Change |
| --- | --- |
| `src/ReconEngine/ReconEngineTypes.res` | Added `StrReplaceChar({fromChar, toChar, mode})` to `stringTransformationRule`, reusing the existing `replaceMode` type |
| `src/ReconEngine/ReconEngineUtils.res` | Added the `"replace_char"` case to `stringTransformationRuleMapper`, reusing the existing `replaceModeMapper` |
| `src/ReconEngine/ReconEngineScreens/.../ReconEnginePipelinesUtils.res` | Added the display case to `describeStringTransformationRule`, reusing the existing `describeReplaceMode` |

No new types, mappers or helpers — the wire shape is identical to the majorunit variant (same `from` / `to` / `mode` fields, same `ReplaceMode` enum). The single mapper change covers both consumers, since `order_id` (`ReconEngineUtils.res:868`) and string metadata fields (`ReconEngineUtils.res:882`) both route through `stringTransformationRuleMapper`.

### Display wording

The existing majorunit chip does `toChar->Option.getOr("")`, which renders a deletion as `Replace "," with ""`. On `majorunit` that reads acceptably, but on `string` deletion (`to: null`) is the *primary* use case and the empty quotes read as a bug — so the string chip branches on the option instead of defaulting it:

| Wire | Chip |
| --- | --- |
| `{from: "-", to: null, mode: {all}}` | `Delete "-" (all occurrences)` |
| `{from: "/", to: "_", mode: {single, occurrence: 0, from_end: true}}` | `Replace "/" with "_" (occurrence 0 from end)` |

The issue lists applying this wording to `describeMajorUnitTransformationRule` as an *optional* follow-up, but its acceptance criteria also require existing majorunit rendering to be unchanged. Deferred to keep this PR to the read path the ticket scopes — happy to fold it in if reviewers would rather the two chips match now.

## Motivation and Context

Closes #5517.

A schema that strips hyphens from `order_id` — the canonical use, normalising `TXN-2026-00123` on the PSP side against `TXN202600123` internally so equality joins line up — currently displays `Transform: Unknown rule`. That makes the modal actively misleading: an operator debugging a failed match cannot see the normalisation that was applied.

## How did you test it?

Exercised the compiled mappers and describe functions directly against the wire JSON from the backend PR (`ReconEngineUtils.res.js` / `ReconEnginePipelinesUtils.res.js` imported in Node), covering every acceptance criterion on the issue:

| Case | Wire | Chip |
| --- | --- | --- |
| Delete, all occurrences | `{from: "-", to: null, mode: {all}}` | `Delete "-" (all occurrences)` |
| Replace, single from end | `{from: "/", to: "_", mode: {single, occurrence: 0, from_end: true}}` | `Replace "/" with "_" (occurrence 0 from end)` |
| Replace, single from start | `{from: ".", to: "-", mode: {single, occurrence: 2, from_end: false}}` | `Replace "." with "-" (occurrence 2)` |
| `to` key absent entirely | `{from: " ", mode: {all}}` | `Delete " " (all occurrences)` |
| Unknown `mode_type` | `{from: "-", to: null, mode: {mode_type: "bogus"}}` | `Delete "-" (unknown)` |
| `mode` object absent | `{from: "-", to: null}` | `Delete "-" (unknown)` |
| `from` absent | `{to: "x", mode: {all}}` | `Replace "" with "x" (all occurrences)` |

Against the acceptance criteria:

- ✅ A `replace_char` rule renders a readable chip, not "Unknown rule"
- ✅ Both `mode_type: "all"` and `"single"` render, with `from_end` true/false distinguishable
- ✅ `to: null` (delete) and `to: "<char>"` (replace) render distinguishably
- ✅ Unknown or absent `mode_type` falls back to `UnknownReplaceMode` → `"unknown"` without crashing
- ✅ Existing majorunit rendering unchanged — still `Replace "," with "" (all occurrences)`

Regression-checked alongside: `trim`, `regex` (with capture group) and a genuinely unknown rule type still map and render as before, the last still reaching `"Unknown rule"`.

`npm run re:build` is clean and `rescript format -check` passes on all three files.

No screenshot: rendering a chip requires a recon backend serving a metadata schema that carries a `replace_char` rule, which is not stood up locally. The table above is the same string the chip renders, taken from the compiled `describeStringTransformationRule`.

## Where to test it?

- [x] INTEG
- [x] SANDBOX
- [ ] PROD

Pipelines → pipeline details → Transformation run details modal → **Fields & rules**, on a pipeline whose metadata schema carries a `replace_char` rule on `order_id` or on any `string` metadata field.

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [x] Yes
- [ ] No

Backend PR URL: https://github.com/juspay/hyperswitch-recon/pull/616

The dependency is one-way and non-breaking: this is a read-path change that adds a case to an existing fall-through. Without the backend deployed no schema can carry the rule, so nothing renders differently; with it deployed the chip becomes readable instead of "Unknown rule".

## Feature Flag

<!-- Does this PR add a new feature flag or update an existing one? -->

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s): —

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

The repo carries no unit-test harness for these ReScript mappers; verification is the compiled-output exercise described above.

Before:

<img width="1069" height="71" alt="Screenshot 2026-09-08 at 9 36 01 PM" src="https://github.com/user-attachments/assets/6b81e59d-db1f-41c1-9818-900119d264f3" />

After:

<img width="1092" height="147" alt="Screenshot 2026-09-08 at 9 37 26 PM" src="https://github.com/user-attachments/assets/2b5b322c-9bf5-4a36-8c83-23056184dfe4" />

