### PR TITLE
fix: send recon report time range in recon format and gate generate report by view access

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineExceptions/ReconEngineExceptions.res
@@ -14,6 +14,7 @@ let make = () => {
   let getAccounts = ReconEngineHooks.useGetAccounts()
   let getReconRuleList = ReconEngineHooks.useGetReconRuleList()
   let mixpanelEvent = MixpanelHook.useSendEvent()
+  let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
 
   let onTitleClick = idx => {
     let url =
@@ -81,10 +82,11 @@ let make = () => {
       <div className="flex flex-row items-center gap-4">
         <PortalCapture name=ReconEngineFilterUtils.globalDateFilterPortalName customStyle="-mt-1" />
         <div className="flex-shrink-0">
-          <Button
+          <ACLButton
             text="Generate Report"
             buttonType=Primary
             buttonSize=Large
+            authorization={userHasAccess(~groupAccess=ReconExceptionsView)}
             buttonState={selectedRule->Option.isSome ? Normal : Disabled}
             onClick={_ => {
               setReportModal(_ => true)

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineGenerateReportModal.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineGenerateReportModal.res
@@ -10,6 +10,7 @@ let make = (
 ) => {
   open APIUtils
   open LogicUtils
+  open ReconEngineFilterUtils
 
   let getURL = useGetURL()
   let showToast = ToastAdapter.useShowToast()
@@ -39,6 +40,14 @@ let make = (
     mixpanelEvent(~eventName="recon_engine_generate_report_submit", ~metadata)
     let bodyDict = metadata->getDictFromJsonObject
     bodyDict->Dict.set("rule_id", rule.rule_id->JSON.Encode.string)
+    bodyDict->Dict.set(
+      "start_time",
+      bodyDict->getString("start_time", "")->toReconTimeString->JSON.Encode.string,
+    )
+    bodyDict->Dict.set(
+      "end_time",
+      bodyDict->getString("end_time", "")->toReconTimeString->JSON.Encode.string,
+    )
     generateReport(bodyDict->JSON.Encode.object)
   }
 

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactions.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactions.res
@@ -7,6 +7,7 @@ let make = () => {
   open ReconEngineHooks
 
   let mixpanelEvent = MixpanelHook.useSendEvent()
+  let {userHasAccess} = GroupACLHooks.useUserGroupACLHook()
   let url = RescriptReactRouter.useUrl()
   let basePath = GlobalVars.appendDashboardPath(~url="v1/recon-engine/transactions")
   let (accountData, setAccountData) = React.useState(_ => [])
@@ -81,10 +82,11 @@ let make = () => {
       <div className="flex flex-row items-center gap-4">
         <PortalCapture name=ReconEngineFilterUtils.globalDateFilterPortalName customStyle="-mt-1" />
         <div className="flex-shrink-0">
-          <Button
+          <ACLButton
             text="Generate Report"
             buttonType=Primary
             buttonSize=Large
+            authorization={userHasAccess(~groupAccess=ReconTransactionsView)}
             buttonState={selectedRule->Option.isSome ? Normal : Disabled}
             onClick={_ => {
               setReportModal(_ => true)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two independent fixes to the recon engine Generate Report flow.

**1. Report time range was posted as real UTC instead of the recon format**

Every recon list and query path normalises timestamps through `ReconEngineFilterUtils.toReconTimeString` before sending them — `buildTransactionsV2Body` does it at `ReconEngineTransactionsUtils.res:87-88`, and `buildQueryStringFromFilters` does it for the overview and pipeline cards. That helper runs `dateFormat`, i.e. `(timestamp->DayJs.getDayJsForString).format(...)` with no `.utc()`, so it renders **local wall-clock time and stamps a literal `Z`** — which is what the recon backend expects.

The report modal skipped that step and posted the form value straight through, so a range starting at local midnight went out as real UTC:

```
start_time: "2026-03-12T18:30:00Z"   // before - 00:00 IST expressed as UTC
start_time: "2026-03-13T00:00:00Z"   // after  - matches what the list sends
```

The report therefore covered a different window than the table the user was looking at. `onSubmit` now applies the same normalisation to `start_time` and `end_time`.

**2. Generate Report was not permission gated**

The button on both the Transactions and Exceptions pages was a plain `Button` with no authorization check. Switched to `ACLButton` — the pattern already used in recon at `ReconEngineDataSourceDetailsConfig.res:265` and `ReconEnginePipelinesUploadModal.res:440` — which disables the button and shows the standard no-access tooltip.

| Page | Group |
| --- | --- |
| Transactions | `ReconTransactionsView` |
| Exceptions | `ReconExceptionsView` |

The existing `selectedRule->Option.isSome` condition is unchanged, so the button needs both a selected rule and the permission.

## Motivation and Context

Closes #5520

The time range bug means a generated report silently covers a window shifted by the viewer's UTC offset relative to the list they generated it from — wrong data, with no error to signal it.

Note that `GroupACLHooks.res:32` still carries `reconGroupFallback`, which grants all eight recon groups until the permission groups land in the production backend. Until then the new gate reads as Access for everyone, so this is correct-but-dormant rather than an immediate behaviour change.

## How did you test it?

Locally, against the recon engine dev setup.

- Confirmed the request payload now sends `start_time` matching the list's value rather than the UTC-shifted one.
- `npm run re:build` compiles clean.

## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

<!-- Does this PR depend on any backend changes? -->

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

Feature flag name(s):

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4FJ478H94PrUipNc3psD
