### PR TITLE
fix(revenue-recovery): fix chargebee auth fields bug

### DIFF
--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorUtils.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryConnectorUtils.res
@@ -169,12 +169,10 @@ let updatableConnectorFields = [
 ]
 
 let getUpdatableConnectorBody = (~valuesDict, ~merchantId) => {
+  open LogicUtils
   let body = Dict.make()
   updatableConnectorFields->Array.forEach(field => {
-    switch valuesDict->Dict.get(field) {
-    | Some(value) => body->Dict.set(field, value)
-    | None => ()
-    }
+    valuesDict->Dict.get(field)->mapOptionOrDefault((), value => body->Dict.set(field, value))
   })
   body->Dict.set("merchant_id", merchantId->JSON.Encode.string)
   body

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryOnboardingPayments.res
@@ -3,6 +3,7 @@ let make = (
   ~currentStep,
   ~setConnectorID,
   ~connector,
+  ~billingConnector,
   ~setConnectorName,
   ~setNextStep,
   ~profileId,
@@ -98,7 +99,7 @@ let make = (
 
   let handleClick = () => {
     mixpanelEvent(~eventName=currentStep->getMixpanelEventName)
-    onNextClick(currentStep, setNextStep, isLiveMode)->ignore
+    onNextClick(currentStep, setNextStep, ~isLiveMode, ~billingConnector)->ignore
   }
 
   let onSubmit = async (values, _form: ReactFinalForm.formApi) => {

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryPaymentProcessorsSection.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RecoveryProcessorsPaymentProcessors/RecoveryPaymentProcessorsSection.res
@@ -263,10 +263,7 @@ let make = (
       paymentConnectorList->Array.find((item: ConnectorTypes.connectorPayloadCommonType) =>
         item.id === paymentConnectorId
       )
-    let connectorName = switch details {
-    | Some(item) => item.connector_name
-    | None => ""
-    }
+    let connectorName = details->mapOptionOrDefault("", item => item.connector_name)
     let reference = billingAccountReference->getString(paymentConnectorId, "")
 
     let isSelected = selectedProcessorId === paymentConnectorId
@@ -291,18 +288,18 @@ let make = (
         <h4 className="text-nd_gray-400"> {"Merchant Connector ID"->React.string} </h4>
         <HelperComponents.CopyTextCustomComp
           displayValue={Some(paymentConnectorId)}
-          customTextCss="!font-jetbrains-mono text-nd_gray-600"
+          customTextCss={`${code.lg.regular} text-nd_gray-600`}
         />
       </div>
       <div className="flex flex-col gap-1">
         <h4 className="text-nd_gray-400"> {"Processor Reference"->React.string} </h4>
-        <p className="!font-jetbrains-mono text-nd_gray-600"> {reference->React.string} </p>
+        <p className={`${code.lg.regular} text-nd_gray-600`}> {reference->React.string} </p>
       </div>
       <div className="flex flex-col gap-1">
         <h4 className="text-nd_gray-400"> {"Status"->React.string} </h4>
         <RenderIf condition={details->Option.isSome}>
           <p className="text-nd_gray-600">
-            {details->Option.mapOr("", item => item.status)->React.string}
+            {details->mapOptionOrDefault("", item => item.status)->React.string}
           </p>
         </RenderIf>
         <RenderIf condition={details->Option.isNone}>
@@ -382,7 +379,7 @@ let make = (
             <ConnectorWebhookDetails isInEditState=true connectorInfo={connectorInfoDict} />
             <RenderIf condition={!isCustomBilling}>
               <FormRenderer.FieldRenderer
-                labelClass="font-semibold !text-hyperswitch_black"
+                labelClass={`${body.md.semibold} !text-hyperswitch_black`}
                 field={FormRenderer.makeFieldInfo(
                   ~label="Processor Reference ID",
                   ~name="processor_reference_id",

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsUtils.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/BillingProcessorsUtils.res
@@ -44,7 +44,7 @@ let getConnectorConfig = connector => {
     {
       "connector_auth": {
         "HeaderKey": {
-          "api_key": "Custom billing API Key",
+          "api_key": "Stripe Billing API Key",
         },
       },
       "connector_webhook_details": {

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryBillingProcessors/RecoveryOnboardingBilling.res
@@ -56,7 +56,8 @@ let make = (
       )
     } else {
       // TODO: need to be removed when we have file upload on live
-      let billingAccountReference = [(connectorID, connectorID->JSON.Encode.string)]->Dict.fromArray
+      let reference = connector->requiresProcessorReference ? "" : connectorID
+      let billingAccountReference = [(connectorID, reference->JSON.Encode.string)]->Dict.fromArray
 
       let revenueRecovery =
         [
@@ -79,13 +80,13 @@ let make = (
   let handleAuthKeySubmit = async (values, _) => {
     mixpanelEvent(~eventName=currentStep->getMixpanelEventName)
     setInitialValues(_ => values)
-    onNextClick(currentStep, setNextStep, isLiveMode)
+    onNextClick(currentStep, setNextStep, ~isLiveMode, ~billingConnector=connector)
     Nullable.null
   }
 
   let handleClick = () => {
     mixpanelEvent(~eventName=currentStep->getMixpanelEventName)
-    onNextClick(currentStep, setNextStep, isLiveMode)->ignore
+    onNextClick(currentStep, setNextStep, ~isLiveMode, ~billingConnector=connector)->ignore
   }
 
   let onSubmit = async (values, _form: ReactFinalForm.formApi) => {
@@ -158,38 +159,39 @@ let make = (
         revenue_recovery->getInt("billing_connector_retry_threshold", 0)
       let max_retry_count = revenue_recovery->getInt("max_retry_count", 0)
 
-      if !isLiveMode {
-        if billing_connector_retry_threshold === 0 {
-          Dict.set(
-            errors,
-            "billing_connector_retry_threshold",
-            `Please enter start retry count`->JSON.Encode.string,
-          )
-        } else if billing_connector_retry_threshold > 15 {
-          Dict.set(
-            errors,
-            "billing_connector_retry_threshold",
-            `Start retry count should be less than 15`->JSON.Encode.string,
-          )
-        }
+      if billing_connector_retry_threshold === 0 {
+        Dict.set(
+          errors,
+          "billing_connector_retry_threshold",
+          `Please enter start retry count`->JSON.Encode.string,
+        )
+      } else if billing_connector_retry_threshold > 15 {
+        Dict.set(
+          errors,
+          "billing_connector_retry_threshold",
+          `Start retry count should be less than 15`->JSON.Encode.string,
+        )
+      }
 
-        if max_retry_count === 0 {
-          Dict.set(
-            errors,
-            "max_retry_count",
-            `Please enter max retry count count`->JSON.Encode.string,
-          )
-        } else if max_retry_count > 15 {
-          Dict.set(
-            errors,
-            "max_retry_count",
-            `Max retry count count should be less than 15`->JSON.Encode.string,
-          )
-        }
+      if max_retry_count === 0 {
+        Dict.set(
+          errors,
+          "max_retry_count",
+          `Please enter max retry count count`->JSON.Encode.string,
+        )
+      } else if max_retry_count > 15 {
+        Dict.set(
+          errors,
+          "max_retry_count",
+          `Max retry count count should be less than 15`->JSON.Encode.string,
+        )
       }
     }
 
-    if currentStep->getSectionVariant == (#addAPlatform, #processorSetUp) {
+    if (
+      currentStep->getSectionVariant == (#addAPlatform, #processorSetUp) &&
+        connector->requiresProcessorReference
+    ) {
       let billing_account_reference =
         revenue_recovery->getObj("billing_account_reference", Dict.make())
 
@@ -213,7 +215,8 @@ let make = (
     )
   }
 
-  let authKeysSubmit = isLiveMode ? onSubmit : handleAuthKeySubmit
+  let hasProcessorSetUpStep = !isLiveMode || connector->requiresProcessorReference
+  let authKeysSubmit = hasProcessorSetUpStep ? handleAuthKeySubmit : onSubmit
 
   <div>
     <Form onSubmit initialValues>
@@ -234,6 +237,11 @@ let make = (
             mixpanelEventPrefix="recovery_billing_connector_click"
             onCardClick={connectorName => {
               setConnectorName(_ => connectorName)
+              RescriptReactRouter.replace(
+                GlobalVars.appendDashboardPath(
+                  ~url=`/v2/recovery/onboarding?name=${connectorName}`,
+                ),
+              )
               handleClick()
             }}
           />

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboarding.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboarding.res
@@ -35,7 +35,7 @@ let make = () => {
   <div className="flex flex-row">
     <VerticalStepIndicator
       titleElement={"Setup Recovery"->React.string}
-      sections={getSections(isLiveMode)}
+      sections={getSections(~isLiveMode, ~billingConnector=billingConnectorName)}
       currentStep
       backClick={() => {
         RescriptReactRouter.replace(
@@ -48,6 +48,7 @@ let make = () => {
         currentStep
         setConnectorID={setPaymentConnectorID}
         connector={paymentConnectorName}
+        billingConnector={billingConnectorName}
         setConnectorName={setPaymentConnectorName}
         setNextStep
         profileId

--- a/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingUtils.res
+++ b/src/RevenueRecovery/RevenueRecoveryScreens/RecoveryProcessors/RevenueRecoveryOnboarding/RevenueRecoveryOnboardingUtils.res
@@ -27,8 +27,16 @@ let getIcon = step => {
   }
 }
 
+let requiresProcessorReference = billingConnector =>
+  switch billingConnector->ConnectorUtils.getConnectorNameTypeFromString(
+    ~connectorType=ConnectorTypes.BillingProcessor,
+  ) {
+  | ConnectorTypes.BillingProcessor(CUSTOMBILLING) | ConnectorTypes.UnknownConnector(_) => false
+  | _ => true
+  }
+
 open VerticalStepIndicatorTypes
-let getSections = isLiveMode => {
+let getSections = (~isLiveMode, ~billingConnector) => {
   let platformSubsectionsDefaultSteps = [
     {
       id: (#selectAPlatform: revenueRecoverySubsections :> string),
@@ -40,7 +48,7 @@ let getSections = isLiveMode => {
     },
   ]
 
-  if !isLiveMode {
+  if !isLiveMode || billingConnector->requiresProcessorReference {
     platformSubsectionsDefaultSteps->Array.push({
       id: (#processorSetUp: revenueRecoverySubsections :> string),
       name: #processorSetUp->getStepName,
@@ -93,23 +101,23 @@ let defaultStepBilling = {
 }
 
 open VerticalStepIndicatorUtils
-let getNextStep = (currentStep: step, isLiveMode): option<step> => {
-  findNextStep(getSections(isLiveMode), currentStep)
+let getNextStep = (currentStep: step, ~isLiveMode, ~billingConnector): option<step> => {
+  findNextStep(getSections(~isLiveMode, ~billingConnector), currentStep)
 }
 
-let getPreviousStep = (currentStep: step, isLiveMode): option<step> => {
-  findPreviousStep(getSections(isLiveMode), currentStep)
+let getPreviousStep = (currentStep: step, ~isLiveMode, ~billingConnector): option<step> => {
+  findPreviousStep(getSections(~isLiveMode, ~billingConnector), currentStep)
 }
 
-let onNextClick = (currentStep, setNextStep, isLiveMode) => {
-  switch getNextStep(currentStep, isLiveMode) {
+let onNextClick = (currentStep, setNextStep, ~isLiveMode, ~billingConnector) => {
+  switch getNextStep(currentStep, ~isLiveMode, ~billingConnector) {
   | Some(nextStep) => setNextStep(_ => nextStep)
   | None => ()
   }
 }
 
-let onPreviousClick = (currentStep, setNextStep, isLiveMode) => {
-  switch getPreviousStep(currentStep, isLiveMode) {
+let onPreviousClick = (currentStep, setNextStep, ~isLiveMode, ~billingConnector) => {
+  switch getPreviousStep(currentStep, ~isLiveMode, ~billingConnector) {
   | Some(previousStep) => setNextStep(_ => previousStep)
   | None => ()
   }
@@ -152,7 +160,10 @@ let billingConnectorList: array<connectorTypes> = [
   BillingProcessor(CUSTOMBILLING),
 ]
 
-let prodBillingConnectorList: array<connectorTypes> = [BillingProcessor(CUSTOMBILLING)]
+let prodBillingConnectorList: array<connectorTypes> = [
+  BillingProcessor(CHARGEBEE),
+  BillingProcessor(CUSTOMBILLING),
+]
 
 let billingConnectorProdList: array<BillingProcessorsUtils.optionType> = [
   {


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

**Chargebee auth fields** — #5423 split biller selection into its own step and dropped the router write that put the selected biller in the url's `name` param. `ConnectorAuthKeys`, `ConnectorMetadataV2` and `ConnectorWebhookDetails` all resolve the connector from that param, so the auth step rendered no fields while validation still demanded an api key, site and webhook. Restores the url write.

Chargebee authenticates by api key, so it is now selectable in live too. Custom billing is therefore no longer the only live biller, and the set-up step, connector creation and retry validation no longer assume it is.

**Review follow-ups** — the three comments on #5423 marked *"pick in follow up pr"*: `LogicUtils.mapOptionOrDefault` in place of hand-rolled `Some`/`None` switches, and `Typography` tokens in place of raw font classes.

> One rendered difference: `code.lg.regular` pins the two mono values in the processor row at 14px, where they previously inherited their size.

## Motivation and Context

Fixes the billing auth step broken by #5423, and clears its deferred review comments.

## How did you test it?

Tested this with integ:
Bug: 
<img width="3430" height="1888" alt="image" src="https://github.com/user-attachments/assets/6fc14ce0-a158-404c-a741-a05a014a2e85" />
Fix: 
<img width="3456" height="1992" alt="image" src="https://github.com/user-attachments/assets/a6a67778-60c6-4b0f-8399-97661a52001a" />


## Where to test it?

- [x] INTEG
- [ ] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
