### PR TITLE
chore: scope the transformation filter to the account on transaction details

### DIFF
--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntries.res
@@ -5,84 +5,27 @@ let make = (
   ~accountsData: array<ReconEngineTypes.accountType>,
   ~entriesDetailFields=EntriesTableEntity.transactionEntriesDetailFields,
 ) => {
-  open APIUtils
   open LogicUtils
   open ReconEngineTransactionsUtils
-
-  let getURL = useGetURL()
-  let fetchDetails = useGetMethod()
-  let showToast = ToastAdapter.useShowToast()
-  let (screenState, setScreenState) = React.useState(_ => PageLoaderWrapper.Loading)
-  let (transformationConfigs, setTransformationConfigs) = React.useState((_): array<
-    ReconEngineTypes.transformationConfigType,
-  > => [])
 
   let currencyOptions = React.useMemo(() => {
     getCurrencyOptionsFromAccounts(accountsData, ~accountIds)
   }, (accountsData, accountIds))
 
-  let transformationNameMap = React.useMemo(() => {
-    let nameMap = Dict.make()
-    transformationConfigs->Array.forEach(config =>
-      nameMap->Dict.set(config.transformation_id, config.name)
+  <div className="flex flex-col gap-6 mt-6">
+    <RenderIf condition={accountIds->isEmptyArray}>
+      <NoDataFound customCssClass="my-6" message="No Data Available" renderType=Painting />
+    </RenderIf>
+    {accountIds
+    ->Array.map(accountId =>
+      <FilterContext
+        key=accountId
+        index={`recon-engine-transaction-entries-${primaryTransactionId}-${accountId}`}>
+        <ReconEngineTransactionEntriesContent
+          primaryTransactionId accountId accountsData currencyOptions entriesDetailFields
+        />
+      </FilterContext>
     )
-    nameMap
-  }, [transformationConfigs])
-
-  let transformationConfigOptions = React.useMemo(() => {
-    transformationConfigs->Array.map((config): FilterSelectBox.dropdownOption => {
-      label: config.name,
-      value: config.transformation_id,
-    })
-  }, [transformationConfigs])
-
-  let fetchTransformationConfigs = async () => {
-    try {
-      let url = getURL(
-        ~entityName=V1(HYPERSWITCH_RECON),
-        ~methodType=Get,
-        ~hyperswitchReconType=#TRANSFORMATION_CONFIG,
-      )
-      let res = await fetchDetails(url)
-      let configs = res->getArrayDataFromJson(ReconEngineUtils.transformationConfigItemToObjMapper)
-      setTransformationConfigs(_ => configs)
-      setScreenState(_ => PageLoaderWrapper.Success)
-    } catch {
-    | _ => {
-        showToast(~message="Failed to fetch transformation configs", ~toastType=ToastError)
-        setScreenState(_ => PageLoaderWrapper.Success)
-      }
-    }
-  }
-
-  React.useEffect(() => {
-    fetchTransformationConfigs()->ignore
-    None
-  }, [])
-
-  <PageLoaderWrapper
-    screenState customLoader={<Shimmer styleClass="h-40 w-full mt-6 rounded-xl" />}>
-    <div className="flex flex-col gap-6 mt-6">
-      <RenderIf condition={accountIds->isEmptyArray}>
-        <NoDataFound customCssClass="my-6" message="No Data Available" renderType=Painting />
-      </RenderIf>
-      {accountIds
-      ->Array.map(accountId =>
-        <FilterContext
-          key=accountId
-          index={`recon-engine-transaction-entries-${primaryTransactionId}-${accountId}`}>
-          <ReconEngineTransactionEntriesContent
-            primaryTransactionId
-            accountId
-            accountsData
-            transformationNameMap
-            currencyOptions
-            transformationConfigOptions
-            entriesDetailFields
-          />
-        </FilterContext>
-      )
-      ->React.array}
-    </div>
-  </PageLoaderWrapper>
+    ->React.array}
+  </div>
 }

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntriesContent.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsComponents/ReconEngineTransactionEntriesContent.res
@@ -5,26 +5,30 @@ let make = (
   ~primaryTransactionId: string,
   ~accountId: string,
   ~accountsData: array<ReconEngineTypes.accountType>,
-  ~transformationNameMap: Dict.t<string>,
   ~currencyOptions: array<FilterSelectBox.dropdownOption>,
-  ~transformationConfigOptions: array<FilterSelectBox.dropdownOption>,
   ~entriesDetailFields=EntriesTableEntity.transactionEntriesDetailFields,
 ) => {
   open LogicUtils
   open EntriesTableEntity
   open ReconEngineExceptionTransactionUtils
   open ReconEngineExceptionTransactionHelper
+  open ReconEngineHooks
   open ReconEngineTransactionsTypes
   open ReconEngineTransactionsUtils
 
-  let getEntries = ReconEngineHooks.useGetCursorPage(
+  let getEntries = useGetCursorPage(
     ~hyperswitchReconType=#PROCESSED_ENTRIES_LIST,
     ~itemMapper=transactionsEntryItemToObjMapperFromDict,
   )
+  let getTransformationConfigs = useGetTransformationConfigs()
+  let showToast = ToastAdapter.useShowToast()
   let {updateExistingKeys, filterValueJson, filterValue, filterKeys} = React.useContext(
     FilterContext.filterContext,
   )
   let (searchText, setSearchText) = React.useState(_ => "")
+  let (transformationConfigs, setTransformationConfigs) = React.useState((_): array<
+    ReconEngineTypes.transformationConfigType,
+  > => [])
   let searchTypeRef = React.useRef(SearchEntryOrderId)
 
   let {
@@ -48,10 +52,41 @@ let make = (
     )
   })
 
+  let fetchTransformationConfigs = async () => {
+    try {
+      let configs = await getTransformationConfigs(~queryParameters=Some(`account_id=${accountId}`))
+      setTransformationConfigs(_ => configs)
+    } catch {
+    | _ =>
+      setTransformationConfigs(_ => [])
+      showToast(~message="Failed to fetch transformation configs", ~toastType=ToastError)
+    }
+  }
+
+  React.useEffect(() => {
+    fetchTransformationConfigs()->ignore
+    None
+  }, [accountId])
+
   React.useEffect(() => {
     goToFirstPage()
     None
   }, [filterValue])
+
+  let transformationConfigOptions = React.useMemo(() => {
+    transformationConfigs->Array.map((config): FilterSelectBox.dropdownOption => {
+      label: config.name,
+      value: config.transformation_id,
+    })
+  }, [transformationConfigs])
+
+  let transformationNameMap = React.useMemo(() => {
+    let nameMap = Dict.make()
+    transformationConfigs->Array.forEach(config =>
+      nameMap->Dict.set(config.transformation_id, config.name)
+    )
+    nameMap
+  }, [transformationConfigs])
 
   let handleSearchSubmit = (selectedType: option<string>) => {
     searchTypeRef.current =

--- a/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsUtils.res
+++ b/src/ReconEngine/ReconEngineScreens/ReconEngineTransactions/ReconEngineTransactionsUtils.res
@@ -233,7 +233,7 @@ let entriesDisplayFilters = (~currencyOptions, ~transformationConfigOptions) => 
     (
       {
         field: FormRenderer.makeFieldInfo(
-          ~label="transformation_config_ids",
+          ~label="Transformation",
           ~name="transformation_config_ids",
           ~customInput=InputFields.filterMultiSelectInput(
             ~options=transformationConfigOptions,


### PR DESCRIPTION
## Type of Change

- [x] Enhancement

## Description

- Scope the transformation filter on the transaction details entries to the account of that entries block (`GET /transformations/configs?account_id=<account_id>`), so only the configs applicable to the transaction are listed.
- Rename the filter to `Transformation`, matching the transformed entries page.

## Motivation and Context

Closes #5528

## How did you test it?

Manually on the transaction details page (Entries tab) — each account's block lists only that account's transformation configs, and filtering by one returns the matching entries.

## Where to test it?

- [ ] INTEG
- [x] SANDBOX
- [ ] PROD

## Backend Dependency

- [ ] Yes
- [x] No

Backend PR URL:

## Feature Flag

- [ ] New feature flag added
- [ ] Existing feature flag updated
- [x] No feature flag changes

## Checklist

- [x] I ran `npm run re:build`
- [x] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
